### PR TITLE
Add support for partial orders of L/R-classes

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -192,13 +192,17 @@ gap> MinimalDClass(S);
   </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="MaximalDClasses">
+<#GAPDoc Label="MaximalXClasses">
   <ManSection>
+    <Heading>MaximalXClasses</Heading>
     <Attr Name="MaximalDClasses" Arg="S"/>
-    <Returns>The maximal &D;-classes of a semigroup.</Returns>
+    <Attr Name="MaximalLClasses" Arg="S"/>
+    <Attr Name="MaximalRClasses" Arg="S"/>
+    <Returns>The maximal &D;, &L;, or &R;-classes of a semigroup.</Returns>
     <Description>
-      <C>MaximalDClasses</C> returns the maximal &D;-classes with respect to
-      the partial order of &D;-classes. <P/>
+      Let <C>X</C> be one of Green's &D;-, &L;-, or &R;-relations. Then
+      <C>MaximalXClasses</C> returns the maximal Green's <C>X</C>-classes with
+      respect to the partial order of <C>X</C>-classes. <P/>
 
       See also <Ref Attr="PartialOrderOfDClasses"/>,
       <Ref Oper="IsGreensLessThanOrEqual" BookName="ref"/>, and

--- a/doc/greens-generic.xml
+++ b/doc/greens-generic.xml
@@ -892,22 +892,43 @@ gap> AsSet(RegularDClasses(S));
 </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="PartialOrderOfDClasses">
+<#GAPDoc Label="PartialOrderOfXClasses">
   <ManSection>
+  <Heading>PartialOrderOfXClasses</Heading>
   <Attr Name = "PartialOrderOfDClasses" Arg = "S"/>
-  <Returns>The partial order of the &D;-classes of <A>S</A>.
+  <Attr Name = "PartialOrderOfLClasses" Arg = "S"/>
+  <Attr Name = "PartialOrderOfRClasses" Arg = "S"/>
+  <Returns>The partial order of the &D;, &L;, or &R;-classes of <A>S</A>.
   </Returns>
   <Description>
-    Returns a digraph <C>D</C> where the vertex <C>i</C> is adjacent to  vertex
-    <C>j</C> if <C>GreensDClasses(S)[j]</C> is immediately strictly less than
-    <C>GreensDClasses(S)[i]</C> in the partial order of &D;-classes of
-    <A>S</A>; it might be that <C>i</C> is adjacent to further nodes in
-    addition to those just mentioned. The returned digraph has no loops.  The
-    reflexive transitive closure of the digraph <C>D</C> is the partial order
-    of &D;-classes of <A>S</A>. <P/>
+    <!-- TODO Should return a digraph, as it now does for D classes -->
+    Let <C>X</C> be one of Green's &D;-, &L;-, or &R;-relations. Then
+    <C>PartialOrderOfXClasses</C> returns a list <C>list</C> where
+    <C>list[i]</C> contains every <C>j</C> such that <C>GreensXClasses(S)[j]</C>
+    is immediately less than <C>GreensXClasses(S)[i]</C> in the partial order of
+    <C>X</C>-classes of <A>S</A>. There might be other indices in <C>list</C>,
+    and it may or may not include <C>i</C>.  The reflexive transitive closure of
+    the relation defined by <C>list</C> is the partial order of <C>X</C>-classes
+    of <A>S</A>. <P/>
 
-    The partial order on the &D;-classes is defined by <M>x\leq y</M> if and
-    only if <M>S ^ 1xS ^ 1</M> is a subset of  <M>S ^ 1yS ^ 1</M>. <P/>
+    The partial order on the <C>X</C>-classes is defined as follows.
+    <List>
+      <Mark>Green's &D;-relation:</Mark>
+      <Item>
+        <M>x\leq y</M> if and only if <M>S ^ 1xS ^ 1</M> is a subset of
+        <M>S ^ 1yS ^ 1</M>.
+      </Item>
+      <Mark>Green's &L;-relation:</Mark>
+      <Item>
+        <M>x\leq y</M> if and only if <M>S ^ 1x</M> is a subset of
+        <M>S ^ 1y</M>.
+      </Item>
+      <Mark>Green's &R;-relation:</Mark>
+      <Item>
+        <M>x\leq y</M> if and only if <M>xS ^ 1</M> is a subset of
+        <M>yS ^ 1</M>.
+      </Item>
+    </List>
 
     See also <Ref Meth = "GreensDClasses"/>,
     <Ref Meth = "GreensDClasses" BookName = "ref"/>,

--- a/doc/z-chap10.xml
+++ b/doc/z-chap10.xml
@@ -25,10 +25,10 @@
     <#Include Label = "GreensXClasses">
     <#Include Label = "XClassReps">
     <#Include Label = "MinimalDClass">
-    <#Include Label = "MaximalDClasses">
+    <#Include Label = "MaximalXClasses">
     <#Include Label = "NrRegularDClasses">
     <#Include Label = "NrXClasses">
-    <#Include Label = "PartialOrderOfDClasses">
+    <#Include Label = "PartialOrderOfXClasses">
     <#Include Label = "LengthOfLongestDClassChain">
     <#Include Label = "IsGreensDGreaterThanFunc">
 

--- a/gap/attributes/attr.gd
+++ b/gap/attributes/attr.gd
@@ -58,6 +58,8 @@ DeclareAttribute("StructureDescription", IsGroupAsSemigroup);
 DeclareAttribute("StructureDescriptionMaximalSubgroups",
                  IsSemigroup);
 DeclareAttribute("MaximalDClasses", IsSemigroup);
+DeclareAttribute("MaximalLClasses", IsSemigroup);
+DeclareAttribute("MaximalRClasses", IsSemigroup);
 DeclareAttribute("MinimalDClass", IsSemigroup);
 DeclareAttribute("IsGreensDGreaterThanFunc", IsSemigroup);
 

--- a/gap/attributes/attr.gi
+++ b/gap/attributes/attr.gi
@@ -546,6 +546,32 @@ InstallMethod(MaximalDClasses, "for a finite monoid as semigroup",
 [IsFinite and IsMonoidAsSemigroup],
 S -> [DClass(S, MultiplicativeNeutralElement(S))]);
 
+InstallMethod(MaximalLClasses, "for an enumerable semigroup",
+[IsEnumerableSemigroupRep],
+function(S)
+  local gr;
+
+  if NrLClasses(S) = 1 then
+    return LClasses(S);
+  fi;
+
+  gr := DigraphRemoveLoops(Digraph(PartialOrderOfLClasses(S)));
+  return LClasses(S){DigraphSources(gr)};
+end);
+
+InstallMethod(MaximalRClasses, "for an enumerable semigroup",
+[IsEnumerableSemigroupRep],
+function(S)
+  local gr;
+
+  if NrRClasses(S) = 1 then
+    return RClasses(S);
+  fi;
+
+  gr := DigraphRemoveLoops(Digraph(PartialOrderOfRClasses(S)));
+  return RClasses(S){DigraphSources(gr)};
+end);
+
 # same method for ideals
 
 InstallMethod(StructureDescriptionMaximalSubgroups,

--- a/gap/attributes/attr.gi
+++ b/gap/attributes/attr.gi
@@ -549,27 +549,23 @@ S -> [DClass(S, MultiplicativeNeutralElement(S))]);
 InstallMethod(MaximalLClasses, "for an enumerable semigroup",
 [IsSemigroup and CanUseFroidurePin],
 function(S)
-  local gr;
 
   if NrLClasses(S) = 1 then
     return LClasses(S);
   fi;
 
-  gr := DigraphRemoveLoops(Digraph(PartialOrderOfLClasses(S)));
-  return LClasses(S){DigraphSources(gr)};
+  return LClasses(S){DigraphSources(PartialOrderOfLClasses(S))};
 end);
 
 InstallMethod(MaximalRClasses, "for an enumerable semigroup",
 [IsSemigroup and CanUseFroidurePin],
 function(S)
-  local gr;
 
   if NrRClasses(S) = 1 then
     return RClasses(S);
   fi;
 
-  gr := DigraphRemoveLoops(Digraph(PartialOrderOfRClasses(S)));
-  return RClasses(S){DigraphSources(gr)};
+  return RClasses(S){DigraphSources(PartialOrderOfRClasses(S))};
 end);
 
 # same method for ideals

--- a/gap/attributes/attr.gi
+++ b/gap/attributes/attr.gi
@@ -547,7 +547,7 @@ InstallMethod(MaximalDClasses, "for a finite monoid as semigroup",
 S -> [DClass(S, MultiplicativeNeutralElement(S))]);
 
 InstallMethod(MaximalLClasses, "for an enumerable semigroup",
-[IsEnumerableSemigroupRep],
+[IsSemigroup and CanUseFroidurePin],
 function(S)
   local gr;
 
@@ -560,7 +560,7 @@ function(S)
 end);
 
 InstallMethod(MaximalRClasses, "for an enumerable semigroup",
-[IsEnumerableSemigroupRep],
+[IsSemigroup and CanUseFroidurePin],
 function(S)
   local gr;
 

--- a/gap/greens/froidure-pin.gi
+++ b/gap/greens/froidure-pin.gi
@@ -564,7 +564,7 @@ function(S)
 end);
 
 InstallMethod(PartialOrderOfLClasses, "for a finite enumerable semigroup",
-[IsEnumerableSemigroupRep and IsFinite],
+[IsSemigroup and CanUseFroidurePin and IsFinite],
 function(S)
   local gr, comps, enum, canon, actual, perm;
 
@@ -585,7 +585,7 @@ function(S)
 end);
 
 InstallMethod(PartialOrderOfRClasses, "for a finite enumerable semigroup",
-[IsEnumerableSemigroupRep and IsFinite],
+[IsSemigroup and CanUseFroidurePin and IsFinite],
 function(S)
   local gr, comps, enum, canon, actual, perm;
 

--- a/gap/greens/froidure-pin.gi
+++ b/gap/greens/froidure-pin.gi
@@ -566,11 +566,11 @@ end);
 InstallMethod(PartialOrderOfLClasses, "for a finite enumerable semigroup",
 [IsSemigroup and CanUseFroidurePin and IsFinite],
 function(S)
-  local gr, comps, enum, canon, actual, perm;
+  local D, comps, enum, canon, actual, perm;
 
-  gr := LeftCayleyDigraph(S);
-  comps := DigraphStronglyConnectedComponents(gr).comps;
-  gr := QuotientDigraph(gr, comps);
+  D := DigraphMutableCopy(LeftCayleyDigraph(S));
+  comps := DigraphStronglyConnectedComponents(LeftCayleyDigraph(S)).comps;
+  QuotientDigraph(D, comps);
   if not IsBound(GreensLRelation(S)!.data) then
     # Rectify the ordering of the Green's classes, if necessary
     enum := EnumeratorCanonical(S);
@@ -578,20 +578,24 @@ function(S)
     actual := SortingPerm(GreensLClasses(S));
     perm := canon / actual;
     if not IsOne(perm) then
-      gr := OnDigraphs(gr, perm);
+      D := OnDigraphs(D, perm);
     fi;
   fi;
-  return List(OutNeighbours(gr), Set);
+  DigraphRemoveLoops(D);
+  Apply(OutNeighbours(D), Set);
+  MakeImmutable(D);
+  return D;
 end);
 
 InstallMethod(PartialOrderOfRClasses, "for a finite enumerable semigroup",
 [IsSemigroup and CanUseFroidurePin and IsFinite],
 function(S)
-  local gr, comps, enum, canon, actual, perm;
+  local D, comps, enum, canon, actual, perm;
 
-  gr := RightCayleyDigraph(S);
-  comps := DigraphStronglyConnectedComponents(gr).comps;
-  gr := QuotientDigraph(gr, comps);
+  D := DigraphMutableCopy(RightCayleyDigraph(S));
+  comps := DigraphStronglyConnectedComponents(RightCayleyDigraph(S)).comps;
+  QuotientDigraph(D, comps);
+
   if not IsBound(GreensRRelation(S)!.data) then
     # Rectify the ordering of the Green's classes, if necessary
     enum := EnumeratorCanonical(S);
@@ -599,10 +603,13 @@ function(S)
     actual := SortingPerm(GreensRClasses(S));
     perm := canon / actual;
     if not IsOne(perm) then
-      gr := OnDigraphs(gr, perm);
+      D := OnDigraphs(D, perm);
     fi;
   fi;
-  return List(OutNeighbours(gr), Set);
+  DigraphRemoveLoops(D);
+  Apply(OutNeighbours(D), Set);
+  MakeImmutable(D);
+  return D;
 end);
 
 #############################################################################

--- a/gap/greens/generic.gd
+++ b/gap/greens/generic.gd
@@ -32,6 +32,8 @@ DeclareOperation("GreensJClassOfElementNC",
 DeclareAttribute("RegularDClasses", IsSemigroup);
 DeclareAttribute("NrRegularDClasses", IsSemigroup);
 DeclareAttribute("PartialOrderOfDClasses", IsSemigroup);
+DeclareAttribute("PartialOrderOfLClasses", IsSemigroup);
+DeclareAttribute("PartialOrderOfRClasses", IsSemigroup);
 
 DeclareOperation("GreensLClassOfElement",
                  [IsGreensClass, IsMultiplicativeElement]);

--- a/gap/greens/generic.gi
+++ b/gap/greens/generic.gi
@@ -410,6 +410,8 @@ function(S)
   D := Digraph(IsMutableDigraph, List([1 .. Length(L)],
                                       i -> Concatenation(L[i], R[i])));
   D := QuotientDigraph(D, DigraphStronglyConnectedComponents(D).comps);
+  # WW: I do not see how the ordering of the vertices of <gr> is guaranteed
+  #     to match the ordering of GreensDClasses(S).
   Apply(OutNeighbours(D), Set);
   DigraphRemoveLoops(D);
   MakeImmutable(D);

--- a/tst/standard/attributes/attr.tst
+++ b/tst/standard/attributes/attr.tst
@@ -2089,6 +2089,30 @@ true
 gap> LeftIdentity(S, Matrix(IsBooleanMat, [[0, 0, 1, 0], [1, 0, 0, 0], [0, 1, 0, 0], [0, 1, 0, 0]])) = MultiplicativeNeutralElement(S);
 true
 
+#T# MaximalL/RClasses
+gap> S := LeftZeroSemigroup(3);
+<transformation semigroup of degree 4 with 3 generators>
+gap> MaximalLClasses(S);
+[ <Green's L-class: Transformation( [ 1, 2, 1, 1 ] )> ]
+gap> MaximalRClasses(S);
+[ <Green's R-class: Transformation( [ 1, 2, 1, 1 ] )>, 
+  <Green's R-class: Transformation( [ 1, 2, 1, 2 ] )>, 
+  <Green's R-class: Transformation( [ 1, 2, 2, 1 ] )> ]
+gap> S := RightZeroSemigroup(3);
+<transformation semigroup of degree 3 with 3 generators>
+gap> MaximalLClasses(S);
+[ <Green's L-class: Transformation( [ 1, 1, 1 ] )>, 
+  <Green's L-class: Transformation( [ 2, 2, 2 ] )>, 
+  <Green's L-class: Transformation( [ 3, 3, 3 ] )> ]
+gap> MaximalRClasses(S);
+[ <Green's R-class: Transformation( [ 1, 1, 1 ] )> ]
+gap> S := FullPBRMonoid(1);
+<pbr monoid of degree 1 with 4 generators>
+gap> MaximalLClasses(S);
+[ <Green's L-class: PBR([ [ -1 ] ], [ [ 1 ] ])> ]
+gap> MaximalRClasses(S);
+[ <Green's R-class: PBR([ [ -1 ] ], [ [ 1 ] ])> ]
+
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(D);
 gap> Unbind(G);

--- a/tst/standard/greens/froidure-pin.tst
+++ b/tst/standard/greens/froidure-pin.tst
@@ -1699,6 +1699,32 @@ Error, the argument does not belong to the domain of the function
 gap> () ^ InverseGeneralMapping(map);
 Matrix(GF(3), [[Z(3)^0, 0*Z(3)], [0*Z(3), Z(3)^0]])
 
+# PartialOrderOfL/RClasses: 1
+gap> S := Semigroup([
+>  PBR([[-1], []], [[], [-2, -1, 1, 2]]),
+>  PBR([[-2, -1, 1, 2], [-2, -1, 2]], [[-2, -1], [-2, 1, 2]]),
+>  PBR([[-1], [1]], [[-1], [-2]])]);
+<pbr semigroup of degree 2 with 3 generators>
+gap> PartialOrderOfLClasses(S);
+[ [ 1 ], [ 1, 2 ], [ 1, 2 ], [ 1, 3, 4 ], [ 5 ], [ 5, 6 ], [ 5, 6 ], [ 8 ] ]
+gap> PartialOrderOfRClasses(S);
+[ [ 1 ], [ 1, 2 ], [ 3 ], [ 2, 3, 4 ], [ 5 ], [ 5, 6 ], [ 7 ], [ 6, 7, 8 ], 
+  [ 6, 7, 8 ], [ 10 ] ]
+
+# PartialOrderOfL/RClasses: 1
+gap> S := FullTransformationMonoid(3);
+<full transformation monoid of degree 3>
+gap> gr := PartialOrderOfLClasses(S);;
+gap> gr := DigraphReflexiveTransitiveReduction(Digraph(gr));
+<digraph with 7 vertices, 9 edges>
+gap> IsIsomorphicDigraph(gr, DigraphFromDigraph6String("+F?OGC@OoK?"));
+true
+gap> gr := PartialOrderOfRClasses(S);;
+gap> gr := DigraphReflexiveTransitiveReduction(Digraph(gr));
+<digraph with 5 vertices, 6 edges>
+gap> IsIsomorphicDigraph(gr, DigraphFromDigraph6String("+D[CGO?"));
+true
+
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(D);
 gap> Unbind(DD);

--- a/tst/standard/greens/froidure-pin.tst
+++ b/tst/standard/greens/froidure-pin.tst
@@ -1706,23 +1706,20 @@ gap> S := Semigroup([
 >  PBR([[-1], [1]], [[-1], [-2]])]);
 <pbr semigroup of degree 2 with 3 generators>
 gap> PartialOrderOfLClasses(S);
-[ [ 1 ], [ 1, 2 ], [ 1, 2 ], [ 1, 3, 4 ], [ 5 ], [ 5, 6 ], [ 5, 6 ], [ 8 ] ]
+<immutable digraph with 8 vertices, 8 edges>
 gap> PartialOrderOfRClasses(S);
-[ [ 1 ], [ 1, 2 ], [ 3 ], [ 2, 3, 4 ], [ 5 ], [ 5, 6 ], [ 7 ], [ 6, 7, 8 ], 
-  [ 6, 7, 8 ], [ 10 ] ]
+<immutable digraph with 10 vertices, 9 edges>
 
 # PartialOrderOfL/RClasses: 1
 gap> S := FullTransformationMonoid(3);
 <full transformation monoid of degree 3>
-gap> gr := PartialOrderOfLClasses(S);;
-gap> gr := DigraphReflexiveTransitiveReduction(Digraph(gr));
-<digraph with 7 vertices, 9 edges>
-gap> IsIsomorphicDigraph(gr, DigraphFromDigraph6String("+F?OGC@OoK?"));
+gap> D := PartialOrderOfLClasses(S);
+<immutable digraph with 7 vertices, 9 edges>
+gap> IsIsomorphicDigraph(D, DigraphFromDigraph6String("+F?OGC@OoK?"));
 true
-gap> gr := PartialOrderOfRClasses(S);;
-gap> gr := DigraphReflexiveTransitiveReduction(Digraph(gr));
-<digraph with 5 vertices, 6 edges>
-gap> IsIsomorphicDigraph(gr, DigraphFromDigraph6String("+D[CGO?"));
+gap> D := PartialOrderOfRClasses(S);
+<immutable digraph with 5 vertices, 6 edges>
+gap> IsIsomorphicDigraph(D, DigraphFromDigraph6String("+D[CGO?"));
 true
 
 # SEMIGROUPS_UnbindVariables


### PR DESCRIPTION
We already have `PartialOrderOfDClasses` and `MaximalDClasses`; it would be nice if we had similar for `L` and `R`. It would be useful for my code to do with direct products, in particular.

I've added methods for enumerable semigroups. I feel like it should be simple to do something clever for acting semigroups, but maybe not.

I still need to polish this PR (more manual examples and tests), so it's not ready to be merged, but I'm creating this PR to spur me to finish it, and possibly as a way to ask for advice.