### PR TITLE
WIP: Make integer and finite field matrices be MatrixObjs

### DIFF
--- a/gap/elements/ffmat.gd
+++ b/gap/elements/ffmat.gd
@@ -81,10 +81,6 @@ DeclareAttribute("RightInverse", IsMatrixOverFiniteField);
 DeclareAttribute("LeftInverse", IsMatrixOverFiniteField);
 
 DeclareAttribute("RowRank", IsMatrixOverFiniteField);
-DeclareAttribute("BaseDomain", IsMatrixOverFiniteField);
-
-# TODO(later) shouldn't this be IsMultiplicativeZero??
-DeclareProperty("IsZero", IsMatrixOverFiniteField);
 
 #############################################################################
 ## Declarations specifically for finite field matrices collections
@@ -130,7 +126,7 @@ BindGlobal("PlistRowBasisOverFiniteFieldType",
 
 DeclareRepresentation("IsPlistMatrixOverFiniteFieldRep",
                       IsMatrixOverFiniteField and IsComponentObjectRep and
-                      IsAttributeStoringRep, ["mat"]);
+                      IsAttributeStoringRep and IsRowListMatrix, ["mat"]);
 BindGlobal("PlistMatrixOverFiniteFieldFamily",
            NewFamily("PlistMatrixOverFiniteFieldFamily",
                      IsMatrixOverFiniteField, CanEasilyCompareElements));

--- a/gap/elements/ffmat.gi
+++ b/gap/elements/ffmat.gi
@@ -26,7 +26,7 @@ InstallMethod(SEMIGROUPS_TypeOfMatrixOverSemiringCons,
 # It is not currently possible to create any type of matrix except
 # IsPlistMatrixOverFiniteFieldRep
 
-InstallMethod(ELM_LIST, "for a plist matrix over finite field and pos int",
+InstallOtherMethod(\[\], "for a plist matrix over finite field and pos int",
 [IsPlistMatrixOverFiniteFieldRep, IsPosInt],
 function(mat, pos)
   if not IsBound(mat[pos]) then
@@ -39,15 +39,17 @@ end);
 InstallMethod(IsBound\[\],
 "for a plist matrix over finite field and pos int",
 [IsPlistMatrixOverFiniteFieldRep, IsPosInt],
-function(mat, pos)
-  return IsBound(mat!.mat[pos]);
-end);
+{mat, pos} -> IsBound(mat!.mat[pos]));
 
-# This is here to silence some GAP tests when Semigroups is loaded
-# and should become rendundant once the GAP MatrixObj code works
-InstallOtherMethod(TraceMat, "for a plist matrix over finite field",
-[IsPlistMatrixOverFiniteFieldRep],
-mat -> TraceMat(mat!.mat));
+InstallMethod(MatElm,
+"for a plist matrix over finite field positional rep, and two pos ints",
+[IsPlistMatrixOverFiniteFieldRep, IsPosInt, IsPosInt],
+function(mat, row, col)
+  if Maximum(row, col) > NumberRows(mat) then
+    ErrorNoReturn("a position is greater than the dimension of the matrix");
+  fi;
+  return mat!.mat[row][col];
+end);
 
 # This should be used with caution, it can create corrupt objects
 

--- a/gap/elements/semiringmat.gd
+++ b/gap/elements/semiringmat.gd
@@ -11,13 +11,14 @@
 # This file contains declarations for matrices over semirings.
 
 DeclareCategory("IsMatrixOverSemiring",
-                IsMultiplicativeElementWithInverse);
+                IsMultiplicativeElementWithInverse and IsMatrixObj);
 
 DeclareCategoryCollections("IsMatrixOverSemiring");
 DeclareCategoryCollections("IsMatrixOverSemiringCollection");
 
 DeclareRepresentation("IsPlistMatrixOverSemiringPositionalRep",
-                      IsMatrixOverSemiring and IsPositionalObjectRep, 1);
+                      IsMatrixOverSemiring and
+                      IsRowListMatrix and IsPositionalObjectRep, 1);
 
 DeclareOperation("OneMutable", [IsMatrixOverSemiringCollection]);
 DeclareAttribute("OneImmutable", IsMatrixOverSemiringCollection);
@@ -96,13 +97,10 @@ DeclareOperation("RandomMatrixOp", [IsField and IsFinite, IsPosInt, IsPosInt]);
 
 DeclareAttribute("AsList", IsMatrixOverSemiring);
 DeclareOperation("AsMutableList", [IsMatrixOverSemiring]);
-DeclareOperation("ELM_LIST", [IsMatrixOverSemiring, IsPosInt]);
-DeclareOperation("IsBound[]", [IsMatrixOverSemiring, IsPosInt]);
 DeclareOperation("Iterator", [IsMatrixOverSemiring]);
 DeclareAttribute("DimensionOfMatrixOverSemiring", IsMatrixOverSemiring);
 DeclareAttribute("DimensionOfMatrixOverSemiringCollection",
                  IsMatrixOverSemiringCollection);
-DeclareAttribute("TransposedMatImmutable", IsMatrixOverSemiring);
 DeclareProperty("IsTorsion", IsMatrixOverSemiring);
 
 # Cannot use TypeObj since it can contain information about

--- a/gap/elements/semiringmat.gi
+++ b/gap/elements/semiringmat.gi
@@ -35,10 +35,10 @@ SEMIGROUPS.TropicalizeMat := function(mat, threshold)
   mat[n + 1] := threshold;
   for i in [1 .. n] do
     for j in [1 .. n] do
-      if IsInt(mat[i][j]) then
-        mat[i][j] := AbsInt(mat[i][j]);
-        if mat[i][j] > threshold then
-          mat[i][j] := threshold;
+      if IsInt(mat[i, j]) then
+        mat[i, j] := AbsInt(mat[i, j]);
+        if mat[i, j] > threshold then
+          mat[i, j] := threshold;
         fi;
       fi;
     od;
@@ -54,9 +54,9 @@ SEMIGROUPS.NaturalizeMat := function(x, threshold, period)
   x[n + 2] := period;
   for i in [1 .. n] do
     for j in [1 .. n] do
-      x[i][j] := AbsInt(x[i][j]);
-      if x[i][j] > threshold then
-        x[i][j] := threshold + (x[i][j] - threshold) mod period;
+      x[i, j] := AbsInt(x[i, j]);
+      if x[i, j] > threshold then
+        x[i, j] := threshold + (x[i, j] - threshold) mod period;
       fi;
     od;
   od;
@@ -82,7 +82,7 @@ SEMIGROUPS.MatrixTrans := function(x, dim, zero, one)
 
   mat := List([1 .. dim], x -> ShallowCopy([1 .. dim] * 0 + zero));
   for i in [1 .. dim] do
-    mat[i][i ^ x] := one;
+    mat[i, i ^ x] := one;
   od;
   return mat;
 end;
@@ -102,7 +102,7 @@ function(file, mat)
   pickle := [SEMIGROUPS_FilterOfMatrixOverSemiring(mat), []];
   i := 1;
   while IsBound(mat![i]) do
-    pickle[2][i] := mat![i];
+    pickle[2, i] := mat![i];
     i := i + 1;
   od;
 
@@ -385,11 +385,11 @@ function(mat)
   one := One(mat);
   dim := DimensionOfMatrixOverSemiring(mat);
   if Union(AsList(mat)) <> Union(AsList(one))
-      or ForAny([1 .. dim], i -> Number(mat[i], j -> j = one[1][1]) <> 1) then
+      or ForAny([1 .. dim], i -> Number(mat[i], j -> j = one[1, 1]) <> 1) then
     return fail;
   fi;
 
-  one := one[1][1];
+  one := one[1, 1];
   return Transformation(List([1 .. dim], i -> Position(mat[i], one)));
 end);
 
@@ -473,7 +473,7 @@ function(x)
   for i in [1 .. n] do
     y[i] := [];
     for j in [1 .. n] do
-      y[i][j] := x[j][i];
+      y[i, j] := x[j, i];
     od;
   od;
 
@@ -570,12 +570,12 @@ function(x)
   max := 0;
   for i in [1 .. n] do
     for j in [1 .. n] do
-      if x[i][j] = infinity then
+      if x[i, j] = infinity then
         length := 1;
-      elif x[i][j] = -infinity then
+      elif x[i, j] = -infinity then
         length := 2;
       else
-        length := Length(String(x[i][j]));
+        length := Length(String(x[i, j]));
       fi;
       if length > max then
         max := length;
@@ -602,7 +602,7 @@ function(x)
   str := "";
   for i in [1 .. n] do
     for j in [1 .. n] do
-      Append(str, pad(x[i][j]));
+      Append(str, pad(x[i, j]));
     od;
     Remove(str, Length(str));
     Append(str, "\n");
@@ -665,13 +665,13 @@ function(x)
     Append(str, "\>\>[");
     for j in [1 .. n] do
       if IsBooleanMat(x) then
-        if x[i][j] then
+        if x[i, j] then
           Append(str, String(1));
         else
           Append(str, String(0));
         fi;
       else
-        Append(str, String(x[i][j]));
+        Append(str, String(x[i, j]));
       fi;
 
       Append(str, ", ");

--- a/gap/semigroups/semiffmat.gi
+++ b/gap/semigroups/semiffmat.gi
@@ -438,7 +438,7 @@ function(S, x, y)
     row := 1;
 
     while col <= deg do
-      while IsZero(eqs[row][col]) and col <= deg do
+      while IsZero(eqs[row, col]) and col <= deg do
         col := col + 1;
       od;
       if col <= deg then

--- a/gap/semigroups/semimaxplus.gi
+++ b/gap/semigroups/semimaxplus.gi
@@ -664,7 +664,7 @@ function(S)
 
   func := function(i)
     return List([1 .. dim],
-                j -> Maximum(List([1 .. Length(gens)], k -> gens[k][i][j])));
+                j -> Maximum(List([1 .. Length(gens)], k -> gens[k][i, j])));
   end;
 
   m := Matrix(IsMaxPlusMatrix, List([1 .. dim], func));
@@ -699,7 +699,7 @@ function(S)
 
   func := function(i)
     return List([1 .. dim],
-                j -> Maximum(List([1 .. Length(gens)], k -> gens[k][i][j])));
+                j -> Maximum(List([1 .. Length(gens)], k -> gens[k][i, j])));
   end;
 
   # Sum with respect to max-plus algebra of generators of S.

--- a/gap/semigroups/semimaxplus.gi
+++ b/gap/semigroups/semimaxplus.gi
@@ -660,7 +660,7 @@ function(S)
   local gens, dim, func, m, rad, T;
 
   gens := GeneratorsOfSemigroup(S);
-  dim := Length(gens[1][1]);
+  dim := DimensionOfMatrixOverSemiring(Representative(gens));
 
   func := function(i)
     return List([1 .. dim],
@@ -695,7 +695,7 @@ function(S)
   local gens, dim, func, m, critcol, d, ngens, i;
 
   gens := GeneratorsOfSemigroup(S);
-  dim := Length(gens[1][1]);
+  dim := DimensionOfMatrixOverSemiring(Representative(gens));
 
   func := function(i)
     return List([1 .. dim],


### PR DESCRIPTION
I'm trying to see how painful it is, and whether it's even possible, to make Semigroups matrices fit into the GAP `MatrixObj` framework. This would let us benefit from the setup there, in particular some new notation, and default methods, and we would also be using the standard names for things, so that people familiar with how to manipulate other matrices in GAP will already know what the appropriate commands are for our matrices.

(One thing that I like is that with matrix objects, you can do `mat[i,j]` to access the entry in row `i` and column `j`.)

This is related to but still mostly independent of #512: we can create matrices with some other operation than `Matrix`, but still have them be matrix objects. However, if we can make our matrices fully fit into the `MatrixObj` framework, then I think we would happily continue to use `Matrix`.

On the whole this seems to be going fairly smoothly, with no major interventions, except for the requirement of GAP 4.10.0 rather than GAP 4.9.0. However, I've definitely not done everything (I'm not sure exactly which methods `MatrixObj`s need to offer), but perhaps the stumbling block will be if it is required to implement `BaseDomain` methods for our matrices.

Basically, the `BaseDomain` is supposed to be something like the field/ring/whatever generated by the elements of the matrix, or at least the field/ring/whatever in which they live. However, I'm not sure if we can always do that. Consider an `NTPMatrix`: the entries are integers, but we definitely wouldn't want the `BaseDomain` to be `Integers`; but we also haven't implemented NTP semiring objects (and we have no intention to), so we couldn't return an appropriate NTP semiring either. Therefore we can't install a `BaseDomain` method in this case. Hopefully that's not fatal.