### PR TITLE
Add EqualInFreeBand method

### DIFF
--- a/doc/freeband.xml
+++ b/doc/freeband.xml
@@ -200,7 +200,7 @@ gap> ContentOfFreeBandElementCollection([x, y]);
 
       Where <C>F</C> is a free band over some alphabet containing the
       contents of <A>u</A> and <A>v</A>, this operation returns <E>true</E>
-      if <A>u</A> and <A>v</A> are equal in <C>F</C>, and <E>false</E>
+      if <A>u</A> and <A>v</A> are equal in <C>F</C>, and <K>false</K>
       otherwise.<P/>
 
       Note that this operation is for lists and strings, as opposed to

--- a/doc/freeband.xml
+++ b/doc/freeband.xml
@@ -196,15 +196,15 @@ gap> ContentOfFreeBandElementCollection([x, y]);
     <Oper Name="EqualInFreeBand"  Arg="u, v"/>
     <Description>
       This operation takes a pair <A>u</A> and <A>v</A> of lists of
-      positive integers or strings, representing words in a free band.<P/>
+      positive integers or strings, representing words in a free semigroup.<P/>
 
       Where <C>F</C> is a free band over some alphabet containing the
-      contents of <A>u</A> and <A>v</A>, this operation returns <E>true</E>
+      letters occurring in <A>u</A> and <A>v</A>, this operation returns <K>true</K>
       if <A>u</A> and <A>v</A> are equal in <C>F</C>, and <K>false</K>
       otherwise.<P/>
 
       Note that this operation is for lists and strings, as opposed to
-      FreeBandElement objects.<P/>
+      <C>FreeBandElement</C> objects.<P/>
 
       This is an implementation of an algorithm described by Jakub Radoszewski
       and Wojciech Rytter in 'Efficient Testing of Equivalence of Words in a

--- a/doc/freeband.xml
+++ b/doc/freeband.xml
@@ -190,3 +190,35 @@ gap> ContentOfFreeBandElementCollection([x, y]);
     </Description>
   </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="EqualInFreeBand">
+  <ManSection>
+    <Oper Name="EqualInFreeBand"  Arg="u, v"/>
+    <Description>
+      This operation takes a pair <A>u</A> and <A>v</A> of lists of
+      positive integers or strings, representing words in a free band.<P/>
+
+      Where <C>F</C> is a free band over some alphabet containing the
+      contents of <A>u</A> and <A>v</A>, this operation returns <E>true</E>
+      if <A>u</A> and <A>v</A> are equal in <C>F</C>, and <E>false</E>
+      otherwise.<P/>
+
+      Note that this operation is for lists and strings, as opposed to
+      FreeBandElement objects.<P/>
+
+      This is an implementation of an algorithm described by Jakub Radoszewski
+      and Wojciech Rytter in 'Efficient Testing of Equivalence of Words in a
+      Free Idempotent Semigroup⋆'
+      <Example><![CDATA[
+gap> EqualInFreeBand("aa", "a");
+true
+gap> EqualInFreeBand("abcacba", "abcba");
+true
+gap> EqualInFreeBand("aab", "aac");
+false
+gap> EqualInFreeBand([1, 3, 3], [2]);
+false
+]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>

--- a/doc/word.xml
+++ b/doc/word.xml
@@ -44,3 +44,60 @@ gap> RandomWord(8, 4);
 </Description> 
 </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="StandardiseWord" >
+<ManSection>
+  <Oper Name = "StandardiseWord" Arg = "w"/>
+  <Oper Name = "StandardizeWord" Arg = "w"/>
+  <Returns>
+    A list of positive integers.
+  </Returns>
+  <Description>
+    This function takes a word <A>w</A>, consisting of <C>n</C> distinct
+    positive integers and returns a word <C>s</C> where the characters of
+    <C>s</C> correspond to those of <A>w</A> in order of first appearence.<P/>
+
+    The word <A>w</A> is changed in-place into word <C>s</C>.
+  <Example><![CDATA[
+gap> w := [3, 1, 2];
+[ 3, 1, 2 ]
+gap> StandardiseWord(w);
+[ 1, 2, 3 ]
+gap> w;
+[ 1, 2, 3 ]
+gap> w := [4, 2, 10, 2];
+[ 4, 2, 10, 2 ]
+gap> StandardiseWord(w);
+[ 1, 2, 3, 2 ]]]></Example> 
+</Description> 
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="StringToWord" >
+<ManSection>
+  <Oper Name = "StringToWord" Arg = "s"
+    Label="for a string"/>
+  <Returns>
+    A list of positive integers.
+  </Returns>
+  <Description>
+    This function takes a string <A>s</A>, consisting of <C>n</C> distinct
+    positive integers and returns a word <C>w</C> (i.e. a list of positive
+    integers) over the alphabet <C>[1 .. n]</C>. The positive integers of
+    <C>w</C> correspond to the characters of <A>s</A>, in order of first
+    appearence.
+  <Example><![CDATA[
+gap> w := "abac";
+"abac"
+gap> StringToWord(w);
+[ 1, 2, 1, 3 ]
+gap> w := "ccala";
+"ccala"
+gap> StringToWord(w);
+[ 1, 1, 2, 3, 2 ]
+gap> StringToWord(w);
+[ 1, 2, 3, 4 ]
+]]></Example> 
+</Description> 
+</ManSection>
+<#/GAPDoc>

--- a/doc/word.xml
+++ b/doc/word.xml
@@ -1,0 +1,46 @@
+#############################################################################
+##
+#W  word.xml
+#Y  Copyright (C) 2020                                      Maria Tsalakou
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+
+<#GAPDoc Label="WordToString" >
+<ManSection>
+  <Oper Name = "WordToString" Arg = "alphabet, word"
+    Label="for a string and a list"/>
+  <Returns>
+    The <A>word</A> in the form of a string.
+  </Returns>
+  <Description>
+    Returns the word <A>word</A> that is given in the form of a list, in 
+    the form of a string of letters of the <A>alphabet</A>.
+ <Example><![CDATA[
+ gap> WordToString("abcd", [4, 2, 3, 1, 1, 4, 2, 3]);
+"dbcaadbc"]]></Example>
+    </Description>
+   </ManSection>
+   <#/GAPDoc>
+
+<#GAPDoc Label="RandomWord" >
+<ManSection>
+  <Oper Name = "RandomWord" Arg = "length, number_letters"
+    Label="for two integers"/>
+  <Returns>
+    A random word of length <A>length</A> in the form of a list using 
+    <A>number_letters</A> letters.
+  </Returns>
+  <Description>
+	  Returns a random word of length <A>length</A>
+  <Example><![CDATA[
+gap> RandomWord(8, 5);
+[ 2, 4, 3, 4, 5, 3, 3, 2 ]
+gap> RandomWord(8, 5);
+[ 3, 3, 5, 5, 5, 4, 4, 5 ]
+gap> RandomWord(8, 4);
+[ 1, 4, 1, 1, 3, 3, 4, 4 ]"]]></Example> 
+</Description> 
+</ManSection>
+<#/GAPDoc>

--- a/doc/word.xml
+++ b/doc/word.xml
@@ -9,14 +9,15 @@
 
 <#GAPDoc Label="WordToString" >
 <ManSection>
-  <Oper Name = "WordToString" Arg = "alphabet, word"
+  <Oper Name = "WordToString" Arg = "A, w"
     Label="for a string and a list"/>
   <Returns>
-    The <A>word</A> in the form of a string.
+    A string.
   </Returns>
   <Description>
-    Returns the word <A>word</A> that is given in the form of a list, in 
-    the form of a string of letters of the <A>alphabet</A>.
+    Returns the word <A>w</A>, in the form of a string of letters
+    of the alphabet <A>A</A>. The alphabet is given as a string containing
+    its members.
  <Example><![CDATA[
 gap> WordToString("abcd", [4, 2, 3, 1, 1, 4, 2, 3]);
 "dbcaadbc"]]></Example>
@@ -26,14 +27,13 @@ gap> WordToString("abcd", [4, 2, 3, 1, 1, 4, 2, 3]);
 
 <#GAPDoc Label="RandomWord" >
 <ManSection>
-  <Oper Name = "RandomWord" Arg = "length, number_letters"
+  <Oper Name = "RandomWord" Arg = "l, n"
     Label="for two integers"/>
   <Returns>
-    A random word of length <A>length</A> in the form of a list using 
-    <A>number_letters</A> letters.
+    A word.
   </Returns>
   <Description>
-	  Returns a random word of length <A>length</A>
+    Returns a random word of length <A>l</A> over <A>n</A> letters.
   <Example><![CDATA[
 gap> RandomWord(8, 5);
 [ 2, 4, 3, 4, 5, 3, 3, 2 ]

--- a/doc/word.xml
+++ b/doc/word.xml
@@ -20,9 +20,9 @@
  <Example><![CDATA[
  gap> WordToString("abcd", [4, 2, 3, 1, 1, 4, 2, 3]);
 "dbcaadbc"]]></Example>
-    </Description>
-   </ManSection>
-   <#/GAPDoc>
+  </Description>
+ </ManSection>
+<#/GAPDoc>
 
 <#GAPDoc Label="RandomWord" >
 <ManSection>
@@ -41,8 +41,8 @@ gap> RandomWord(8, 5);
 [ 3, 3, 5, 5, 5, 4, 4, 5 ]
 gap> RandomWord(8, 4);
 [ 1, 4, 1, 1, 3, 3, 4, 4 ]"]]></Example> 
-</Description> 
-</ManSection>
+  </Description> 
+ </ManSection>
 <#/GAPDoc>
 
 <#GAPDoc Label="StandardiseWord" >
@@ -69,8 +69,8 @@ gap> w := [4, 2, 10, 2];
 [ 4, 2, 10, 2 ]
 gap> StandardiseWord(w);
 [ 1, 2, 3, 2 ]]]></Example> 
-</Description> 
-</ManSection>
+  </Description> 
+ </ManSection>
 <#/GAPDoc>
 
 <#GAPDoc Label="StringToWord" >
@@ -95,9 +95,10 @@ gap> w := "ccala";
 "ccala"
 gap> StringToWord(w);
 [ 1, 1, 2, 3, 2 ]
+gap> w := "a1b5";
+"a1b5"
 gap> StringToWord(w);
-[ 1, 2, 3, 4 ]
-]]></Example> 
-</Description> 
-</ManSection>
+[ 1, 2, 3, 4 ]]]]></Example> 
+  </Description> 
+ </ManSection>
 <#/GAPDoc>

--- a/doc/word.xml
+++ b/doc/word.xml
@@ -18,7 +18,7 @@
     Returns the word <A>word</A> that is given in the form of a list, in 
     the form of a string of letters of the <A>alphabet</A>.
  <Example><![CDATA[
- gap> WordToString("abcd", [4, 2, 3, 1, 1, 4, 2, 3]);
+gap> WordToString("abcd", [4, 2, 3, 1, 1, 4, 2, 3]);
 "dbcaadbc"]]></Example>
   </Description>
  </ManSection>
@@ -40,7 +40,7 @@ gap> RandomWord(8, 5);
 gap> RandomWord(8, 5);
 [ 3, 3, 5, 5, 5, 4, 4, 5 ]
 gap> RandomWord(8, 4);
-[ 1, 4, 1, 1, 3, 3, 4, 4 ]"]]></Example> 
+[ 1, 4, 1, 1, 3, 3, 4, 4 ]]]></Example> 
   </Description> 
  </ManSection>
 <#/GAPDoc>
@@ -98,7 +98,7 @@ gap> StringToWord(w);
 gap> w := "a1b5";
 "a1b5"
 gap> StringToWord(w);
-[ 1, 2, 3, 4 ]]]]></Example> 
+[ 1, 2, 3, 4 ]]]></Example> 
   </Description> 
  </ManSection>
 <#/GAPDoc>

--- a/doc/z-chap10.xml
+++ b/doc/z-chap10.xml
@@ -180,4 +180,13 @@ x1x2x2^-1x1^-1x1x2]]></Example>
 
     <#Include Label = "GreensDClassOfElement" >
   </Section>
+
+
+  <Section>
+    <Heading> Words as strings in finitely presented semigroups
+    </Heading>
+
+    <#Include Label = "WordToString" >
+    <#Include Label = "RandomWord" > 
+  </Section>
 </Chapter>

--- a/doc/z-chap10.xml
+++ b/doc/z-chap10.xml
@@ -183,10 +183,12 @@ x1x2x2^-1x1^-1x1x2]]></Example>
 
 
   <Section>
-    <Heading> Words as strings in finitely presented semigroups
+    <Heading> Words and strings in finitely presented semigroups
     </Heading>
 
     <#Include Label = "WordToString" >
-    <#Include Label = "RandomWord" > 
+    <#Include Label = "RandomWord" >
+    <#Include Label = "StandardiseWord" >
+    <#Include Label = "StringToWord" >
   </Section>
 </Chapter>

--- a/doc/z-chap10.xml
+++ b/doc/z-chap10.xml
@@ -185,6 +185,8 @@ x1x2x2^-1x1^-1x1x2]]></Example>
   <Section>
     <Heading> Words and strings in finitely presented semigroups
     </Heading>
+    This section contains various methods for dealing with words, which for
+    these purposes are lists of positive integers.
 
     <#Include Label = "WordToString" >
     <#Include Label = "RandomWord" >

--- a/doc/z-chap10.xml
+++ b/doc/z-chap10.xml
@@ -154,6 +154,7 @@ x1x2x2^-1x1^-1x1x2]]></Example>
     <#Include Label = "IsFreeBandElementCollection">
     <#Include Label = "IsFreeBandSubsemigroup">
     <#Include Label = "ContentOfFreeBandElement">
+    <#Include Label = "EqualInFreeBand">
     
   </Section>
 

--- a/gap/fp/freeband.gd
+++ b/gap/fp/freeband.gd
@@ -18,3 +18,6 @@ DeclareGlobalFunction("FreeBand");
 DeclareAttribute("ContentOfFreeBandElement", IsFreeBandElement);
 DeclareAttribute("ContentOfFreeBandElementCollection",
                  IsFreeBandElementCollection);
+
+DeclareOperation("EqualInFreeBand", [IsList, IsList]);
+DeclareOperation("EqualInFreeBand", [IsString, IsString]);

--- a/gap/fp/freeband.gd
+++ b/gap/fp/freeband.gd
@@ -20,4 +20,3 @@ DeclareAttribute("ContentOfFreeBandElementCollection",
                  IsFreeBandElementCollection);
 
 DeclareOperation("EqualInFreeBand", [IsList, IsList]);
-DeclareOperation("EqualInFreeBand", [IsString, IsString]);

--- a/gap/fp/freeband.gi
+++ b/gap/fp/freeband.gi
@@ -440,42 +440,8 @@ end);
 InstallMethod(EqualInFreeBand, "for two lists of positive integers",
 [IsList, IsList],
 function(w1_in, w2_in)
-  local ListOfPosIntsToStandardListOfPosInts, Right, Left, LevelEdges,
-  RadixSort, StripFreeBandString, w1, w2, dollar, l1, l2, w, c, check,
-  rightk, leftk, edgecodes, rightm, leftm, i, k;
-
-  ListOfPosIntsToStandardListOfPosInts := function(list)
-    local L, distinct_chars, lookup, i;
-    if not IsList(list) then
-      ErrorNoReturn("expected a list as the argument");
-    fi;
-    for i in list do
-      if not IsPosInt(i) then
-        ErrorNoReturn("expected a list of positive integers as the argument");
-      fi;
-    od;
-    L := Length(list);
-    if L = 0 then
-      return [];
-    fi;
-
-    distinct_chars  := 1;
-    lookup          := [];
-    lookup[list[1]] := 1;
-    list[1]         := 1;
-
-    for i in [2 .. L] do
-      if IsBound(lookup[list[i]]) then
-        list[i] := lookup[list[i]];
-      else
-        distinct_chars  := distinct_chars + 1;
-        lookup[list[i]] := distinct_chars;
-        list[i]         := lookup[list[i]];
-      fi;
-    od;
-
-    return list;
-  end;
+  local Right, Left, LevelEdges, RadixSort, StripFreeBandString, w1, w2, dollar,
+  l1, l2, w, c, check, rightk, leftk, edgecodes, rightm, leftm, i, k;
 
   Right := function(w, k)
     local max_char, right, i, j, content_size, multiplicity, length_w;
@@ -554,7 +520,7 @@ function(w1_in, w2_in)
     od;
 
     length_w := Length(w);
-    w        := ListOfPosIntsToStandardListOfPosInts(Reversed(w));
+    w        := StandardiseWord(Reversed(w));
     left     := Reversed(Right(w, k));
     for i in [1 .. length_w] do
       if left[i] <> fail then
@@ -699,7 +665,7 @@ function(w1_in, w2_in)
   l2     := Length(w2);
 
   w := Concatenation(w1, [dollar], w2);
-  w := ListOfPosIntsToStandardListOfPosInts(w);
+  w := StandardiseWord(w);
 
   c     := w[l1 + 1];
   check := ListWithIdenticalEntries(c, false);

--- a/gap/fp/freeband.gi
+++ b/gap/fp/freeband.gi
@@ -438,7 +438,7 @@ end);
 # in a Free Idempotent Semigroup⋆'
 
 InstallMethod(EqualInFreeBand, "for two lists of positive integers",
-[IsList, IsList],
+[IsHomogeneousList, IsHomogeneousList],
 function(w1_in, w2_in)
   local Right, Left, LevelEdges, RadixSort, StripFreeBandString, w1, w2, dollar,
   l1, l2, w, c, check, rightk, leftk, edgecodes, rightm, leftm, i, k;

--- a/gap/fp/freeband.gi
+++ b/gap/fp/freeband.gi
@@ -444,26 +444,8 @@ function(w1_in, w2_in)
   l1, l2, w, c, check, rightk, leftk, edgecodes, rightm, leftm, i, k;
 
   Right := function(w, k)
-    local max_char, right, i, j, content_size, multiplicity, length_w;
-    if not IsList(w) then
-      ErrorNoReturn("expected a list as first argument");
-    elif not IsPosInt(k) then
-      ErrorNoReturn("expected a positive integer as second argument");
-    fi;
-    max_char := 0;
-    for i in w do
-      if not IsPosInt(i) then
-        ErrorNoReturn("expected a list of positive integers as first argument");
-      fi;
-      if i > max_char + 1 then
-        ErrorNoReturn("expected first argument w to be a list of positive ",
-                      "integers which contains at least one instance of each ",
-                      "integer in [1 .. Maximum(w)], and whose entries are ",
-                      "ordered in order of first appearence.");
-      elif i > max_char then
-        max_char := max_char + 1;
-      fi;
-    od;
+    local right, i, j, content_size, multiplicity, length_w;
+
     length_w := Length(w);
     if length_w = 0 then
       return [];
@@ -499,25 +481,7 @@ function(w1_in, w2_in)
   end;
 
   Left := function(w, k)
-    local max_char, i, left, length_w;
-    if not IsList(w) then
-      ErrorNoReturn("expected a list as first argument");
-    elif not IsPosInt(k) then
-      ErrorNoReturn("expected a positive integer as second argument");
-    fi;
-    max_char := 0;
-    for i in w do
-      if not IsPosInt(i) then
-        ErrorNoReturn("expected a list of positive integers as first argument");
-      elif i > max_char + 1 then
-        ErrorNoReturn("expected first argument w to be a list of positive ",
-                      "integers which contains at least one instance of each ",
-                      "integer in [1 .. Maximum(w)], and whose entries are ",
-                      "ordered in order of first appearence.");
-      elif i > max_char then
-        max_char := max_char + 1;
-      fi;
-    od;
+    local i, left, length_w;
 
     length_w := Length(w);
     w        := StandardiseWord(Reversed(w));
@@ -532,24 +496,8 @@ function(w1_in, w2_in)
 
   LevelEdges := function(w, k, radix, rightk, leftk, rightm, leftm)
     local n, outr, outl, i;
-    if not IsList(w) then
-      ErrorNoReturn("expected a string as the argument, found ", w);
-    fi;
-    if not IsPosInt(k) then
-      ErrorNoReturn("expected a positive integer as second argument");
-    fi;
-    if not k <= Length(w) then
-      ErrorNoReturn("level k cannot be greater than length of word");
-    fi;
-    if not (IsList(radix) and IsList(rightk)
-                          and IsList(leftk)
-                          and IsList(rightm)
-                          and IsList(leftm)) then
-      ErrorNoReturn("expected final five arguments to be lists");
-    fi;
 
     n    := Length(w);
-
     outr := [];
     outl := [];
 

--- a/gap/fp/word.gd
+++ b/gap/fp/word.gd
@@ -10,3 +10,6 @@
 
 DeclareOperation("WordToString", [IsString, IsList]);
 DeclareOperation("RandomWord", [IsInt, IsInt]);
+DeclareOperation("StandardiseWord", [IsList]);
+DeclareSynonym("StandardizeWord", StandardiseWord);
+DeclareOperation("StringToWord", [IsString]);

--- a/gap/fp/word.gd
+++ b/gap/fp/word.gd
@@ -1,0 +1,12 @@
+#############################################################################
+##
+##  word.gd
+##  Copyright (C) 2020                                      Maria Tsalakou
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+
+DeclareOperation("WordToString", [IsString, IsList]);
+DeclareOperation("RandomWord", [IsInt, IsInt]);

--- a/gap/fp/word.gi
+++ b/gap/fp/word.gi
@@ -33,3 +33,42 @@ function(length, number_letters)
   od;
   return word;
 end);
+
+InstallMethod(StandardiseWord, "for a list of positive integers",
+[IsList],
+function(w)
+  local L, distinct_chars, lookup, i;
+  if not IsList(w) then
+    ErrorNoReturn("expected a list as argument");
+  fi;
+
+  L := Length(w);
+  if L = 0 then
+    return w;
+  fi;
+
+  for i in w do
+    if not IsPosInt(i) then
+      ErrorNoReturn("expected a list of positive integers as argument");
+    fi;
+  od;
+
+  distinct_chars := 1;
+  lookup         := [];
+  lookup[w[1]]   := 1;
+  w[1]           := 1;
+
+  for i in [2 .. L] do
+    if IsBound(lookup[w[i]]) then
+      w[i] := lookup[w[i]];
+    else
+      distinct_chars := distinct_chars + 1;
+      lookup[w[i]]   := distinct_chars;
+      w[i]           := distinct_chars;
+    fi;
+  od;
+  return w;
+end);
+
+InstallMethod(StringToWord, "for a string", [IsString],
+w -> StandardiseWord(List(w, IntChar)));

--- a/gap/fp/word.gi
+++ b/gap/fp/word.gi
@@ -17,7 +17,8 @@ function(alphabet, word)
   fi;
   for i in word do
     if not IsPosInt(i) then
-      ErrorNoReturn("expected a list of positive integers as second argument");
+      ErrorNoReturn("Semigroups: WordToString: usage,\n",
+                    "expected list of positive integers as second argument,");
     fi;
   od;
   if Maximum(word) > Length(alphabet) then
@@ -39,6 +40,8 @@ function(length, number_letters)
     ErrorNoReturn("expected non-negative integer as first argument");
   elif number_letters < 0 then
     ErrorNoReturn("expected non-negative integer as second argument");
+  elif number_letters = 0 and length > 0 then
+    ErrorNoReturn("first argument cannot be positive if second is zero");
   fi;
   word := EmptyPlist(length);
   for i in [1 .. length] do
@@ -51,9 +54,6 @@ InstallMethod(StandardiseWord, "for a list of positive integers",
 [IsList],
 function(w)
   local L, distinct_chars, lookup, i;
-  if not IsList(w) then
-    ErrorNoReturn("expected a list as argument");
-  fi;
 
   L := Length(w);
   if L = 0 then

--- a/gap/fp/word.gi
+++ b/gap/fp/word.gi
@@ -1,0 +1,35 @@
+#############################################################################
+##
+##  word.gi
+##  Copyright (C) 2020                                      Maria Tsalakou
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+
+InstallMethod(WordToString, "for a string and a list",
+[IsString, IsList],
+function(alphabet, word)
+  local str, i;
+   if Maximum(word) > Length(alphabet) then
+     ErrorNoReturn("Semigroups: WordToString: usage,\n",
+                   "there are not enough letters in the alphabet,");
+   fi;
+  str := "";
+  for i in word do
+     Add(str, alphabet[i]);
+  od;
+  return str;
+end);
+
+InstallMethod(RandomWord, "for two integers",
+[IsInt, IsInt],
+function(length, number_letters)
+  local word, i;
+  word := EmptyPlist(length);
+  for i in [1 .. length] do
+      Add(word, Random([1 .. number_letters]));
+  od;
+  return word;
+end);

--- a/gap/fp/word.gi
+++ b/gap/fp/word.gi
@@ -12,10 +12,18 @@ InstallMethod(WordToString, "for a string and a list",
 [IsString, IsList],
 function(alphabet, word)
   local str, i;
-   if Maximum(word) > Length(alphabet) then
-     ErrorNoReturn("Semigroups: WordToString: usage,\n",
-                   "there are not enough letters in the alphabet,");
-   fi;
+  if Length(word) = 0 then
+    return "";
+  fi;
+  for i in word do
+    if not IsPosInt(i) then
+      ErrorNoReturn("expected a list of positive integers as second argument");
+    fi;
+  od;
+  if Maximum(word) > Length(alphabet) then
+    ErrorNoReturn("Semigroups: WordToString: usage,\n",
+                  "there are not enough letters in the alphabet,");
+  fi;
   str := "";
   for i in word do
      Add(str, alphabet[i]);
@@ -23,10 +31,15 @@ function(alphabet, word)
   return str;
 end);
 
-InstallMethod(RandomWord, "for two integers",
+InstallMethod(RandomWord, "for two non-negative integers",
 [IsInt, IsInt],
 function(length, number_letters)
   local word, i;
+  if length < 0 then
+    ErrorNoReturn("expected non-negative integer as first argument");
+  elif number_letters < 0 then
+    ErrorNoReturn("expected non-negative integer as second argument");
+  fi;
   word := EmptyPlist(length);
   for i in [1 .. length] do
       Add(word, Random([1 .. number_letters]));

--- a/gap/tools/utils.gi
+++ b/gap/tools/utils.gi
@@ -284,7 +284,8 @@ SEMIGROUPS.DocXMLFiles := ["../PackageInfo.g",
                            "semiringmat.xml",
                            "semitrans.xml",
                            "trans.xml",
-                           "utils.xml"];
+                           "utils.xml",
+                           "word.xml"];
 
 SEMIGROUPS.ManualExamples := function()
   return ExtractExamples(DirectoriesPackageLibrary("semigroups", "doc"),

--- a/init.g
+++ b/init.g
@@ -117,6 +117,7 @@ ReadPackage("semigroups", "gap/congruences/congfpmon.gd");
 
 ReadPackage("semigroups", "gap/fp/freeinverse.gd");
 ReadPackage("semigroups", "gap/fp/freeband.gd");
+ReadPackage("semigroups", "gap/fp/word.gd");
 
 ReadPackage("semigroups", "gap/obsolete.gd");
 

--- a/read.g
+++ b/read.g
@@ -91,6 +91,7 @@ ReadPackage("semigroups", "gap/congruences/congfpmon.gi");
 
 ReadPackage("semigroups", "gap/fp/freeinverse.gi");
 ReadPackage("semigroups", "gap/fp/freeband.gi");
+ReadPackage("semigroups", "gap/fp/word.gi");
 
 ReadPackage("semigroups", "gap/obsolete.gi");
 

--- a/tst/standard/freeband.tst
+++ b/tst/standard/freeband.tst
@@ -237,6 +237,32 @@ gap> ContentOfFreeBandElement(S.2 * S.1);
 gap> FreeBand(100);
 <free band with 100 generators>
 
+# Test EqualInFreeBand
+gap> x := [1, 4, 2, 3, 10];
+[ 1, 4, 2, 3, 10 ]
+gap> y := [1, 4, 1, 4, 2, 3, 10];
+[ 1, 4, 1, 4, 2, 3, 10 ]
+gap> EqualInFreeBand(x, y);
+true
+gap> x := "aaaaaaaaaaaaaaaaaababaaaaaaabbbbb";
+"aaaaaaaaaaaaaaaaaababaaaaaaabbbbb"
+gap> y := "ab";
+"ab"
+gap> EqualInFreeBand(x, y);
+true
+gap> EqualInFreeBand("a", "b");
+false
+gap> EqualInFreeBand("", "");
+true
+gap> x := "abcbcccbabacab";
+"abcbcccbabacab"
+gap> y := "abcab";
+"abcab"
+gap> EqualInFreeBand(x, y);
+true
+gap> EqualInFreeBand("abac", "abad");
+false
+
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(D);
 gap> Unbind(S);

--- a/tst/standard/word.tst
+++ b/tst/standard/word.tst
@@ -1,0 +1,68 @@
+#############################################################################
+##
+##  standard/freeband.tst
+#Y  Copyright (C) 2020                                   Murray T. Whyte
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+gap> START_TEST("Semigroups package: standard/freeband.tst");
+gap> LoadPackage("semigroups", false);;
+
+#
+gap> SEMIGROUPS.StartTest();
+
+# Test StandardiseWord
+gap> A := [3, 100, 2, 100, 3];
+[ 3, 100, 2, 100, 3 ]
+gap> StandardiseWord(A);
+[ 1, 2, 3, 2, 1 ]
+gap> A;
+[ 1, 2, 3, 2, 1 ]
+gap> A := [];
+[  ]
+gap> StandardiseWord(A);
+[  ]
+gap> StandardiseWord([10]);
+[ 1 ]
+gap> A := [1, 2, 3, 4, 5];
+[ 1, 2, 3, 4, 5 ]
+gap> StandardiseWord(A);
+[ 1, 2, 3, 4, 5 ]
+gap> A := [1, 1, 1, 1, 1, 1, 1, 1, 3];
+[ 1, 1, 1, 1, 1, 1, 1, 1, 3 ]
+gap> StandardizeWord(A);
+[ 1, 1, 1, 1, 1, 1, 1, 1, 2 ]
+gap> A := [2, 1, 2, 3, 2];
+[ 2, 1, 2, 3, 2 ]
+gap> StandardiseWord(A);
+[ 1, 2, 1, 3, 1 ]
+
+# Test StringToWord
+gap> w := "aabaacaad";
+"aabaacaad"
+gap> StringToWord(w);
+[ 1, 1, 2, 1, 1, 3, 1, 1, 4 ]
+gap> w;
+"aabaacaad"
+gap> w := "3a5bz!";
+"3a5bz!"
+gap> StringToWord(w);
+[ 1, 2, 3, 4, 5, 6 ]
+gap> w := "xyab77x";
+"xyab77x"
+gap> StringToWord(w);
+[ 1, 2, 3, 4, 5, 5, 1 ]
+gap> StringToWord("");
+[  ]
+gap> StringToWord("a");
+[ 1 ]
+
+# SEMIGROUPS_UnbindVariables
+gap> Unbind(A);
+gap> Unbind(w);
+
+#
+gap> SEMIGROUPS.StopTest();
+gap> STOP_TEST("Semigroups package: standard/freeband.tst");

--- a/tst/standard/word.tst
+++ b/tst/standard/word.tst
@@ -1,13 +1,13 @@
 #############################################################################
 ##
-##  standard/freeband.tst
+##  standard/word.tst
 #Y  Copyright (C) 2020                                   Murray T. Whyte
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
 #############################################################################
 ##
-gap> START_TEST("Semigroups package: standard/freeband.tst");
+gap> START_TEST("Semigroups package: standard/word.tst");
 gap> LoadPackage("semigroups", false);;
 
 #
@@ -65,4 +65,4 @@ gap> Unbind(w);
 
 #
 gap> SEMIGROUPS.StopTest();
-gap> STOP_TEST("Semigroups package: standard/freeband.tst");
+gap> STOP_TEST("Semigroups package: standard/word.tst");

--- a/tst/standard/word.tst
+++ b/tst/standard/word.tst
@@ -24,6 +24,12 @@ gap> WordToString("", []);
 ""
 gap> WordToString("abc", [1]);
 "a"
+gap> WordToString("abc", [4]);
+Error, Semigroups: WordToString: usage,
+there are not enough letters in the alphabet,
+gap> WordToString("ab", [1, -1]);
+Error, Semigroups: WordToString: usage,
+expected list of positive integers as second argument,
 
 # Test RandomWord
 gap> Length(RandomWord(4, 4)) = 4;
@@ -36,6 +42,12 @@ gap> Length(DuplicateFreeList(RandomWord(100, 20))) <= 20;
 true
 gap> RandomWord(0, 0);
 [  ]
+gap> RandomWord(1, 0);
+Error, first argument cannot be positive if second is zero
+gap> RandomWord(-1, 2);
+Error, expected non-negative integer as first argument
+gap> RandomWord(2, -1);
+Error, expected non-negative integer as second argument
 
 # Test StandardiseWord
 gap> A := [3, 100, 2, 100, 3];
@@ -62,6 +74,10 @@ gap> A := [2, 1, 2, 3, 2];
 [ 2, 1, 2, 3, 2 ]
 gap> StandardiseWord(A);
 [ 1, 2, 1, 3, 1 ]
+gap> StandardiseWord([0, 1, 2, 1]);
+Error, expected a list of positive integers as argument
+gap> StandardiseWord([[1, 2], [0]]);
+Error, expected a list of positive integers as argument
 
 # Test StringToWord
 gap> w := "aabaacaad";

--- a/tst/standard/word.tst
+++ b/tst/standard/word.tst
@@ -13,6 +13,30 @@ gap> LoadPackage("semigroups", false);;
 #
 gap> SEMIGROUPS.StartTest();
 
+# Test WordToString
+gap> WordToString("abc", [1, 1, 2, 1, 3]);
+"aabac"
+gap> WordToString("e3a", [3, 3, 3, 1]);
+"aaae"
+gap> WordToString("abc", []);
+""
+gap> WordToString("", []);
+""
+gap> WordToString("abc", [1]);
+"a"
+
+# Test RandomWord
+gap> Length(RandomWord(4, 4)) = 4;
+true
+gap> Length(RandomWord(3, 10)) = 3;
+true
+gap> RandomWord(0, 100) = [];
+true
+gap> Length(DuplicateFreeList(RandomWord(100, 20))) <= 20;
+true
+gap> RandomWord(0, 0);
+[  ]
+
 # Test StandardiseWord
 gap> A := [3, 100, 2, 100, 3];
 [ 3, 100, 2, 100, 3 ]


### PR DESCRIPTION
This PR adds an operation `EqualInFreeBand`, written by @tomcontileslie, @reiniscirpons and myself, which is an implementation of the algorithm described in Jakub Radoszewski and Wojciech Rytter's _Efficient Testing of Equivalence of Words in a Free Idempotent Semigroup⋆_.

https://link.springer.com/chapter/10.1007/978-3-642-11266-9_55