### PR TITLE
Coset monoids

### DIFF
--- a/gap/semigroups/cosetmonoid.gd
+++ b/gap/semigroups/cosetmonoid.gd
@@ -1,0 +1,11 @@
+#############################################################################
+##
+##  cosetmonoid.gd
+##  Copyright (C) 2020                                  Luke Elliott
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+#
+DeclareOperation("CosetMonoid", [IsPermGroup]);

--- a/gap/semigroups/cosetmonoid.gi
+++ b/gap/semigroups/cosetmonoid.gi
@@ -33,7 +33,7 @@ function(G)
       rep := Representative(cosets[i][j]);
       newgens := Concatenation(Generators(subgroups[i]),
                   Generators(E ^ (rep ^ -1)));
-      if newgens = [] then 
+      if newgens = [] then
         newgens := [()];
       fi;
       newgroup := Group(newgens);
@@ -53,7 +53,7 @@ function(G)
 
   gens := Concatenation(gens, Generators(G));
 
-  Apply(gens, x -> 
+  Apply(gens, x ->
         Transformation(List(cosetpositions, y -> genprod(y[1], y[2], x))));
 
   return Semigroup(gens);

--- a/gap/semigroups/cosetmonoid.gi
+++ b/gap/semigroups/cosetmonoid.gi
@@ -1,0 +1,60 @@
+#############################################################################
+##
+##  cosetmonoid.gi
+##  Copyright (C) 2020                                  Luke Elliott
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+
+InstallMethod(CosetMonoid, "for a perm group", [IsPermGroup],
+function(G)
+  local genprod, cosets, subgroup, subgroups, gens, cosetpositions, i, j;
+
+  subgroups := AllSubgroups(G);
+
+  cosets := List(subgroups, x -> RightCosets(G, x));
+  cosetpositions := [];
+
+  for i in [1 .. Size(cosets)] do
+    for j in [1 .. Size(cosets[i])] do
+      Add(cosetpositions, [i, j]);
+    od;
+  od;
+  Sort(cosetpositions);
+
+  genprod := function(i, j, E)
+    local newgroup, rep, newgens;
+    if E in Generators(G) then
+      return Position(cosetpositions,
+                      [i, Position(cosets[i], cosets[i][j] * E)]);
+    else
+      rep := Representative(cosets[i][j]);
+      newgens := Concatenation(Generators(subgroups[i]),
+                  Generators(E ^ (rep ^ -1)));
+      if newgens = [] then 
+        newgens := [()];
+      fi;
+      newgroup := Group(newgens);
+      newgroup := Position(subgroups, newgroup);
+      rep := Position(cosets[newgroup], RightCoset(subgroups[newgroup], rep));
+      return Position(cosetpositions, [newgroup, rep]);
+    fi;
+  end;
+
+  gens := [];
+
+  for subgroup in subgroups do
+    if IsCyclic(subgroup) then
+      Add(gens, subgroup);
+    fi;
+  od;
+
+  gens := Concatenation(gens, Generators(G));
+
+  Apply(gens, x -> 
+        Transformation(List(cosetpositions, y -> genprod(y[1], y[2], x))));
+
+  return Semigroup(gens);
+end);

--- a/init.g
+++ b/init.g
@@ -77,6 +77,7 @@ ReadPackage("semigroups", "gap/semigroups/semifp.gd");
 ReadPackage("semigroups", "gap/semigroups/semiquo.gd");
 ReadPackage("semigroups", "gap/semigroups/semieunit.gd");
 ReadPackage("semigroups", "gap/semigroups/semidp.gd");
+ReadPackage("semigroups", "gap/semigroups/cosetmonoid.gd");
 
 ReadPackage("semigroups", "gap/hash.gd");
 

--- a/read.g
+++ b/read.g
@@ -8,6 +8,8 @@
 #############################################################################
 ##
 
+ReadPackage("semigroups", "gap/smallestimage.g");
+
 ReadPackage("semigroups", "gap/hash.gi");
 
 ReadPackage("semigroups", "gap/elements/star.gi");
@@ -49,6 +51,7 @@ ReadPackage("semigroups", "gap/semigroups/grpffmat.gi");
 ReadPackage("semigroups", "gap/semigroups/semiquo.gi");
 ReadPackage("semigroups", "gap/semigroups/semieunit.gi");
 ReadPackage("semigroups", "gap/semigroups/semidp.gi");
+ReadPackage("semigroups", "gap/semigroups/cosetmonoid.gi");
 
 ReadPackage("semigroups", "gap/ideals/ideals.gi");
 ReadPackage("semigroups", "gap/ideals/idealact.gi");

--- a/tst/standard/cosetmonoid.tst
+++ b/tst/standard/cosetmonoid.tst
@@ -1,0 +1,36 @@
+#############################################################################
+##
+#W  standard/acting.tst
+#Y  Copyright (C) 2011-15                                James D. Mitchell
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+gap> START_TEST("Semigroups package: standard/acting.tst");
+gap> LoadPackage("semigroups", false);;
+
+#
+gap> SEMIGROUPS.StartTest();
+gap> SEMIGROUPS.DefaultOptionsRec.acting := true;;
+
+# CosetMonoid
+gap> CosetMonoid(SymmetricGroup(2));      
+<transformation monoid of degree 3 with 2 generators>
+gap> CosetMonoid(SymmetricGroup(3));      
+<transformation monoid of degree 18 with 6 generators>
+gap> CosetMonoid(SymmetricGroup(4));
+<transformation monoid of degree 234 with 18 generators>
+
+# UnbindVariables
+gap> Unbind(S);
+gap> Unbind(f);
+gap> Unbind(gens);
+gap> Unbind(iter);
+gap> Unbind(r);
+gap> Unbind(s);
+gap> Unbind(x);
+
+#
+gap> SEMIGROUPS.StopTest();
+gap> STOP_TEST("Semigroups package: standard/acting.tst");


### PR DESCRIPTION
This is adds a function called "CosetMonoid", which takes as input a permutation group and returns a transformation monoid isomorphic to the coset monoid of the given group.

(The function is currently quite slow at dealing with even Sym(5) and doesn't currently work on Sym(1) as the AllSubgroups function doesn't seem to work on that group)