### PR TITLE
Replace some uses of IMMUTABLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 #### Copyright (C) 2011-20 James D. Mitchell et al.<br />Licensing information is available in the LICENSE file.
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.592893.svg)](https://doi.org/10.5281/zenodo.592893)
-[![Build Status](https://travis-ci.org/gap-packages/Semigroups.svg?branch=stable-3.1)](https://travis-ci.org/gap-packages/Semigroups)
+[![Build Status](https://travis-ci.com/gap-packages/Semigroups.svg?branch=stable-3.4)](https://travis-ci.com/gap-packages/Semigroups)
 
 ## Getting Semigroups
 

--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -22,7 +22,7 @@ if [ -d $LIBS_DIR ] && [ "$(ls -A $LIBS_DIR)" ]; then
   INSTALLED=`tr -d '\n' < $LIBS_DIR/.VERSION`
   echo -e "The installed version of libsemigroups is v$INSTALLED"
   LEAST=`echo -e "$VERS\n$INSTALLED" | sort -V | head -n1`
-  if ! [ "$VERS" == "$LEAST" ]; then
+  if [[ "$VERS" != "$LEAST" ]]; then
     echo -e "Error, the installed version of libsemigroups is too old"
     exit 3
   fi

--- a/src/converter.cc
+++ b/src/converter.cc
@@ -64,7 +64,7 @@ Obj BoolMatConverter::unconvert(Element const* x) const {
   SET_LEN_PLIST(o, n);
 
   for (size_t i = 0; i < n; i++) {
-    Obj blist = NewBag(T_BLIST + IMMUTABLE, SIZE_PLEN_BLIST(n));
+    Obj blist = NewBag(T_BLIST, SIZE_PLEN_BLIST(n));
     SET_LEN_BLIST(blist, n);
     for (size_t j = 0; j < n; j++) {
       if ((*xx)[i * n + j]) {
@@ -75,6 +75,7 @@ Obj BoolMatConverter::unconvert(Element const* x) const {
 #endif
       }
     }
+    MakeImmutable(blist);
     SET_ELM_PLIST(o, i + 1, blist);
     CHANGED_BAG(o);
   }

--- a/src/semigrp.cc
+++ b/src/semigrp.cc
@@ -1126,7 +1126,7 @@ gap_int_t EN_SEMI_IDEMS_SUBSET(Obj self, gap_semigroup_t so, gap_list_t list) {
 
   en_semi_obj_t es = semi_obj_get_en_semi(so);
 
-  gap_list_t out = NEW_PLIST_IMM(T_PLIST_CYC, 0);
+  gap_list_t out = NEW_PLIST(T_PLIST_CYC, 0);
   // IMMUTABLE since it should not be altered on the GAP level
   SET_LEN_PLIST(out, 0);
   size_t len = 0;
@@ -1166,8 +1166,9 @@ gap_int_t EN_SEMI_IDEMS_SUBSET(Obj self, gap_semigroup_t so, gap_list_t list) {
   }
   SEMIGROUPS_ASSERT(len == (size_t) LEN_PLIST(out));
   if (len == 0) {
-    RetypeBag(out, T_PLIST_EMPTY + IMMUTABLE);
+    RetypeBag(out, T_PLIST_EMPTY);
   }
+  MakeImmutable(out);
   return out;
 }
 


### PR DESCRIPTION
Use of IMMUTABLE is an internal kernel detail, and there are some plans
to eventually move it from a bit in the TNUM to a separate object flag
at some point.