### PR TITLE
ci: add more actions (working)

### DIFF
--- a/.github/workflows/GAP.yml
+++ b/.github/workflows/GAP.yml
@@ -1,0 +1,28 @@
+name: "GAP tests"
+
+# Trigger the workflow on push or pull request
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    name: "GAP ${{ matrix.gap-branch }} on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        gap-branch:
+          - master
+          - stable-4.11
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gap-actions/setup-gap-for-packages@v1
+        with:
+          GAP_PKGS_TO_BUILD: "digraphs genss io orb images datastructures profiling"
+          GAPBRANCH: ${{ matrix.gap-branch }}
+      - uses: gap-actions/run-test-for-packages@v1
+        with:
+          GAP_TESTFILE: "tst/teststandard.g"


### PR DESCRIPTION
I've got a working version of #717, because my PRs there were merged. You can either merge this PR, or close it and take the code for use in #717. I just thought it would be easiest for you to get the code this way.

It wasn't completely simple to add GAP `stable-4.10` support (some of the packages contained in `bootstrap-pkg-full` for GAP 4.10 are too old for this package, so would have to be manually replaced), so I haven't done that.

All this does is run `tst/teststandard.g`, which runs `SemigroupsTestStandard()`. If you want it to do more (e.g. compile the manual, test the manual examples, run `SemigroupsTestInstall`, run extreme tests) then I recommend you make a file `tst/testall.g` analogous to the one in the Digraphs package to do what you want.