### PR TITLE
Strong Semilattice of Semigroups

### DIFF
--- a/doc/semicons.xml
+++ b/doc/semicons.xml
@@ -308,16 +308,18 @@ true]]></Example>
     </Returns>
     <Description>
       If <A>D</A> is a digraph, <A>L</A> is a list of semigroups, and <A>H</A>
-      is a list of lists of maps, then this function performs argument checks
-      and returns an <C>IsStrongSemilatticeOfSemigroups</C> object. The format
+      is a list of lists of maps, then this function returns a corresponding
+      <C>IsStrongSemilatticeOfSemigroups</C> object. The format
       of the arguments is not required to be exactly analogous to Howie's
       description above, but consistency amongst the arguments is required:
       <List>
         <Item>
           <A>D</A> must be a digraph whose
-          <C>DigraphReflexiveTransitiveClosure</C> is a meet-semilattice. For
+          <Ref Oper="DigraphReflexiveTransitiveClosure" BookName="Digraphs"/>
+          is a meet-semilattice. For
           example, <C>Digraph([2, 3], [4], [4], []])</C> is valid and produces
           a semilattice where the meet of <C>2</C> and <C>3</C> is <C>1</C>.
+          See <Ref Prop="IsMeetSemilatticeDigraph" BookName="Digraphs"/>.
         </Item>
         <Item>
           <A>L</A> must contain as many semigroups as there are vertices in
@@ -330,13 +332,13 @@ true]]></Example>
           <A>D</A> has out-edges. The entries of each sublist must be the
           corresponding homomorphisms: for example, if <A>D</A> is entered as
           above, then <C>H[1][2]</C> must be the homomorphism <M>f_31</M>, i.e.
-          <C>H[1][2]</C> is an <C>IsMapping</C> object whose domain is a supset
-          of <C>L[3]</C> and whose range is a subset of <C>L[1]</C>.
+          <C>H[1][2]</C> is an <C>IsMapping</C> object whose domain is a
+          superset of <C>L[3]</C> and whose range is a subset of <C>L[1]</C>.
         </Item>
       </List>
       Note that in the example above, the edge <M>1 \rightarrow 4</M> is not
       entered as part of the argument <A>D</A>, but it is still an edge in the
-      reflexive transitive closure of <A>D</A>. When greating the object, &GAP;
+      reflexive transitive closure of <A>D</A>. When creating the object, &GAP;
       creates the homomorphism <M>f_{41}</M> by composing the mappings along
       paths that lead from 4 to 1, and checks that composing along all possible
       paths produces the same result.
@@ -351,7 +353,7 @@ true]]></Example>
       <K>true</K> or <K>false</K>.
     </Returns>
     <Description>
-      Every SSS in &GAP; belongs to the category
+      Every Strong Semilattice of Semigroups in &GAP; belongs to the category
       <C>IsStrongSemilatticeOfSemigroups</C>. Basic operations in this category
       allow the user to recover the three essential elements of an SSS object:
       <Ref Attr="SemilatticeOfStrongSemilatticeOfSemigroups"/>,
@@ -361,8 +363,6 @@ true]]></Example>
   </ManSection>
 <#/GAPDoc>
 
-<!-- TODO link to digraphs refs -->
-
 <#GAPDoc Label="SemilatticeOfStrongSemilatticeOfSemigroups">
   <ManSection>
     <Attr Name="SemilatticeOfStrongSemilatticeOfSemigroups" Arg="SSS"/>
@@ -371,10 +371,24 @@ true]]></Example>
     </Returns>
     <Description>
       If <A>SSS</A> is a strong semilattice of semigroups, this function
-      returns the underlying semilattice structure in the form of a Digraphs
-      object. Note that this may not be equal to the digraph passed as input
-      when the SSS was created: it is equal to reflexive transitive closure
-      of the input.
+      returns the underlying semilattice structure as a digraph.
+      Note that this may not be equal to the digraph passed as input
+      when <A>SSS</A> was created: rather, it is the reflexive transitive
+      closure of the input digraph.
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="UnderlyingSemilatticeOfSemigroups">
+  <ManSection>
+    <Oper Name="UnderlyingSemilatticeOfSemigroups" Arg="el"/>
+    <Returns>
+      A strong semilattice of semigroups.
+    </Returns>
+    <Description>
+      If <A>el</A> is an element of a strong semilattice of semigroups (i.e.
+      is in the category <Ref Filt="IsSSSE"/>), then this operation returns
+      the strong semilattice of semigroups object that <A>el</A> belongs to.
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -427,21 +441,17 @@ true]]></Example>
   <ManSection>
     <Oper Name="SSSE" Arg="SSS, n, x"/>
     <Returns>
-      The element of the strong semilattice of semigroups <A>SSS</A> which lies
-      in semigroup number <A>n</A> and which corresponds to the element
-      <A>x</A>.
+      An element of a strong semilattice of semigroups.
     </Returns>
     <Description>
-      If <A>n</A> is a positive integer no greater than the number of vertices
-      in the underlying semilattice of <A>SSS</A>, and if <A>x</A> is an
+      If <A>n</A> is a vertex of the underlying semilattice of the strong
+      semilattice of semigroups <A>SSS</A>, and if <A>x</A> is an
       element of the <A>n</A>th semigroup of <A>SSS</A>, then this function
-      returns an <Ref Attr="IsSSSE"/> object which is an element of <A>SSS</A>.
-      SSSEs of the same SSS can be compared and multiplied.
+      returns the element of <A>SSS</A> which lies in semigroup number <A>n</A>
+      and which corresponds to the element <A>x</A> in that semigroup.
       <P/>
-
-      If <C>el</C> is an SSSE, then the underlying strong semilattice of
-      semigroups object it belongs to can be recovered by calling
-      <C>StrongSemilatticeOfSemigroups(el)</C>.
+      This function returns an <Ref Filt="IsSSSE"/> object. SSSEs from the
+      same strong semilattice of semigroups can be compared and multiplied.
       <Example><![CDATA[
 gap> D := Digraph([[2, 3], [4], [4], []]);;
 gap> S4 := FullTransformationMonoid(2);;

--- a/doc/semicons.xml
+++ b/doc/semicons.xml
@@ -299,3 +299,174 @@ true]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="StrongSemilatticeOfSemigroups">
+  <ManSection>
+    <Oper Name="StrongSemilatticeOfSemigroups" Arg="D, L, H"/>
+    <Returns>
+      A strong semilattice of semigroups.
+    </Returns>
+    <Description>
+      If <A>D</A> is a digraph, <A>L</A> is a list of semigroups, and <A>H</A>
+      is a list of lists of maps, then this function performs argument checks
+      and returns an <C>IsStrongSemilatticeOfSemigroups</C> object. The format
+      of the arguments is not required to be exactly analogous to Howie's
+      description above, but consistency amongst the arguments is required:
+      <List>
+        <Item>
+          <A>D</A> must be a digraph whose
+          <C>DigraphReflexiveTransitiveClosure</C> is a meet-semilattice. For
+          example, <C>Digraph([2, 3], [4], [4], []])</C> is valid and produces
+          a semilattice where the meet of <C>2</C> and <C>3</C> is <C>1</C>.
+        </Item>
+        <Item>
+          <A>L</A> must contain as many semigroups as there are vertices in
+          <A>D</A>.
+        </Item>
+        <Item>
+          <A>H</A> must be a list with as many elements as there are vertices
+          in <A>D</A>. Each element of <A>H</A> must itself be a (possibly
+          empty) list with as many entries as the corresponding vertex of
+          <A>D</A> has out-edges. The entries of each sublist must be the
+          corresponding homomorphisms: for example, if <A>D</A> is entered as
+          above, then <C>H[1][2]</C> must be the homomorphism <M>f_31</M>, i.e.
+          <C>H[1][2]</C> is an <C>IsMapping</C> object whose domain is a supset
+          of <C>L[3]</C> and whose range is a subset of <C>L[1]</C>.
+        </Item>
+      </List>
+      Note that in the example above, the edge <M>1 \rightarrow 4</M> is not
+      entered as part of the argument <A>D</A>, but it is still an edge in the
+      reflexive transitive closure of <A>D</A>. When greating the object, &GAP;
+      creates the homomorphism <M>f_{41}</M> by composing the mappings along
+      paths that lead from 4 to 1, and checks that composing along all possible
+      paths produces the same result.
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="IsStrongSemilatticeOfSemigroups">
+  <ManSection>
+    <Filt Name="IsStrongSemilatticeOfSemigroups" Arg="obj"/>
+    <Returns>
+      <K>true</K> or <K>false</K>.
+    </Returns>
+    <Description>
+      Every SSS in &GAP; belongs to the category
+      <C>IsStrongSemilatticeOfSemigroups</C>. Basic operations in this category
+      allow the user to recover the three essential elements of an SSS object:
+      <Ref Attr="SemilatticeOfStrongSemilatticeOfSemigroups"/>,
+      <Ref Attr="SemigroupsOfStrongSemilatticeOfSemigroups"/>, and
+      <Ref Attr="HomomorphismsOfStrongSemilatticeOfSemigroups"/>.
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<!-- TODO link to digraphs refs -->
+
+<#GAPDoc Label="SemilatticeOfStrongSemilatticeOfSemigroups">
+  <ManSection>
+    <Attr Name="SemilatticeOfStrongSemilatticeOfSemigroups" Arg="SSS"/>
+    <Returns>
+      A meet-semilattice digraph.
+    </Returns>
+    <Description>
+      If <A>SSS</A> is a strong semilattice of semigroups, this function
+      returns the underlying semilattice structure in the form of a Digraphs
+      object. Note that this may not be equal to the digraph passed as input
+      when the SSS was created: it is equal to reflexive transitive closure
+      of the input.
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="SemigroupsOfStrongSemilatticeOfSemigroups">
+  <ManSection>
+    <Attr Name="SemigroupsOfStrongSemilatticeOfSemigroups" Arg="SSS"/>
+    <Returns>
+      A list of semigroups.
+    </Returns>
+    <Description>
+      If <A>SSS</A> is a strong semilattice of semigroups, this function
+      returns the list of semigroups that make up <A>SSS</A>. The position of
+      a semigroup in the list corresponds to the node of the semilattice where
+      that semigroup lies.
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="HomomorphismsOfStrongSemilatticeOfSemigroups">
+  <ManSection>
+    <Attr Name="HomomorphismsOfStrongSemilatticeOfSemigroups" Arg="SSS"/>
+    <Returns>
+      A list of lists of mappings.
+    </Returns>
+    <Description>
+      If <A>SSS</A> is a strong semilattice of <M>n</M> semigroups, this
+      function returns an <M>n \times n</M> list where the <M>(i, j)</M>th
+      entry of the list is the homomorphism <M>f_{ji}</M>, provided
+      <M>i \leq j</M> in the semilattice. If this last condition is not true,
+      then the entry is <K>fail</K>.
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="IsSSSE">
+  <ManSection>
+    <Filt Name="IsSSSE" Arg="obj"/>
+    <Returns>
+      <K>true</K> or <K>false</K>.
+    </Returns>
+    <Description>
+      All elements of an SSS belong in the category <C>IsSSSE</C> (for "Strong
+      Semilattice of Semigroups Element").
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="SSSE">
+  <ManSection>
+    <Oper Name="SSSE" Arg="SSS, n, x"/>
+    <Returns>
+      The element of the strong semilattice of semigroups <A>SSS</A> which lies
+      in semigroup number <A>n</A> and which corresponds to the element
+      <A>x</A>.
+    </Returns>
+    <Description>
+      If <A>n</A> is a positive integer no greater than the number of vertices
+      in the underlying semilattice of <A>SSS</A>, and if <A>x</A> is an
+      element of the <A>n</A>th semigroup of <A>SSS</A>, then this function
+      returns an <Ref Attr="IsSSSE"/> object which is an element of <A>SSS</A>.
+      SSSEs of the same SSS can be compared and multiplied.
+      <P/>
+
+      If <C>el</C> is an SSSE, then the underlying strong semilattice of
+      semigroups object it belongs to can be recovered by calling
+      <C>StrongSemilatticeOfSemigroups(el)</C>.
+      <Example><![CDATA[
+gap> D := Digraph([[2, 3], [4], [4], []]);;
+gap> S4 := FullTransformationMonoid(2);;
+gap> S3 := FullTransformationMonoid(3);;
+gap> pairs := [[Transformation([1, 2]), Transformation([2, 1])]];;
+gap> cong := SemigroupCongruence(S4, pairs);;
+gap> S2 := S4 / cong;;
+gap> S1 := TrivialSemigroup();;
+gap> L := [S1, S2, S3, S4];;
+gap> idfn := function(t) return IdentityTransformation; end;;
+gap> f21 := MappingByFunction(S2, S1, idfn);;
+gap> f31 := MappingByFunction(S3, S1, idfn);;
+gap> f42 := HomomorphismQuotientSemigroup(cong);;
+gap> f43 := IdentityMapping(S4);;
+gap> H := [[f21, f31], [f42], [f43], []];;
+gap> SSS := StrongSemilatticeOfSemigroups(D, L, H);
+<strong semilattice of 4 semigroups>
+gap> Size(SSS);
+34
+gap> x := SSSE(SSS, 3, Elements(S3)[10]);
+SSSE(3, Transformation( [ 2, 1, 1 ] ))
+gap> y := SSSE(SSS, 4, Elements(S4)[1]);
+SSSE(4, Transformation( [ 1, 1 ] ))
+gap> x * y;
+SSSE(3, Transformation( [ 1, 1, 1 ] ))]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>

--- a/doc/z-chap09.xml
+++ b/doc/z-chap09.xml
@@ -32,4 +32,37 @@
   <!--**********************************************************************-->
   <!--**********************************************************************-->
 
+  <Section Label = "Strong semilattices of semigroups">
+    <Heading>
+      Strong semilattices of semigroups
+    </Heading>
+
+    In this section, we describe how &Semigroups; can be used to create and
+    manipulate strong semilattices of semigroups (SSSs).
+    Strong semilattices of semigroups are described, for example, in Section
+    4.1 of <Cite Key = "Howie1995aa"/>.
+    They consist of a meet-semilattice <M>Y</M> along with a collection of
+    semigroups <M>S_a</M> for each <M>a</M> in <M>Y</M>, and a collection of
+    homomorphisms <M>f_{ab} : S_a \rightarrow S_b</M> for each <M>a</M> and
+    <M>b</M> in <M>Y</M> such that <M>a \geq b</M>.
+    <P/>
+
+    The product of two elements <M>x \in S_a, y \in S_b</M> is defined to lie
+    in the semigroup <M>S_c</M>, corresponding to the meet <M>c</M> of
+    <M>a, b \in Y</M>. The exact element of <M>S_c</M> equal to the product
+    is obtained using the homomorphisms of the SSS: <M>xy = (x f_{ac})
+    (y f_{bc})</M>.
+
+    <#Include Label = "StrongSemilatticeOfSemigroups">
+    <#Include Label = "SSSE">
+    <#Include Label = "IsSSSE">
+    <#Include Label = "IsStrongSemilatticeOfSemigroups">
+    <#Include Label = "SemilatticeOfStrongSemilatticeOfSemigroups">
+    <#Include Label = "SemigroupsOfStrongSemilatticeOfSemigroups">
+    <#Include Label = "HomomorphismsOfStrongSemilatticeOfSemigroups">
+  </Section>
+
+  <!--**********************************************************************-->
+  <!--**********************************************************************-->
+
 </Chapter>

--- a/doc/z-chap09.xml
+++ b/doc/z-chap09.xml
@@ -57,6 +57,7 @@
     <#Include Label = "SSSE">
     <#Include Label = "IsSSSE">
     <#Include Label = "IsStrongSemilatticeOfSemigroups">
+    <#Include Label = "StrongSemilatticeOfSemigroups">
     <#Include Label = "SemilatticeOfStrongSemilatticeOfSemigroups">
     <#Include Label = "SemigroupsOfStrongSemilatticeOfSemigroups">
     <#Include Label = "HomomorphismsOfStrongSemilatticeOfSemigroups">

--- a/doc/z-chap09.xml
+++ b/doc/z-chap09.xml
@@ -57,7 +57,6 @@
     <#Include Label = "SSSE">
     <#Include Label = "IsSSSE">
     <#Include Label = "IsStrongSemilatticeOfSemigroups">
-    <#Include Label = "StrongSemilatticeOfSemigroups">
     <#Include Label = "SemilatticeOfStrongSemilatticeOfSemigroups">
     <#Include Label = "SemigroupsOfStrongSemilatticeOfSemigroups">
     <#Include Label = "HomomorphismsOfStrongSemilatticeOfSemigroups">

--- a/gap/main/fropin.gi
+++ b/gap/main/fropin.gi
@@ -60,6 +60,9 @@ InstallTrueMethod(IsGeneratorsOfEnumerableSemigroup,
 InstallTrueMethod(IsGeneratorsOfEnumerableSemigroup,
                   IsMcAlisterTripleSemigroupElementCollection);
 
+InstallTrueMethod(IsGeneratorsOfEnumerableSemigroup,
+                  IsSSSECollection);
+
 InstallMethod(IsGeneratorsOfEnumerableSemigroup,
 "for a matrix over semiring collection", [IsMatrixOverSemiringCollection],
 IsGeneratorsOfSemigroup);

--- a/gap/semigroups/semicons.gd
+++ b/gap/semigroups/semicons.gd
@@ -20,3 +20,31 @@ DeclareGlobalFunction("LeftZeroSemigroup");
 DeclareGlobalFunction("RightZeroSemigroup");
 DeclareConstructor("BrandtSemigroupCons", [IsSemigroup, IsGroup, IsPosInt]);
 DeclareGlobalFunction("BrandtSemigroup");
+
+DeclareCategory("IsSSSE", IsAssociativeElement);
+DeclareCategoryCollections("IsSSSE");
+
+# Objects in IsSSERep have 3 slots:
+# 1) the strong semilattice of semigroup of which this is an element;
+# 2) the node of the digraph;
+# 3) the underlying semigroup element itself.
+DeclareRepresentation("IsSSSERep", IsSSSE and IsPositionalObjectRep, 2);
+
+DeclareOperation("StrongSemilatticeOfSemigroups", [IsDigraph, IsList, IsList]);
+DeclareOperation("StrongSemilatticeOfSemigroups", [IsSSSERep]);
+
+DeclareCategory("IsStrongSemilatticeOfSemigroups",
+                IsSemigroup and IsSSSECollection);
+DeclareAttribute("SemilatticeOfStrongSemilatticeOfSemigroups",
+                 IsStrongSemilatticeOfSemigroups);
+DeclareAttribute("SemigroupsOfStrongSemilatticeOfSemigroups",
+                 IsStrongSemilatticeOfSemigroups);
+DeclareAttribute("HomomorphismsOfStrongSemilatticeOfSemigroups",
+                 IsStrongSemilatticeOfSemigroups);
+DeclareAttribute("ElementTypeOfStrongSemilatticeOfSemigroups",
+                 IsStrongSemilatticeOfSemigroups);
+
+DeclareOperation("SSSE",
+                 [IsStrongSemilatticeOfSemigroups,
+                  IsPosInt,
+                  IsAssociativeElement]);

--- a/gap/semigroups/semicons.gd
+++ b/gap/semigroups/semicons.gd
@@ -26,9 +26,9 @@ DeclareCategoryCollections("IsSSSE");
 
 # Objects in IsSSERep have 3 slots:
 # 1) the strong semilattice of semigroup of which this is an element;
-# 2) the node of the digraph;
+# 2) the node of the digraph;
 # 3) the underlying semigroup element itself.
-DeclareRepresentation("IsSSSERep", IsSSSE and IsPositionalObjectRep, 2);
+DeclareRepresentation("IsSSSERep", IsSSSE and IsPositionalObjectRep, 3);
 
 DeclareOperation("StrongSemilatticeOfSemigroups", [IsDigraph, IsList, IsList]);
 DeclareOperation("UnderlyingSemilatticeOfSemigroups", [IsSSSERep]);

--- a/gap/semigroups/semicons.gd
+++ b/gap/semigroups/semicons.gd
@@ -31,7 +31,7 @@ DeclareCategoryCollections("IsSSSE");
 DeclareRepresentation("IsSSSERep", IsSSSE and IsPositionalObjectRep, 2);
 
 DeclareOperation("StrongSemilatticeOfSemigroups", [IsDigraph, IsList, IsList]);
-DeclareOperation("StrongSemilatticeOfSemigroups", [IsSSSERep]);
+DeclareOperation("UnderlyingSemilatticeOfSemigroups", [IsSSSERep]);
 
 DeclareCategory("IsStrongSemilatticeOfSemigroups",
                 IsSemigroup and IsSSSECollection);

--- a/gap/semigroups/semicons.gi
+++ b/gap/semigroups/semicons.gi
@@ -805,3 +805,213 @@ for _IsXSemigroup in ["IsTransformationSemigroup",
   end);
 od;
 Unbind(_IsXSemigroup);
+
+InstallMethod(StrongSemilatticeOfSemigroups,
+"for a digraph, a list, and a list",
+[IsDigraph, IsList, IsList],
+function(D, semigroups, homomorphisms)
+  local efam, etype, type, maps, n, rtclosure, path, len, tobecomposed, gens,
+  out, s, i, j, paths, firsthom;
+
+  #  TODO would it be advisable to ensure all the semigroups are distinct?
+  #  In the GAP sense of distinct, that is
+
+  if not IsMeetSemilatticeDigraph(DigraphReflexiveTransitiveClosure(D)) then
+    ErrorNoReturn("expected a digraph whose reflexive transitive closure ",
+                  "is a meet semilattice digraph as first argument");
+  fi;
+  for s in semigroups do
+    if not IsSemigroup(s) then
+      ErrorNoReturn("expected a list of semigroups as second argument");
+    fi;
+  od;
+  if DigraphNrVertices(D) <> Length(semigroups) then
+    ErrorNoReturn("the number of vertices of the first argumement D must ",
+                  "be equal to the length of the second argument semigroups");
+  elif DigraphNrVertices(D) <> Length(homomorphisms) then
+    ErrorNoReturn("where D is the first argument, expected a list of length ",
+                  "DigraphNrVertices(D) as third argument");
+  fi;
+  for i in [1 .. DigraphNrVertices(D)] do
+    if not IsList(homomorphisms[i]) then
+      ErrorNoReturn("expected a list of lists as third argument");
+    fi;
+    if Length(homomorphisms[i]) <> Length(OutNeighbours(D)[i]) then
+      ErrorNoReturn("where D and homomorphisms are the 1st and 3rd arguments ",
+                    "respectively, the length of homomorphisms[i] must be ",
+                    "equal to OutNeighbours(D)[i]");
+    fi;
+    for j in [1 .. Length(homomorphisms[i])] do
+      if not RespectsMultiplication(homomorphisms[i][j]) then
+        ErrorNoReturn("expected a list of lists of homomorphisms ",
+                      "as third argument. homomorphisms[", i,
+                      "][", j, "] is not a homomorphism");
+      fi;
+      if  (not IsSubset(Source(homomorphisms[i][j]),
+                        semigroups[OutNeighbours(D)[i][j]])) or
+          (not IsSubset(semigroups[i],
+                        Range(homomorphisms[i][j]))) then
+        ErrorNoReturn("expected homomorphism from ",
+                      OutNeighbours(D)[i][j],
+                      " to ",
+                      i,
+                      " to have correct source and range");
+      fi;
+    od;
+  od;
+
+  efam := NewFamily("StrongSemilatticeOfSemigroupsElementsFamily", IsSSSE);
+  etype := NewType(efam, IsSSSERep);
+
+  type := NewType(CollectionsFamily(efam),
+                  IsStrongSemilatticeOfSemigroups
+                    and IsComponentObjectRep
+                    and IsAttributeStoringRep);
+
+  # the next section converts the list of homomorphisms into a matrix,
+  # composing when necessary.
+  maps := [];
+  n := Length(semigroups);
+  rtclosure := DigraphReflexiveTransitiveClosure(D);
+  for i in [1 .. n] do
+    Add(maps, []);
+    for j in [1 .. n] do
+      if i = j then
+        # First check that if a homomorphism from i to i was defined, it
+        # is the identity
+        if IsDigraphEdge(D, [i, i]) then
+          if homomorphisms[i][Position(OutNeighboursOfVertex(D, i), i)]
+              <> IdentityMapping(semigroups[i]) then
+             ErrorNoReturn("Expected homomorphism from ",
+                           i, " to ", i,
+                           " to be the identity");
+           fi;
+        fi;
+        Add(maps[i], IdentityMapping(semigroups[i]));
+      elif IsDigraphEdge(rtclosure, [i, j]) then
+        paths        := IteratorOfPaths(D, i, j);
+        path         := NextIterator(paths);
+        len          := Length(path[2]);
+        tobecomposed := List([1 .. len],
+                              x -> homomorphisms[path[1][x]][path[2][x]]);
+        firsthom     := CompositionMapping(tobecomposed);
+
+        # now check the first composition is the same as the composition along
+        # all other paths from i to j
+        while not IsDoneIterator(paths) do
+          path         := NextIterator(paths);
+          len          := Length(path[2]);
+          tobecomposed := List([1 .. len],
+                                x -> homomorphisms[path[1][x]][path[2][x]]);
+          if CompositionMapping(tobecomposed) <> firsthom then
+            ErrorNoReturn("Composing homomorphisms along different paths from ",
+                          i,
+                          " to ",
+                          j,
+                          " does not produce the same result. The ",
+                          "homomorphisms must commute");
+          fi;
+        od;
+        # If no errors so far, then all paths commute and we can add the comp.
+        Add(maps[i], firsthom);
+        # NB. perhaps a dynamic programming approach would be more
+        # efficient here.
+        # for some larger digraphs, the current method might compute some
+        # compositions of homomorphisms several times.
+        # This should be a FIXME.
+      else
+        Add(maps[i], fail);
+        # is fail a reasonable thing to add here?
+      fi;
+    od;
+  od;
+
+  out := rec();
+
+  gens := [];
+  for i in [1 .. Length(semigroups)] do
+    Append(gens, List(GeneratorsOfSemigroup(semigroups[i]),
+                      x -> Objectify(etype, [out, i, x])));
+  od;
+
+  ObjectifyWithAttributes(out,
+                          type,
+                          SemilatticeOfStrongSemilatticeOfSemigroups,
+                          rtclosure,
+                          SemigroupsOfStrongSemilatticeOfSemigroups,
+                          semigroups,
+                          HomomorphismsOfStrongSemilatticeOfSemigroups,
+                          maps,
+                          ElementTypeOfStrongSemilatticeOfSemigroups,
+                          etype,
+                          GeneratorsOfMagma,
+                          gens);
+  return out;
+end);
+
+InstallMethod(Size, "for a strong semilattice of semigroups",
+[IsStrongSemilatticeOfSemigroups],
+function(S)
+  return Sum(SemigroupsOfStrongSemilatticeOfSemigroups(S), Size);
+end);
+
+InstallMethod(ViewString, "for a strong semilattice of semigroups",
+[IsStrongSemilatticeOfSemigroups],
+function(S)
+  local size;
+  size := Size(SemigroupsOfStrongSemilatticeOfSemigroups(S));
+  return Concatenation("<strong semilattice of ",
+                       String(size),
+                       " semigroups>");
+end);
+
+InstallMethod(SSSE,
+"for a strong semilattice of semigroups, a pos int, and an associative elt",
+[IsStrongSemilatticeOfSemigroups, IsPosInt, IsAssociativeElement],
+function(S, n, x)
+  if n > Size(SemigroupsOfStrongSemilatticeOfSemigroups(S)) then
+    ErrorNoReturn("expected second argument to be an integer between 1 and ",
+                  "the size of the semilattice, i.e. ",
+                  Size(SemigroupsOfStrongSemilatticeOfSemigroups(S)));
+  elif not x in SemigroupsOfStrongSemilatticeOfSemigroups(S)[n] then
+    ErrorNoReturn("where S, n and x are the 1st, 2nd and 3rd arguments ",
+                  "respectively, expected x to be an element of ",
+                  "SemigroupsOfStrongSemilatticeOfSemigroups(S)[n]");
+  fi;
+  return Objectify(ElementTypeOfStrongSemilatticeOfSemigroups(S), [S, n, x]);
+end);
+
+InstallMethod(\=, "for SSSEs", IsIdenticalObj,
+[IsSSSERep, IsSSSERep],
+function(x, y)
+  return x![1] = y![1] and x![2] = y![2] and x![3] = y![3];
+end);
+
+InstallMethod(\<, "for SSSEs", IsIdenticalObj, [IsSSSERep, IsSSSERep],
+function(x, y)
+  return (x![2] < y![2]) or (x![2] = y![2] and x![3] < y![3]);
+end);
+
+InstallMethod(\*, "for SSSEs", IsIdenticalObj,
+[IsSSSERep, IsSSSERep],
+function(x, y)
+  local D, meet, maps;
+  D    := SemilatticeOfStrongSemilatticeOfSemigroups(x![1]);
+  meet := PartialOrderDigraphMeetOfVertices(D, x![2], y![2]);
+  maps := HomomorphismsOfStrongSemilatticeOfSemigroups(x![1]);
+  return SSSE(x![1],
+              meet,
+              (x![3] ^ (maps[meet][x![2]])) * (y![3] ^ (maps[meet][y![2]])));
+end);
+
+InstallMethod(ViewString, "for a SSSE",
+[IsSSSERep],
+function(x)
+  return Concatenation("SSSE(", ViewString(x![2]), ", ", ViewString(x![3]), ")");
+end);
+
+InstallMethod(StrongSemilatticeOfSemigroups, "for a SSSE rep",
+[IsSSSERep],
+function(x)
+  return x![1];
+end);

--- a/gap/semigroups/semicons.gi
+++ b/gap/semigroups/semicons.gi
@@ -823,8 +823,8 @@ function(D, semigroups, homomorphisms)
     fi;
   od;
   if DigraphNrVertices(D) <> Length(semigroups) then
-    ErrorNoReturn("the number of vertices of the first argumement D must ",
-                  "be equal to the length of the second argument semigroups");
+    ErrorNoReturn("the number of vertices of the first argument <D> must ",
+                  "be equal to the length of the second argument");
   elif DigraphNrVertices(D) <> Length(homomorphisms) then
     ErrorNoReturn("where D is the first argument, expected a list of length ",
                   "DigraphNrVertices(D) as third argument");
@@ -841,7 +841,7 @@ function(D, semigroups, homomorphisms)
     for j in [1 .. Length(homomorphisms[i])] do
       if not RespectsMultiplication(homomorphisms[i][j]) then
         ErrorNoReturn("expected a list of lists of homomorphisms ",
-                      "as third argument. homomorphisms[", i,
+                      "as third argument, homomorphisms[", i,
                       "][", j, "] is not a homomorphism");
       fi;
       if  (not IsSubset(Source(homomorphisms[i][j]),

--- a/gap/semigroups/semicons.gi
+++ b/gap/semigroups/semicons.gi
@@ -813,9 +813,6 @@ function(D, semigroups, homomorphisms)
   local efam, etype, type, maps, n, rtclosure, path, len, tobecomposed, gens,
   out, s, i, j, paths, firsthom;
 
-  #  TODO would it be advisable to ensure all the semigroups are distinct?
-  #  In the GAP sense of distinct, that is
-
   if not IsMeetSemilatticeDigraph(DigraphReflexiveTransitiveClosure(D)) then
     ErrorNoReturn("expected a digraph whose reflexive transitive closure ",
                   "is a meet semilattice digraph as first argument");
@@ -914,14 +911,18 @@ function(D, semigroups, homomorphisms)
         od;
         # If no errors so far, then all paths commute and we can add the comp.
         Add(maps[i], firsthom);
-        # NB. perhaps a dynamic programming approach would be more
-        # efficient here.
-        # for some larger digraphs, the current method might compute some
+        # FIXME for larger digraphs, the current method will compute some
         # compositions of homomorphisms several times.
-        # This should be a FIXME.
+        # For example, take Digraph([[], [1], [1], [2, 3], [4]]). It defines a
+        # meet-semilattice and the SSS initialisation will check that composing
+        # the homomorphisms 1->3->4 and 1->2->4 give the same result. Later on
+        # in the initialisation, it will also check equivalence of the paths
+        # 1->2->4->5 and 1->3->4->5, but will not be re-using previously
+        # computed information on what the composition 1->3->4 equals, say.
+        # Saving the homomorphsisms already computed using some sort of dynamic
+        # programming approach may improve the speed (at the cost of memory).
       else
         Add(maps[i], fail);
-        # is fail a reasonable thing to add here?
       fi;
     od;
   od;
@@ -1010,7 +1011,7 @@ function(x)
   return Concatenation("SSSE(", ViewString(x![2]), ", ", ViewString(x![3]), ")");
 end);
 
-InstallMethod(StrongSemilatticeOfSemigroups, "for a SSSE rep",
+InstallMethod(UnderlyingSemilatticeOfSemigroups, "for a SSSE rep",
 [IsSSSERep],
 function(x)
   return x![1];

--- a/tst/standard/semicons.tst
+++ b/tst/standard/semicons.tst
@@ -1048,7 +1048,7 @@ false
 gap> SSSE(S, 2, Transformation([2, 1])) * SSSE(S, 3, Transformation([1, 1]))
 >    = SSSE(S, 1, Transformation([2, 2]));
 true
-gap> S = StrongSemilatticeOfSemigroups(SSSE(S, 2, Transformation([2, 1])));
+gap> S = UnderlyingSemilatticeOfSemigroups(SSSE(S, 2, Transformation([2, 1])));
 true
 
 # constructions: strong semilattices of semigroups: full worked example (SLOW!)

--- a/tst/standard/semicons.tst
+++ b/tst/standard/semicons.tst
@@ -960,8 +960,8 @@ gap> D := Digraph([[2], []]);;
 gap> StrongSemilatticeOfSemigroups(D, [S1, 1], [[id], []]);
 Error, expected a list of semigroups as second argument
 gap> StrongSemilatticeOfSemigroups(D, [S1, S1, S1], [[id], []]);
-Error, the number of vertices of the first argumement D must be equal to the l\
-ength of the second argument semigroups
+Error, the number of vertices of the first argument <D> must be equal to the l\
+ength of the second argument
 gap> StrongSemilatticeOfSemigroups(D, [S1, S1], [[id], [], []]);
 Error, where D is the first argument, expected a list of length DigraphNrVerti\
 ces(D) as third argument
@@ -975,7 +975,7 @@ gap> m1 := MappingByFunction(S2, S2, function(x)
 >                                      return Transformation([2, 1]);
 >                                    end);;
 gap> StrongSemilatticeOfSemigroups(D, [S2, S2], [[m1], []]);
-Error, expected a list of lists of homomorphisms as third argument. homomorphi\
+Error, expected a list of lists of homomorphisms as third argument, homomorphi\
 sms[1][1] is not a homomorphism
 gap> StrongSemilatticeOfSemigroups(D, [S1, S2], [[id], []]);
 Error, expected homomorphism from 2 to 1 to have correct source and range

--- a/tst/standard/semicons.tst
+++ b/tst/standard/semicons.tst
@@ -949,8 +949,215 @@ gap> S := BrandtSemigroup(IsIntegerMatrixSemigroup, DihedralGroup(4), 3);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `BrandtSemigroupCons' on 3 arguments
 
+# constructions: strong semilattices of semigroups: trivial argument checks
+gap> D := CompleteDigraph(2);;
+gap> S1 := TrivialSemigroup();;
+gap> id := IdentityMapping(S1);;
+gap> StrongSemilatticeOfSemigroups(D, [S1, S1], [[id, id], [id, id]]);
+Error, expected a digraph whose reflexive transitive closure is a meet semilat\
+tice digraph as first argument
+gap> D := Digraph([[2], []]);;
+gap> StrongSemilatticeOfSemigroups(D, [S1, 1], [[id], []]);
+Error, expected a list of semigroups as second argument
+gap> StrongSemilatticeOfSemigroups(D, [S1, S1, S1], [[id], []]);
+Error, the number of vertices of the first argumement D must be equal to the l\
+ength of the second argument semigroups
+gap> StrongSemilatticeOfSemigroups(D, [S1, S1], [[id], [], []]);
+Error, where D is the first argument, expected a list of length DigraphNrVerti\
+ces(D) as third argument
+gap> StrongSemilatticeOfSemigroups(D, [S1, S1], [1, []]);
+Error, expected a list of lists as third argument
+gap> StrongSemilatticeOfSemigroups(D, [S1, S1], [[id, id], []]);
+Error, where D and homomorphisms are the 1st and 3rd arguments respectively, t\
+he length of homomorphisms[i] must be equal to OutNeighbours(D)[i]
+gap> S2 := FullTransformationMonoid(2);;
+gap> m1 := MappingByFunction(S2, S2, function(x)
+>                                      return Transformation([2, 1]);
+>                                    end);;
+gap> StrongSemilatticeOfSemigroups(D, [S2, S2], [[m1], []]);
+Error, expected a list of lists of homomorphisms as third argument. homomorphi\
+sms[1][1] is not a homomorphism
+gap> StrongSemilatticeOfSemigroups(D, [S1, S2], [[id], []]);
+Error, expected homomorphism from 2 to 1 to have correct source and range
+gap> StrongSemilatticeOfSemigroups(D, [S2, S1], [[id], []]);
+<strong semilattice of 2 semigroups>
+gap> id := IdentityMapping(S2);;
+gap> StrongSemilatticeOfSemigroups(D, [S2, S1], [[id], []]);
+<strong semilattice of 2 semigroups>
+
+# constructions: strong semilattices of semigroups: homomorphism checks
+gap> D := Digraph([[2, 3], [4], [4], []]);;
+gap> S1 := FullTransformationMonoid(2);;
+gap> id := IdentityMapping(S1);;
+gap> m1 := MappingByFunction(S1, S1, function(x)
+>                                      return Transformation([1, 1]);
+>                                    end);;
+gap> m2 := MappingByFunction(S1, S1, function(x)
+>                                      return Transformation([2, 2]);
+>                                    end);;
+gap> L := [S1, S1, S1, S1];;
+gap> H := [[m1, m2], [id], [id], []];;
+gap> StrongSemilatticeOfSemigroups(D, L, H);
+Error, Composing homomorphisms along different paths from 1 to 
+4 does not produce the same result. The homomorphisms must commute
+gap> D := Digraph([[2, 3], [4], [4], [4]]);;
+gap> H := [[id, id], [id], [id], [m1]];;
+gap> StrongSemilatticeOfSemigroups(D, L, H);
+Error, Expected homomorphism from 4 to 4 to be the identity
+
+# constructions: strong semilattices of semigroups: valid example
+gap> D := Digraph([[2, 3], [2], []]);;
+gap> S1 := FullTransformationMonoid(2);;
+gap> id := IdentityMapping(S1);;
+gap> m1 := MappingByFunction(S1, S1, function(x)
+>                                      return Transformation([1, 1]);
+>                                    end);;
+gap> m2 := MappingByFunction(S1, S1, function(x)
+>                                      return Transformation([2, 2]);
+>                                    end);;
+gap> L := [S1, S1, S1];;
+gap> H := [[m1, m2], [id], []];;
+gap> StrongSemilatticeOfSemigroups(D, L, H);
+<strong semilattice of 3 semigroups>
+gap> Size(last);
+12
+
+# constructions: strong semilattices of semigroups: SSSEs
+gap> D := Digraph([[2, 3], [2], []]);;
+gap> S1 := FullTransformationMonoid(2);;
+gap> id := IdentityMapping(S1);;
+gap> m1 := MappingByFunction(S1, S1, function(x)
+>                                      return Transformation([1, 1]);
+>                                    end);;
+gap> m2 := MappingByFunction(S1, S1, function(x)
+>                                      return Transformation([2, 2]);
+>                                    end);;
+gap> L := [S1, S1, S1];;
+gap> H := [[m1, m2], [id], []];;
+gap> S := StrongSemilatticeOfSemigroups(D, L, H);;
+gap> SSSE(S, 10, IdentityTransformation);
+Error, expected second argument to be an integer between 1 and the size of the\
+ semilattice, i.e. 3
+gap> SSSE(S, 1, Transformation([3, 2, 1]));
+Error, where S, n and x are the 1st, 2nd and 3rd arguments respectively, expec\
+ted x to be an element of SemigroupsOfStrongSemilatticeOfSemigroups(S)[n]
+gap> SSSE(S, 2, Transformation([2, 1])) < SSSE(S, 3, Transformation([1, 1]));
+true
+gap> SSSE(S, 2, Transformation([2, 1])) = SSSE(S, 3, Transformation([1, 1]));
+false
+gap> SSSE(S, 2, Transformation([2, 1])) * SSSE(S, 3, Transformation([1, 1]))
+>    = SSSE(S, 1, Transformation([2, 2]));
+true
+gap> S = StrongSemilatticeOfSemigroups(SSSE(S, 2, Transformation([2, 1])));
+true
+
+# constructions: strong semilattices of semigroups: full worked example (SLOW!)
+#
+#           5     4
+#          / \   /
+#         /   \ /
+#        2     3
+#         \   /
+#          \ /
+#           1
+#
+gap> L := [];;
+gap> H := [[], [], [], [], []];;
+gap> Add(L, Semigroup(Transformation([1, 1, 1]),
+>                     Transformation([1, 2, 3]),
+>                     Transformation([1, 3, 2])));
+gap> Add(L, MagmaWithZeroAdjoined(SymmetricGroup(3)));
+gap> Add(L, FullTransformationMonoid(4));
+gap> Add(L, RightZeroSemigroup(4));
+gap> Add(L, FullTransformationMonoid(3));
+gap> m1 := function(trans)
+>      local temp, out;
+>      # A clever way of embedding T3 in T4, fixing the point 1 rather than 4.
+>      temp := ShallowCopy(ListTransformation(trans)) + 1;
+>      out  := [1];
+>      Append(out, temp);
+>      return Transformation(out);
+>    end;;
+gap> H[3][2] := MappingByFunction(L[5], L[3], m1);;
+gap> c := SemigroupCongruence(L[3], [[Transformation([1, 2, 4, 3]),
+>                                     Transformation([1, 3, 2, 4])]]);;
+gap> # this congruence separates T_4 into three sets:
+gap> # A_4;
+gap> # S_4 \ A_4;
+gap> # all transformations with size of image < 4.
+gap> c1 := CongruenceClassOfElement(c,
+>                                   Transformation([1, 2, 3, 1]));;
+gap> c2 := CongruenceClassOfElement(c,
+>                                   IdentityTransformation);;
+gap> c3 := CongruenceClassOfElement(c,
+>                                   Transformation([2, 3, 4, 1]));;
+gap> m1 := function(trans)
+>      if trans in c1 then
+>        return Transformation([1, 1, 1]);
+>      elif trans in c2 then
+>        return Transformation([1, 2, 3]);
+>      elif trans in c3 then
+>        return Transformation([1, 3, 2]);
+>      else
+>        return fail;
+>      fi;
+>    end;;
+gap> H[1][2] := MappingByFunction(L[3], L[1], m1);;
+gap> m1 := function(trans)
+>      if Length(ImageSetOfTransformation(trans, 3)) < 3 then
+>        return MultiplicativeZero(L[2]);
+>      else
+>        return PermutationOfImage(trans) ^ UnderlyingInjectionZeroMagma(L[2]);
+>      fi;
+>    end;;
+gap> H[2][1] := MappingByFunction(L[5], L[2], m1);;
+gap> m1 := function(magelem)
+>      local p;
+>      p := magelem ^ InverseGeneralMapping(UnderlyingInjectionZeroMagma(L[2]));
+>      if p = fail then
+>        return Transformation([1, 1, 1]);
+>      elif p in AlternatingGroup(3) then
+>        return Transformation([1, 2, 3]);
+>      else
+>        return Transformation([1, 3, 2]);
+>      fi;
+>    end;;
+gap> H[1][1] := MappingByFunction(L[2], L[1], m1);;
+gap> H[3][1] := IdentityMapping(L[3]);;
+gap> D := Digraph([[2, 3], [5], [4, 5], [], []]);;
+gap> S := StrongSemilatticeOfSemigroups(D, L, H);
+<strong semilattice of 5 semigroups>
+gap> IsStrongSemilatticeOfSemigroups(S);
+true
+gap> Size(S);
+297
+gap> Length(GreensDClasses(S));
+12
+gap> SSSE(S, 2, (1, 2) ^ UnderlyingInjectionZeroMagma(L[2]))
+>    * SSSE(S, 3, Transformation([1, 4, 3, 2]))
+>    = SSSE(S, 1, IdentityTransformation);
+true
+gap> SSSE(S, 4, Transformation([4, 4, 4, 4]))
+>    * SSSE(S, 5, Transformation([3, 3, 2]))
+>    = SSSE(S, 3, Transformation([3, 3, 3, 3]));
+true
+gap> MultiplicativeZero(S) = SSSE(S, 1, Transformation([1, 1, 1]));
+true
+gap> MultiplicativeNeutralElement(S);
+fail
+
 #
 gap> Unbind(S);
+
+# Unbind strong semilattice vars
+gap> Unbind(D);
+gap> Unbind(L);
+gap> Unbind(H);
+gap> Unbind(id);
+gap> Unbind(m1);
+gap> Unbind(m2);
+gap> Unbind(S1);
+gap> Unbind(S2);
 
 # 
 gap> SEMIGROUPS.StopTest();


### PR DESCRIPTION
_This PR supersedes #673; I've started a new one to squash the current log of ~30 commits and have easier write access to the PR (I was previously submitting PRs to Murray's branch)._

This PR is joint work with @james-d-mitchell, @MTWhyte and @reiniscirpons. It creates a new `StrongSemilatticeOfSemigroups` object initialised from a list of semigroups, a (meet-semilattice) digraph and a list of homomorphisms. Currently element enumeration, element comparison and multiplication is possible, which makes this a fully working **Semigroups** object, and it will be ready to merge as soon as it passes tests and review.

In future I will also be working off this branch to create additional features such as decomposition of certain types of completely regular semigroups into `StrongSemilatticeOfSemigroups` objects. 