### PR TITLE
Extend congruence methods to equivalence relations

### DIFF
--- a/doc/cong.xml
+++ b/doc/cong.xml
@@ -406,25 +406,26 @@ gap> congs := PrincipalCongruencesOfSemigroup(S);
 
 <#GAPDoc Label="EquivalenceRelationLookup">
   <ManSection>
-    <Attr Name = "EquivalenceRelationLookup" Arg = "cong"/>
+    <Attr Name = "EquivalenceRelationLookup" Arg = "equiv" Label="for an
+      equivalence relation over a finite semigroup"/>
     <Returns>A list.</Returns>
     <Description>
-      This attribute describes the (left, right or two-sided) semigroup
-      congruence <A>cong</A> as a list of positive integers with length the size
-      of the finite semigroup over which <A>cong</A> is defined.<P/>
+      This attribute describes the equivalence relation <A>equiv</A>, defined
+      over a finite semigroup, as a list of positive integers of length the size
+      of the finite semigroup over which <A>equiv</A> is defined.<P/>
 
       Each position in the list corresponds to an element of the semigroup (in a
       consistent canonical order) and the integer at that position is a unique
-      identifier for that element's congruence class under <A>cong</A>.  Two
-      elements of the semigroup on which the congruence is defined are related
-      in the congruence if and only if they have the same number at their
+      identifier for that element's equivalence class under <A>equiv</A>.  Two
+      elements of the semigroup on which the equivalence is defined are related
+      in the equiavalence if and only if they have the same number at their
       respective positions in the lookup.<P/>
 
       Note that the order in which numbers appear in the list is
-      non-deterministic, and two congruence objects which describe the same
-      equivalence relation might therefore have different lookups.  Note also
+      non-deterministic, and two equivalence relations describing the same
+      mathematical relation might therefore have different lookups.  Note also
       that the maximum value of the list may not be the number of classes of
-      <A>cong</A>, and that any integer might not be included.  However, see
+      <A>equiv</A>, and that any integer might not be included.  However, see
       <Ref Attr = "EquivalenceRelationCanonicalLookup"/>.<P/>
 
       See also <Ref Attr = "EquivalenceRelationPartition" BookName = "ref"/>.
@@ -444,26 +445,28 @@ false]]></Example>
 
 <#GAPDoc Label="EquivalenceRelationCanonicalLookup">
   <ManSection>
-    <Attr Name = "EquivalenceRelationCanonicalLookup" Arg = "cong"/>
+    <Attr Name = "EquivalenceRelationCanonicalLookup" Arg = "equiv" Label="for
+      an equivalence relation over a finite semigroup"/>
     <Returns>A list.</Returns>
     <Description>
-      This attribute describes the semigroup congruence <A>cong</A> as a list of
-      positive integers with length the size of the finite semigroup over which
-      <A>cong</A> is defined.<P/>
+      This attribute describes the equivalence relation <A>equiv</A>, defined
+      over a finite semigroup, as a list of positive integers of length the size
+      of the finite semigroup over which <A>equiv</A> is defined.<P/>
 
       Each position in the list corresponds to an element of the semigroup (in a
-      consistent canonical order) and the integer at that position is a unique
-      identifier for that element's congruence class under <A>cong</A>.  The
+      consistent canonical order as defined by <Ref Oper =
+        "PositionCanonical"/>) and the integer at that position is a unique
+      identifier for that element's equivalence class under <A>equiv</A>.  The
       value of <C>EquivalenceRelationCanonicalLookup</C> has the property that
       the first appearance of the value <C>i</C> is strictly later than the
       first appearance of <C>i-1</C>, and that all entries in the list will be
-      from the range <C>[1 .. NrEquivalenceClasses(<A>cong</A>)]</C>.  As such,
-      two congruences on a given semigroup are equal if and only if their
-      canonical lookups are equal.<P/>
+      from the range <C>[1 .. NrEquivalenceClasses(<A>equiv</A>)]</C>.  As such,
+      two equivalence relations on a given semigroup are equal if and only if
+      their canonical lookups are equal.<P/>
 
-      Two elements of the semigroup on which the congruence is defined
-      are related in the congruence if and only if they have
-      the same number at their respective positions in the lookup.
+      Two elements of the semigroup on which the equivalence relation is defined
+      are related in the equivalence relation if and only if they have the same
+      number at their respective positions in the lookup.
       <P/>
 
       See also <Ref Attr = "EquivalenceRelationLookup"/> and

--- a/gap/congruences/cong.gi
+++ b/gap/congruences/cong.gi
@@ -498,14 +498,13 @@ InstallMethod(EquivalenceRelationLookup,
 "for an equivalence relation",
 [IsEquivalenceRelation],
 function(equiv)
-  if not IsFinite(Range(equiv)) then
+  if not (IsSemigroup(Range(equiv)) and IsFinite(Range(equiv))) then
     ErrorNoReturn("<equiv> must be over a finite semigroup,");
   fi;
   return SEMIGROUPS._GenericEquivLookup(equiv);
 end);
 
-BindGlobal("_GenericEquivCanonicalLookup",
-function(equiv)
+SEMIGROUPS._GenericEquivCanonicalLookup := function(equiv)
   local lookup, max, dictionary, next, out, i, new_nr;
   lookup := EquivalenceRelationLookup(equiv);
   max := Maximum(lookup);
@@ -523,15 +522,17 @@ function(equiv)
     out[i] := new_nr;
   od;
   return out;
-end);
+end;
 
 InstallMethod(EquivalenceRelationCanonicalLookup,
 "for an equivalence relation",
 [IsEquivalenceRelation],
-_GenericEquivCanonicalLookup);
-
-MakeReadWriteGlobal("_GenericCongCanonicalLookup");
-Unbind(_GenericCongCanonicalLookup);
+function(equiv)
+  if not (IsSemigroup(Range(equiv)) and IsFinite(Range(equiv))) then
+    ErrorNoReturn("<equiv> must be over a finite semigroup,");
+  fi;
+  return SEMIGROUPS._GenericEquivCanonicalLookup(equiv);
+end);
 
 InstallMethod(EquivalenceRelationCanonicalPartition,
 "for a left semigroup congruence",

--- a/gap/congruences/cong.gi
+++ b/gap/congruences/cong.gi
@@ -480,12 +480,12 @@ function(class, elm)
   return EquivalenceClassOfElementNC(cong, Representative(class) * elm);
 end);
 
-SEMIGROUPS._GenericCongLookup := function(cong)
+SEMIGROUPS._GenericEquivLookup := function(equiv)
   local S, lookup, class, nr, elm;
 
-  S := Range(cong);
+  S := Range(equiv);
   lookup := [1 .. Size(S)];
-  for class in NonTrivialEquivalenceClasses(cong) do
+  for class in NonTrivialEquivalenceClasses(equiv) do
     nr := PositionCanonical(S, Representative(class));
     for elm in class do
       lookup[PositionCanonical(S, elm)] := nr;
@@ -495,44 +495,21 @@ SEMIGROUPS._GenericCongLookup := function(cong)
 end;
 
 InstallMethod(EquivalenceRelationLookup,
-"for a semigroup congruence",
-[IsSemigroupCongruence],
-function(cong)
-  if not IsFinite(Range(cong)) then
-    ErrorNoReturn("Semigroups: EquivalenceRelationLookup: usage,\n",
-                  "<cong> must be over a finite semigroup,");
+"for an equivalence relation",
+[IsEquivalenceRelation],
+function(equiv)
+  if not IsFinite(Range(equiv)) then
+    ErrorNoReturn("<equiv> must be over a finite semigroup,");
   fi;
-  return SEMIGROUPS._GenericCongLookup(cong);
+  return SEMIGROUPS._GenericEquivLookup(equiv);
 end);
 
-InstallMethod(EquivalenceRelationLookup,
-"for a left semigroup congruence",
-[IsLeftSemigroupCongruence],
-function(cong)
-  if not IsFinite(Range(cong)) then
-    ErrorNoReturn("Semigroups: EquivalenceRelationLookup: usage,\n",
-                  "<cong> must be over a finite semigroup,");
-  fi;
-  return SEMIGROUPS._GenericCongLookup(cong);
-end);
-
-InstallMethod(EquivalenceRelationLookup,
-"for a right semigroup congruence",
-[IsRightSemigroupCongruence],
-function(cong)
-  if not IsFinite(Range(cong)) then
-    ErrorNoReturn("Semigroups: EquivalenceRelationLookup: usage,\n",
-                  "<cong> must be over a finite semigroup,");
-  fi;
-  return SEMIGROUPS._GenericCongLookup(cong);
-end);
-
-BindGlobal("_GenericCongCanonicalLookup",
-function(cong)
+BindGlobal("_GenericEquivCanonicalLookup",
+function(equiv)
   local lookup, max, dictionary, next, out, i, new_nr;
-  lookup := EquivalenceRelationLookup(cong);
+  lookup := EquivalenceRelationLookup(equiv);
   max := Maximum(lookup);
-  # We do not know whether the maximum is NrEquivalenceClasses(cong)
+  # We do not know whether the maximum is NrEquivalenceClasses(equiv)
   dictionary := ListWithIdenticalEntries(max, 0);
   next := 1;
   out := EmptyPlist(max);
@@ -549,14 +526,9 @@ function(cong)
 end);
 
 InstallMethod(EquivalenceRelationCanonicalLookup,
-"for a left semigroup congruence",
-[IsLeftSemigroupCongruence],
-_GenericCongCanonicalLookup);
-
-InstallMethod(EquivalenceRelationCanonicalLookup,
-"for a right semigroup congruence",
-[IsRightSemigroupCongruence],
-_GenericCongCanonicalLookup);
+"for an equivalence relation",
+[IsEquivalenceRelation],
+_GenericEquivCanonicalLookup);
 
 MakeReadWriteGlobal("_GenericCongCanonicalLookup");
 Unbind(_GenericCongCanonicalLookup);
@@ -570,3 +542,8 @@ InstallMethod(EquivalenceRelationCanonicalPartition,
 "for a right semigroup congruence",
 [IsRightSemigroupCongruence],
 cong -> Set(EquivalenceRelationPartition(cong), Set));
+
+InstallMethod(NonTrivialEquivalenceClasses,
+"for an equivalence relation",
+[IsEquivalenceRelation],
+x -> Filtered(EquivalenceClasses(x), y -> Size(y) > 1));

--- a/tst/standard/cong.tst
+++ b/tst/standard/cong.tst
@@ -460,19 +460,15 @@ true
 gap> F := FreeSemigroup(2);;
 gap> cong := ReesCongruenceOfSemigroupIdeal(SemigroupIdeal(F, [F.1]));;
 gap> EquivalenceRelationLookup(cong);
-Error, Semigroups: EquivalenceRelationLookup: usage,
-<cong> must be over a finite semigroup,
+Error, <equiv> must be over a finite semigroup,
 gap> EquivalenceRelationCanonicalLookup(cong);
-Error, Semigroups: EquivalenceRelationLookup: usage,
-<cong> must be over a finite semigroup,
+Error, <equiv> must be over a finite semigroup,
 gap> cong := LeftSemigroupCongruence(F, [F.1, F.2]);;
 gap> EquivalenceRelationLookup(cong);
-Error, Semigroups: EquivalenceRelationLookup: usage,
-<cong> must be over a finite semigroup,
+Error, <equiv> must be over a finite semigroup,
 gap> cong := RightSemigroupCongruence(F, [F.1, F.2]);;
 gap> EquivalenceRelationLookup(cong);
-Error, Semigroups: EquivalenceRelationLookup: usage,
-<cong> must be over a finite semigroup,
+Error, <equiv> must be over a finite semigroup,
 
 # Equality for congruences over different semigroups (false)
 gap> S := Semigroup([Transformation([3, 2, 3]), Transformation([3, 1, 1])]);;

--- a/tst/standard/congpairs.tst
+++ b/tst/standard/congpairs.tst
@@ -33,8 +33,7 @@ gap> cong := SemigroupCongruence(S, gens);
 gap> gens in cong;
 true
 gap> EquivalenceRelationLookup(cong);
-Error, Semigroups: EquivalenceRelationLookup: usage,
-<cong> must be over a finite semigroup,
+Error, <equiv> must be over a finite semigroup,
 gap> NrCongruenceClasses(cong);
 3
 gap> class := CongruenceClassOfElement(cong, x);;

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -1611,8 +1611,7 @@ gap> cong := SemigroupCongruence(F, pair);
 gap> pair in cong;
 true
 gap> EquivalenceRelationLookup(cong);
-Error, Semigroups: EquivalenceRelationLookup: usage,
-<cong> must be over a finite semigroup,
+Error, <equiv> must be over a finite semigroup,
 gap> EquivalenceClasses(cong);
 [ <congruence class of s1>, <congruence class of s1^2>, 
   <congruence class of s1^3> ]
@@ -1765,8 +1764,7 @@ infinity
 gap> CongruenceByGeneratingPairsPartition(S!.cong);
 Error, the argument <cong> has infinitely many classes,
 gap> EquivalenceRelationLookup(S!.cong);
-Error, Semigroups: EquivalenceRelationLookup: usage,
-<cong> must be over a finite semigroup,
+Error, <equiv> must be over a finite semigroup,
 
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(B);


### PR DESCRIPTION
Allows `EquivalenceRelationLookup` and `EquivalenceRelationCanonicalLookup` to be applied to equivalence relations.

I didn't really examine the current setup very hard for subtleties and there should probably be more functions this is done to, hence the draft. Should possibly `TryNextMethod` instead of `Error` as well.