### PR TITLE
Decomposition of some Completely Regular Semigroups into Strong Semilattices of Semigroups

### DIFF
--- a/gap/attributes/isomorph.gi
+++ b/gap/attributes/isomorph.gi
@@ -332,7 +332,7 @@ InstallMethod(IsomorphismSemigroup,
 "for IsStrongSemilatticeOfSemigroups and a Clifford semigroup",
 [IsStrongSemilatticeOfSemigroups, IsSemigroup and IsFinite],
 function(filt, S)
-  local A, idemps, n, D, N, L, classes, idemp, DC, H, map, SSS, i, j;
+  local A, idemps, n, D, N, L, classes, idemp, DC, H, SSS, i, j, addfunc;
   # decomposes a finite Clifford semigroup S into a strong semilattice of
   # groups and returns an SSS object.
   if not (IsCliffordSemigroup(S) and IsFinite(S)) then
@@ -366,12 +366,13 @@ function(filt, S)
   for i in [1 .. n] do
     idemp := idemps[i];
     Add(H, []);
+    addfunc := function(x, a, b, c)  # horrible namespace hack (credits JDM)
+      Add(x, [a, b, z -> c * z]);
+    end;
     for j in N[i] do
-      map := function(elm)
-        return idemp * elm;
-      end;
-      Add(H[i], MappingByFunction(L[j], L[i], map));
+      addfunc(H[i], L[j], L[i], idemps[i]);
     od;
+    Apply(H[i], x -> MappingByFunction(x[1], x[2], x[3]));
   od;
 
   SSS := StrongSemilatticeOfSemigroups(D, L, H);

--- a/gap/attributes/isomorph.gi
+++ b/gap/attributes/isomorph.gi
@@ -327,3 +327,60 @@ function(S)
   UseIsomorphismRelation(H, G);
   return H;
 end);
+
+InstallMethod(IsomorphismSemigroup,
+"for IsStrongSemilatticeOfSemigroups and a Clifford semigroup",
+[IsStrongSemilatticeOfSemigroups, IsSemigroup and IsFinite],
+function(filt, S)
+  local A, idemps, n, D, N, L, classes, idemp, DC, H, map, SSS, i, j;
+  # decomposes a finite Clifford semigroup S into a strong semilattice of
+  # groups and returns an SSS object.
+  if not (IsCliffordSemigroup(S) and IsFinite(S)) then
+    TryNextMethod();
+  fi;
+  # There should be one idempotent per D-class, i.e. per semilattice element
+  # since the semilattice decomposition is by J-classes, and J = D here
+  A      := Semigroup(Idempotents(S));
+  idemps := Elements(A);
+  n      := Size(idemps);
+
+  # create semilattice
+  D := DigraphReflexiveTransitiveReduction(Digraph(NaturalPartialOrder(A)));
+  # currently wrong way round
+  D := DigraphReverse(D);
+  N := OutNeighbours(D);
+
+  # populate list of semigroups in semilattice.
+  # keep a list of D-classes at the same time, to figure out where elements are
+  L       := [];
+  classes := [];
+  for i in [1 .. n] do
+    idemp := idemps[i];  # the idempotent of this D-class
+    DC := DClass(S, idemp);
+    Add(L, Semigroup(DC));
+    Add(classes, DC);
+  od;
+
+  # populate list of homomorphisms
+  H := [];
+  for i in [1 .. n] do
+    idemp := idemps[i];
+    Add(H, []);
+    for j in N[i] do
+      map := function(elm)
+        return idemp * elm;
+      end;
+      Add(H[i], MappingByFunction(L[j], L[i], map));
+    od;
+  od;
+
+  SSS := StrongSemilatticeOfSemigroups(D, L, H);
+
+  return MagmaIsomorphismByFunctionsNC(S,
+                                       SSS,
+                                       x -> SSSE(SSS,
+                                                 Position(classes,
+                                                          DClass(S, x)),
+                                                 x),
+                                       x -> x![3]);
+end);

--- a/gap/attributes/isomorph.gi
+++ b/gap/attributes/isomorph.gi
@@ -345,7 +345,7 @@ function(filt, S)
   n      := Size(idemps);
 
   # create semilattice
-  D := DigraphReflexiveTransitiveReduction(Digraph(NaturalPartialOrder(A)));
+  D := Digraph(NaturalPartialOrder(A));
   # currently wrong way round
   D := DigraphReverse(D);
   N := OutNeighbours(D);

--- a/gap/attributes/properties.gd
+++ b/gap/attributes/properties.gd
@@ -104,4 +104,4 @@ InstallTrueMethod(IsSurjectiveSemigroup, IsMonoidAsSemigroup);
 InstallTrueMethod(IsSurjectiveSemigroup, IsIdempotentGenerated);
 
 DeclareProperty("IsOrthogroup", IsSemigroup);
-DeclareSynonym("IsOrthoGroup", IsOrthogroup);
+DeclareSynonymAttr("IsOrthoGroup", IsOrthogroup);

--- a/gap/attributes/properties.gd
+++ b/gap/attributes/properties.gd
@@ -102,3 +102,6 @@ DeclareProperty("IsSurjectiveSemigroup", IsSemigroup);
 InstallTrueMethod(IsSurjectiveSemigroup, IsRegularSemigroup);
 InstallTrueMethod(IsSurjectiveSemigroup, IsMonoidAsSemigroup);
 InstallTrueMethod(IsSurjectiveSemigroup, IsIdempotentGenerated);
+
+DeclareProperty("IsOrthogroup", IsSemigroup);
+DeclareSynonym("IsOrthoGroup", IsOrthogroup);

--- a/gap/attributes/properties.gi
+++ b/gap/attributes/properties.gi
@@ -1784,3 +1784,9 @@ x -> UnderlyingSemigroupOfSemigroupWithAdjoinedZero(x) <> fail);
 InstallMethod(IsSurjectiveSemigroup, "for a semigroup",
 [IsSemigroup],
 S -> IsEmpty(IndecomposableElements(S)));
+
+InstallMethod(IsOrthogroup, "for a semigroup",
+[IsSemigroup],
+function(S)
+  return IsCompletelyRegularSemigroup(S) and IsOrthodoxSemigroup(S);
+end);

--- a/tst/standard/isomorph.tst
+++ b/tst/standard/isomorph.tst
@@ -385,9 +385,32 @@ gap> G := AutomorphismGroup(S);
 gap> StructureDescription(G);
 "S3"
 
+# IsomorphismSemigroup for Clifford semigroups to strong semilattices
+gap> S := DualSymmetricInverseMonoid(5);;
+gap> T := IdempotentGeneratedSubsemigroup(S);;
+gap> map := IsomorphismSemigroup(IsStrongSemilatticeOfSemigroups, T);;
+gap> S := Range(map);;
+gap> S;
+<strong semilattice of 52 semigroups>
+gap> IsStrongSemilatticeOfSemigroups(S);
+true
+gap> failed := [];;
+gap> for x in T do
+>      if x <> (x ^ map)![3] then
+>        Add(failed, x);;
+>      fi;
+>    od;
+gap> failed;
+[  ]
+gap> IsomorphismSemigroups(S, T) <> fail;
+true
+gap> SemilatticeOfStrongSemilatticeOfSemigroups(S);
+<immutable meet semilattice digraph with 52 vertices, 358 edges>
+
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(S);
 gap> Unbind(T);
+gap> Unbind(x);
 
 #
 gap> SEMIGROUPS.StopTest();

--- a/tst/standard/isomorph.tst
+++ b/tst/standard/isomorph.tst
@@ -385,7 +385,7 @@ gap> G := AutomorphismGroup(S);
 gap> StructureDescription(G);
 "S3"
 
-# IsomorphismSemigroup for Clifford semigroups to strong semilattices
+# IsomorphismSemigroup for Clifford semigroups to strong semilattices (1/3)
 gap> S := DualSymmetricInverseMonoid(5);;
 gap> T := IdempotentGeneratedSubsemigroup(S);;
 gap> map := IsomorphismSemigroup(IsStrongSemilatticeOfSemigroups, T);;
@@ -406,8 +406,48 @@ gap> IsomorphismSemigroups(S, T) <> fail;
 true
 gap> SemilatticeOfStrongSemilatticeOfSemigroups(S);
 <immutable meet semilattice digraph with 52 vertices, 358 edges>
+gap> BruteForceIsoCheck(map);
+true
+
+# IsomorphismSemigroup for Clifford semigroups to strong semilattices (2/3)
+gap> T := Semigroup(Transformation([1, 2, 4, 5, 6, 3, 7, 8]),
+>                   Transformation([3, 3, 4, 5, 6, 2, 7, 8]),
+>                   Transformation([1, 2, 5, 3, 6, 8, 4, 4]));;
+gap> Size(T);
+864
+gap> NrIdempotents(T);
+4
+gap> S := IsomorphismSemigroup(IsStrongSemilatticeOfSemigroups, T);;
+gap> map := IsomorphismSemigroup(IsStrongSemilatticeOfSemigroups, T);;
+gap> S := Range(map);
+<strong semilattice of 4 semigroups>
+gap> Size(S);
+864
+gap> # Property of CLifford semigroups:
+gap> List(SemigroupsOfStrongSemilatticeOfSemigroups(S), IsGroupAsSemigroup);
+[ true, true, true, true ]
+gap> BruteForceIsoCheck(map);
+true
+
+# IsomorphismSemigroup for Clifford semigroups to strong semilattices (3/3)
+gap> T := Semigroup(List([2 .. 10],
+>                   x -> Transformation(ListWithIdenticalEntries(x, 1))));
+<transformation semigroup of degree 10 with 9 generators>
+gap> IsCliffordSemigroup(T);
+true
+gap> map := IsomorphismSemigroup(IsStrongSemilatticeOfSemigroups, T);;
+gap> S := Range(map);
+<strong semilattice of 9 semigroups>
+gap> BruteForceIsoCheck(map);
+true
+gap> Size(S) = Size(T);
+true
+gap> SemilatticeOfStrongSemilatticeOfSemigroups(S) =
+>    DigraphReflexiveTransitiveClosure(ChainDigraph(9));
+true
 
 # SEMIGROUPS_UnbindVariables
+gap> Unbind(map);
 gap> Unbind(S);
 gap> Unbind(T);
 gap> Unbind(x);


### PR DESCRIPTION
**May 2021 update: this PR has only ticked one of four boxes, but it works on Clifford semigroups. Implementing IsomorphismSemigroup for other types of completely regular semigroups can be done in a different PR.**

This PR introduces methods for decomposing certain completely regular semigroups into strong semilattices, as suggested in Issue #671. The aim is introduce `IsomorphismSemigroup` methods from the following types of semigroups:

- [X] Clifford semigroups
- [ ] Normal orthogroups
- [ ] Normal cryptogroups
- [ ] Normal bands (?)

to SSS objects.
