### PR TITLE
add EnumeratorCanonical for enumerable semigroups without generators

### DIFF
--- a/gap/main/fropin.gi
+++ b/gap/main/fropin.gi
@@ -385,6 +385,14 @@ function(S)
   return enum;
 end);
 
+InstallMethod(EnumeratorCanonical,
+"for an enumerable semigroup with known generators",
+[IsEnumerableSemigroupRep],
+function(S)
+  GeneratorsOfSemigroup(S);
+  return EnumeratorCanonical(S);
+end);
+
 # The next method is necessary since it does not necessarily involve
 # enumerating the entire semigroup in the case that the semigroup is partially
 # enumerated and <list> only contains indices that are within the so far

--- a/tst/standard/fropin.tst
+++ b/tst/standard/fropin.tst
@@ -303,6 +303,35 @@ infinity
 gap> IsFinite(S);
 false
 
+# EnumeratorCanonical for IsEnumerableSemigroupRep without generators
+gap> G := Range(IsomorphismPermGroup(SmallGroup(6, 1)));;
+gap> mat := [[G.1, G.2], [G.1 * G.2, G.1], [G.2, G.2]];;
+gap> S := ReesMatrixSemigroup(G, mat);;
+gap> IsEnumerableSemigroupRep(S);
+true
+gap> HasGeneratorsOfSemigroup(S);
+false
+gap> en := EnumeratorCanonical(S);;
+gap> en[1];
+(1,(),1)
+gap> en[2];
+(1,(1,6)(2,5)(3,4),1)
+gap> en[15];
+(2,(1,2)(3,6)(4,5),2)
+gap> en[36];
+(2,(1,2)(3,6)(4,5),3)
+gap> Length(en);
+36
+gap> IsBound(en[37]);
+false
+gap> for x in it do od;
+gap> ForAll(en, x -> en[Position(en, x)] = x);
+true
+gap> ForAll([1 .. Length(en)], i -> Position(en, en[i]) = i);
+true
+gap> ForAll(S, x -> x in en);
+true
+
 # IteratorCanonical
 gap> S := UnitriangularBooleanMatMonoid(3);;
 gap> it := Iterator(S);


### PR DESCRIPTION
This just apes the functionality for ```AsListCanonical```.

In theory all of this should be replaced soon anyway!