### PR TITLE
Improve the prerequisities.sh file

### DIFF
--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -1,35 +1,45 @@
+#!/bin/bash
+
 set -e
 
 SEMI_DIR=`dirname "$0"`
 LIBS_DIR="$SEMI_DIR/libsemigroups"
 
 # Get libsemigroups version from file
-if [ -f $SEMI_DIR/.LIBSEMIGROUPS_VERSION ]; then
+if [ -f "$SEMI_DIR/.LIBSEMIGROUPS_VERSION" ]; then
   VERS=`tr -d '\n' < $SEMI_DIR/.LIBSEMIGROUPS_VERSION`
 else
-  echo -e "Error, cannot find $SEMI_DIR/.LIBSEMIGROUPS_VERSION"
+  echo "Error, cannot find $SEMI_DIR/.LIBSEMIGROUPS_VERSION"
   exit 1
 fi
 
-echo -e "libsemigroups v$VERS is required by this version of Semigroups"
+echo "libsemigroups v$VERS is required by this version of Semigroups"
 
-if [ -d $LIBS_DIR ] && [ "$(ls -A $LIBS_DIR)" ]; then
-  echo -e "the $LIBS_DIR directory exists and is non-empty"
-  if ! [ -f $LIBS_DIR/.VERSION ]; then
-    echo -e "Error, it is not possible to determine the libsemigroups version"
+if [ -d "$LIBS_DIR" ] && [ "$(ls -A $LIBS_DIR)" ]; then
+  echo "the libsemigroups directory exists and is non-empty"
+  if [ -f "$LIBS_DIR/.VERSION" ]; then
+    echo "The file libsemigroups/.VERSION is present"
+    INSTALLED=`tr -d '\n' < "$LIBS_DIR/.VERSION"`
+  elif [ -f "$LIBS_DIR/etc/version-number.sh" ]; then
+    echo "The file libsemigroups/.VERSION is not present; recreating it..."
+    cd "$LIBS_DIR"
+    INSTALLED=`etc/version-number.sh`
+    echo "$INSTALLED" > .VERSION
+    cd "$SEMI_DIR"
+  else
+    echo "Error, it is not possible to determine the libsemigroups version"
     exit 2
   fi
-  INSTALLED=`tr -d '\n' < $LIBS_DIR/.VERSION`
-  echo -e "The installed version of libsemigroups is v$INSTALLED"
+  echo "The installed version of libsemigroups is v$INSTALLED"
   LEAST=`echo -e "$VERS\n$INSTALLED" | sort -V | head -n1`
   if [[ "$VERS" != "$LEAST" ]]; then
-    echo -e "Error, the installed version of libsemigroups is too old"
+    echo "Error, the installed version of libsemigroups is too old"
     exit 3
   fi
   exit 0
 fi
 
 # Download libsemigroups
-echo -e "Downloading libsemigroups v$VERS into $LIBS_DIR..."
-curl -L -O https://github.com/libsemigroups/libsemigroups/releases/download/v$VERS/libsemigroups-$VERS.tar.gz
-tar -xzf libsemigroups-$VERS.tar.gz && rm -f libsemigroups-$VERS.tar.gz && mv libsemigroups-$VERS $LIBS_DIR 
+echo  "Downloading libsemigroups v$VERS into $LIBS_DIR..."
+curl -L -O "https://github.com/libsemigroups/libsemigroups/releases/download/v$VERS/libsemigroups-$VERS.tar.gz"
+tar -xzf "libsemigroups-$VERS.tar.gz" && rm -f "libsemigroups-$VERS.tar.gz" && mv "libsemigroups-$VERS" "$LIBS_DIR"


### PR DESCRIPTION
This should make the file more robust.

* I've added `#!/bin/bash` to the top
* I've put some stuff in quotes
* I've removed the `-e` from the `echo` calls, where possible
* If the `libsemigroups/.VERSION` file is now missing (which might happen accidentally; see #740), the file now attempts to recreate it using the `libsemigroups/etc/version-number.sh` file. This should hopefully never be needed, but why not add it? Previously this script would fail if the `libsemigroups/.VERSION` file was missing.