### PR TITLE
CI: fix the GitHub Actions linting job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: "Install dependencies . . ."
-        run: |
-          sudo pip install gaplint cpplint
-      - name: "Run gaplint + cpplint . . ."
+        name: "Check out the repository"
+      - uses: actions/setup-python@v1
+        name: "Set up Python"
+      - uses: BSFishy/pip-action@v1
+        name: "Install gaplint and cpplint with pip"
+        with:
+          packages: |
+            gaplint
+            cpplint
+      - name: "Run gaplint + cpplint"
         run: bash etc/lint.sh
   test:
     name: "GAP ${{ matrix.gap-branch }}"


### PR DESCRIPTION
I'm not sure exactly why the previous `sudo pip install gaplint cpplint` command started failing, but this fixes it for now, at least.

```
Collecting cpplint
  Downloading https://files.pythonhosted.org/packages/3c/2d/9867b195c5c9b427e07cfeeb982c56086c00bca13c560e093e4133775635/cpplint-1.5.4.tar.gz (359kB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-uzb5wL/cpplint/setup.py", line 85, in <module>
        'lint': Lint
      File "/usr/lib/python2.7/dist-packages/setuptools/__init__.py", line 128, in setup
        _install_setup_requires(attrs)
      File "/usr/lib/python2.7/dist-packages/setuptools/__init__.py", line 123, in _install_setup_requires
        dist.fetch_build_eggs(dist.setup_requires)
      File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 513, in fetch_build_eggs
        replace_conflicting=True,
      File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 774, in resolve
        replace_conflicting=replace_conflicting
      File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 1057, in best_match
        return self.obtain(req, installer)
      File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 1069, in obtain
        return installer(requirement)
      File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 580, in fetch_build_egg
        return cmd.easy_install(req)
      File "/usr/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 698, in easy_install
        return self.install_item(spec, dist.location, tmpdir, deps)
      File "/usr/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 724, in install_item
        dists = self.install_eggs(spec, download, tmpdir)
      File "/usr/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 909, in install_eggs
        return self.build_and_install(setup_script, setup_base)
      File "/usr/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 1177, in build_and_install
        self.run_setup(setup_script, setup_base, args)
      File "/usr/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 1165, in run_setup
        raise DistutilsError("Setup script exited with %s" % (v.args[0],))
    distutils.errors.DistutilsError: Setup script exited with error: package directory 'find_namespace:' does not exist
```