### PR TITLE
Only declare `DirectProductOp`/`SmallGeneratingSet` when required

### DIFF
--- a/gap/attributes/attr.gd
+++ b/gap/attributes/attr.gd
@@ -35,7 +35,11 @@ DeclareAttribute("SmallInverseSemigroupGeneratingSet",
                  IsMultiplicativeElementCollection);
 DeclareAttribute("SmallInverseMonoidGeneratingSet",
                  IsMultiplicativeElementWithOneCollection);
-DeclareAttribute("SmallGeneratingSet", IsSemigroup);
+# SmallGeneratingSet was only declared for IsGroup before GAP 4.12, so the
+# next 3 lines can be removed when Semigroups requires at least GAP 4.12.
+if not [FLAGS_FILTER(IsSemigroup)] in GET_OPER_FLAGS(SmallGeneratingSet) then
+  DeclareAttribute("SmallGeneratingSet", IsSemigroup);
+fi;
 
 DeclareAttribute("MinimalSemigroupGeneratingSet",
                  IsSemigroup);

--- a/gap/semigroups/semidp.gd
+++ b/gap/semigroups/semidp.gd
@@ -10,6 +10,11 @@
 
 # This file contains methods for creating direct products of semigroups
 
-DeclareOperation("DirectProductOp", [IsList, IsSemigroup]);
+# DirectProductOp was only declared for [IsList, IsGroup] before GAP 4.12, so
+# the next 4 lines can be removed when Semigroups requires at least GAP 4.12.
+if not List([IsList, IsSemigroup], FLAGS_FILTER)
+    in GET_OPER_FLAGS(DirectProductOp) then
+  DeclareOperation("DirectProductOp", [IsList, IsSemigroup]);
+fi;
 
 DeclareAttribute("SemigroupDirectProductInfo", IsSemigroup, "mutable");


### PR DESCRIPTION
In GAP versions before 4.12, these are only declared for `IsGroup`.  This means that we have to separately declare them for `IsSemigroup`.  This then gives warnings when further methods are installed for `IsGroup`, (e.g. if you load the polycyclic package after loading Semigroups) because they don't know which declaration they belong to.  Not a huge problem, but one with an easy fix.

The GAP master branch does, and GAP 4.12 will, declare these things for `IsSemigroup` instead – see https://github.com/gap-system/gap/pull/4329. Therefore we should only make these declarations when GAP has not already made them.  Eventually, the package will presumably require GAP 4.12, and so all of this code can be deleted. I have added comments to that effect.

It turns out that the repeated declaration of attributes does not cause a warning to be printed, although repeated declarations of operations do. So when loading Semigroups `stable-3.4` in the GAP `master` branch right now, you get only the warning:
```
 Loading the library and packages ...
#I  equal requirements in multiple declarations for operation `DirectProductOp'
```
That means we only 'need' to make the change in this PR for `DirectProductOp`, but I still think it'd be better to do both.