### PR TITLE
Allow ElementOfFpSemigroup to take simpler args

### DIFF
--- a/doc/semifp.xml
+++ b/doc/semifp.xml
@@ -41,3 +41,51 @@ gap> f2 / ParseRelations(GeneratorsOfSemigroup(f2), "a = a^2");
   </Description>
 </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="ElementOfFpSemigroup">
+<ManSection>
+  <Oper Name="ElementOfFpSemigroup" Arg="S, word"/>
+  <Returns>An element of the fp semigroup <A>S</A>.</Returns>
+  <Description>
+    When <A>S</A> is a finitely presented semigroup and <A>word</A> is an
+    associative word in the associated free semigroup (see
+    <Ref Filt="IsAssocWord" BookName="ref"/>), this returns the
+    fp semigroup element with representative <A>word</A>.
+    <P/>
+
+    This function is just a short form of the &GAP; library implementation of
+    <Ref Oper="ElementOfFpSemigroup" BookName="ref"/> which does not require
+    retrieving an element family.
+
+    <Example><![CDATA[
+gap> f := FreeSemigroup("x", "y");;
+gap> AssignGeneratorVariables(f);
+gap> s := f / [[x * x, x], [y * y, y]];
+<fp semigroup on the generators [ x, y ]>
+gap> a := ElementOfFpSemigroup(s, x * y);
+x*y
+gap> b := ElementOfFpSemigroup(s, x * y * y);
+x*y^2
+gap> a in s;
+true
+gap> a = b;
+true]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="ElementOfFpMonoid">
+<ManSection>
+  <Oper Name="ElementOfFpSemigroup" Arg="M, word"/>
+  <Returns>An element of the fp monoid <A>M</A>.</Returns>
+  <Description>
+    When <A>M</A> is a finitely presented monoid and <A>word</A> is an
+    associative word in the associated free monoid (see
+    <Ref Filt="IsAssocWord" BookName="ref"/>), this returns the
+    fp monoid element with representative <A>word</A>.
+    <P/>
+
+    This is analogous to <Ref Oper="ElementOfFpSemigroup"/>.
+  </Description>
+</ManSection>
+<#/GAPDoc>

--- a/doc/z-chap10.xml
+++ b/doc/z-chap10.xml
@@ -217,5 +217,7 @@ x1x2x2^-1x1^-1x1x2]]></Example>
     BookName="ref"/>).
 
     <#Include Label = "ParseRelations">
+    <#Include Label = "ElementOfFpSemigroup">
+    <#Include Label = "ElementOfFpMonoid">
   </Section>
 </Chapter>

--- a/gap/semigroups/semifp.gd
+++ b/gap/semigroups/semifp.gd
@@ -9,3 +9,5 @@
 ##
 DeclareOperation("ParseRelations", [IsDenseList, IsString]);
 
+DeclareOperation("ElementOfFpSemigroup", [IsFpSemigroup, IsAssocWord]);
+DeclareOperation("ElementOfFpMonoid", [IsFpMonoid, IsAssocWord]);

--- a/gap/semigroups/semifp.gi
+++ b/gap/semigroups/semifp.gi
@@ -43,6 +43,16 @@ function(x)
   return ExtRepOfObj(UnderlyingElement(x));
 end);
 
+InstallMethod(ElementOfFpSemigroup,
+"for an fp semigroup and an associative word",
+[IsFpSemigroup, IsAssocWord],
+{s, w} -> ElementOfFpSemigroup(FamilyObj(Representative(s)), w));
+
+InstallMethod(ElementOfFpMonoid,
+"for an fp monoid and an associative word",
+[IsFpMonoid, IsAssocWord],
+{m, w} -> ElementOfFpMonoid(FamilyObj(Representative(m)), w));
+
 InstallMethod(Size, "for an fp semigroup", [IsFpSemigroup],
 function(S)
   SEMIGROUPS.InitFpSemigroup(S);

--- a/tst/standard/semifp.tst
+++ b/tst/standard/semifp.tst
@@ -2187,9 +2187,42 @@ gap> ParseRelations(GeneratorsOfSemigroup(f), "x=");
 Error, expected the second argument to be a string listing the relations of a \
 semigroup but found an = symbol which isn't pairing two words
 
+# Test ElementOfFpSemigroup
+gap> f := FreeSemigroup("x", "y");;
+gap> x := f.1;;
+gap> y := f.2;;
+gap> s := f / [[x * y, y * x]];
+<fp semigroup on the generators [ x, y ]>
+gap> a := ElementOfFpSemigroup(s, x * y);
+x*y
+gap> b := ElementOfFpSemigroup(s, y * x);
+y*x
+gap> x * y = y * x;
+false
+gap> a = b;
+true
+
+# Test ElementOfFpMonoid
+gap> f := FreeMonoid("x", "y");;
+gap> x := f.1;;
+gap> y := f.2;;
+gap> s := f / [[x * y, y * x]];
+<fp monoid on the generators [ x, y ]>
+gap> a := ElementOfFpMonoid(s, x * y);
+x*y
+gap> b := ElementOfFpMonoid(s, y * x);
+y*x
+gap> x * y = y * x;
+false
+gap> a = b;
+true
+
 # SEMIGROUPS_UnbindVariables
+gap> Unbind(a);
+gap> Unbind(b);
 gap> Unbind(BruteForceInverseCheck);
 gap> Unbind(BruteForceIsoCheck);
+gap> Unbind(f);
 gap> Unbind(F);
 gap> Unbind(G);
 gap> Unbind(R);


### PR DESCRIPTION
This PR adds a new implementation of [`ElementOfFpSemigroup`](https://www.gap-system.org/Manuals/doc/ref/chap52.html#X847012347856C55E) from the main GAP distribution. The original implementation needs the first argument to be an element family, and the second to be an associative word. For ease of use, I thought it might be helpful to have a shorthand that can take an fp semigroup as the first argument. That way, you get reasonable output rather than an error when running the final line of this example:
```
gap> f := FreeSemigroup("x", "y");;
gap> AssignGeneratorVariables(f);
#I  Assigned the global variables [ x, y ]
gap> s := f / [[x * x, x], [y * y, y]];
<fp semigroup on the generators [ x, y ]>
gap> a := ElementOfFpSemigroup(s, x * y);
x*y
```

I also added the corresponding `ElementOfFpMonoid` function.