### PR TITLE
Tietze transformations for semigroups

### DIFF
--- a/doc/main.xml
+++ b/doc/main.xml
@@ -77,10 +77,11 @@
   <#Include SYSTEM "z-chap16.xml">  <!-- properties and attributes of inverse semigroups -->
   <#Include SYSTEM "z-chap17.xml">  <!-- congruences -->
   <#Include SYSTEM "z-chap18.xml">  <!-- homomorphisms -->
-  <#Include SYSTEM "z-chap19.xml">  <!-- visualising semigroups -->
-  <#Include SYSTEM "z-chap20.xml">  <!-- utils -->
-  <!--<#Include SYSTEM "z-chap21.xml">  <!-- orbits -->
-  <!-- <#Include SYSTEM "z-chap22.xml">  <!-- extending the package -->
+  <#Include SYSTEM "z-chap19.xml">  <!-- tietze -->
+  <#Include SYSTEM "z-chap20.xml">  <!-- visualising semigroups -->
+  <#Include SYSTEM "z-chap21.xml">  <!-- utils -->
+  <!--<#Include SYSTEM "z-chap22.xml">  <!-- orbits -->
+  <!-- <#Include SYSTEM "z-chap23.xml">  <!-- extending the package -->
 </Body>
 
 <Bibliography Databases="new_bibliography.xml" />

--- a/doc/tietze.xml
+++ b/doc/tietze.xml
@@ -1,0 +1,1010 @@
+#############################################################################
+##
+#W  tietze.xml
+#Y  Copyright (C) 2021                                   Tom Conti-Leslie
+##                                                       Ben Spiers
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+
+<#GAPDoc Label="StzPresentation">
+  <ManSection>
+    <Oper Name="StzPresentation" Arg="s"/>
+    <Returns>
+      A Semigroup Tietze (Stz) object.
+    </Returns>
+    <Description>
+      If <A>s</A> is a fp semigroup
+      (<Ref Filt="IsFpSemigroup" BookName="ref"/>),
+      then this function returns a modifiable object representing the generators
+      and relations of <A>s</A>.
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="IsStzPresentation">
+  <ManSection>
+    <Filt Name="IsStzPresentation" Arg="stz"/>
+    <Returns>
+      <K>true</K> or <K>false</K>.
+    </Returns>
+    <Description>
+      Every semigroup Tietze object is an element of the category
+      <C>IsStzPresentation</C>. Internally, each Stz object contains a list
+      of generators (each represented as a string) and a list of relations
+      (each represented as a pair of LetterRep words, see
+      <Ref Oper="LetterRepAssocWord" BookName="ref"/>).
+      These generator and relation lists can be modified using Tietze
+      transformations
+      (<Ref Sect="Changing presentations"/>).
+
+      <P/>
+
+      When a <C>IsStzPresentation</C> object <A>stz</A> is created from an fp
+      semigroup <C>s</C> using <C>stz := StzPresentation(s)</C>, the generators
+      and relations of <A>stz</A> are initially equal to the generators and
+      relations of <C>s</C>. However, as the Stz object <A>stz</A> is modified,
+      these lists may change, and their current state can be viewed using
+      <Ref Oper="GeneratorsOfStzPresentation"/> and
+      <Ref Oper="RelationsOfStzPresentation"/>.
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="SimplifiedFpSemigroup">
+  <ManSection>
+    <Oper Name="SimplifiedFpSemigroup" Arg="S"/>
+    <Returns>
+      <A>T</A>, an FpSemigroup object.
+    </Returns>
+    <Description>
+      If <A>S</A> is an FpSemigroup object, then <C>SimplifiedFpSemigroup</C> 
+      will return an FpSemigroup object <A>T</A> which is isomorphic to <A>S</A>
+      which has been reduced to minimise its length.
+
+      <C>SimplifiedFpSemigroup</C> applies
+      <Ref Oper="SimplifyFpSemigroup"/>
+      and assigns the <C>Range</C> of the isomorphism object which is returned
+      to <A>T</A>, adding the isomorphism to <A>T</A> as an attribute. In this
+      way, while <A>T</A> is a completely new FpSemigroup object, words in
+      <A>S</A> can be mapped to <A>T</A> using the map obtained from the
+      attribute <Ref Oper="FpTietzeIsomorphism"/>.<P/>
+
+      For more information on the mapping between the semigroups and how it is 
+      created, see
+      <Ref Oper="Converting a modified presentation into a semigroup"/>.
+
+      <Log><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");;
+gap> S := F / [[F.1 ^ 4, F.1], [F.1, F.1 ^ 44], [F.1 ^ 8, F.2 * F.3]];;
+gap> T := SimplifiedFpSemigroup(S);;
+#I  Applying StzSimplifyPresentation...
+#I  StzSimplifyPresentation is verbose by default. Use SetInfoLevel(InfoFpSemigroup, 1) to hide
+#I  output while maintaining ability to use StzPrintRelations, StzPrintGenerators, etc.
+#I  Current: <fp semigroup presentation with 3 generators and 3 relations with length 63>
+#I  <Replacing all instances in other relations of relation: 1. a^4 = a>
+#I  Current: <fp semigroup presentation with 3 generators and 3 relations with length 24>
+#I  <Replacing all instances in other relations of relation: 1. a^4 = a>
+#I  Current: <fp semigroup presentation with 3 generators and 3 relations with length 18>
+#I  <Replacing all instances in other relations of relation: 1. a^4 = a>
+#I  Current: <fp semigroup presentation with 3 generators and 3 relations with length 15>
+#I  <Replacing all instances in other relations of relation: 3. a = a^2>
+#I  Current: <fp semigroup presentation with 3 generators and 3 relations with length 12>
+#I  <Removing duplicate relation: 1. a = a^2>
+#I  Current: <fp semigroup presentation with 3 generators and 2 relations with length 9>
+#I  <Removing redundant generator a using relation : 2. a = b*c>
+#I  Current: <fp semigroup presentation with 2 generators and 1 relation with length 8>
+gap> map := FpTietzeIsomorphism(T);;
+gap> S.1 ^ map;
+b*c
+gap> S.1 ^ map = T.1 * T.2;
+true
+gap> invmap := InverseGeneralMapping(map);;
+gap> T.1 ^ invmap = S.2;
+true
+gap> T.1 = S.2;
+false]]></Log>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="SimplifyFpSemigroup">
+  <ManSection>
+    <Oper Name="SimplifyFpSemigroup" Arg="S"/>
+    <Returns>
+      A mapping object.
+    </Returns>
+    <Description>
+      If <A>S</A> is an FpSemigroup object, then <C>SimplifyFpSemigroup</C> 
+      will return a mapping object which will map <A>S</A> to an FpSemigroup
+      which has had its presentation simplified.
+
+      <C>SimplifyFpSemigroup</C> creates an <C>StzPresentation</C> object
+      <A>stz</A> from <A>S</A>, which is then reduced using Tietze
+      transformations until the presentation cannot be reduced in length any
+      further.<P/>
+
+      <C>SimplifyFpSemigroup</C> applies the function
+      <Ref Oper="StzSimplifyPresentation"/>
+      to <A>stz</A>, which repeatedly checks
+      whether a number of different possible transformations will cause a
+      reduction in length, and if so applies the best one. This loop continues
+      until no transformations cause any possible reductions, in which case
+      the mapping is returned. The newly reduced FpSemigroup can be accessed
+      either by taking the range of the mapping or calling
+      <C>SimplifiedFpSemigroup</C>, which first runs <C>SimplifyFpSemigroup</C>
+      and then returns the range of the mapping with the mapping held as an 
+      attribute.<P/>
+
+      For more information on how the mapping is created and used, go to
+      <Ref Oper="Converting a modified presentation into a semigroup"/>.
+
+      <Log><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> map := SimplifyFpSemigroup(T);;
+#I  Applying StzSimplifyPresentation...
+#I  StzSimplifyPresentation is verbose by default. Use SetInfoLevel(InfoFpSemigroup, 1) to hide
+#I  output while maintaining ability to use StzPrintRelations, StzPrintGenerators, etc.
+#I  Current: <fp semigroup presentation with 3 generators and 2 relations with length 19>
+#I  <Removing redundant generator a using relation : 1. a = b^5*c>
+#I  Current: <fp semigroup presentation with 2 generators and 1 relation with length 11>
+#I  <Creating new generator to replace instances of word: b^3>
+#I  Current: <fp semigroup presentation with 3 generators and 2 relations with length 10>
+gap> IsMapping(map);
+true
+gap> T.1;
+a
+gap> T.1 ^ map;
+b^5*c
+gap> RelationsOfFpSemigroup(Range(map));
+[ [ b^3, d ], [ d^2, d ] ]]]></Log>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="StzSimplifyOnce">
+  <ManSection>
+    <Oper Name="StzSimplifyOnce" Arg="stz"/>
+    <Returns>
+      <K>true</K> or <K>false</K>.
+    </Returns>
+    <Description>
+      If <A>stz</A> is an StzPresentation object, then
+      <C>StzSimplifyOnce</C> will check the possible reductions in length for a
+      number of different possible Tietze transformations, and apply the choice 
+      which gives the least length. If a valid transformation was found then the 
+      function returns <K>true</K>, and if no transformation was performed
+      because none would not lead to a reduction in length, then the function
+      returns <K>false</K>.<P/>
+
+      There are four different possible transformations that
+      <C>StzSimplifyOnce</C> may apply. The function searches for redundant 
+      generators and checks if removing them would give a lesser length, it 
+      checks whether substituting one side of each relation throughout the rest 
+      of the relations would give a lesser length, it checks whether there are 
+      any trivial relations (of the form <A>w = w</A> for some word <A>w</A>)
+      or any duplicated relations (relations which are formed from precisely the
+      same words as another relation), and it checks whether any frequently
+      occurring subwords in the relations can be replaced with a new generator 
+      to produce a lesser length. For more details, see
+      <Ref Oper="Changing presentations"/><P/>
+
+      It is simple to add a new check that <C>StzSimplifyOnce</C> can apply.
+      More details are found where the function is 
+      defined in <M>gap/fp/tietze.gi</M>.<P/>
+
+      At <C>InfoLevel</C> 2 (which is the default value, and which can be set
+      using <C>SetInfoLevel(InfoFpSemigroup, 2)</C>, the precise transformations
+      performed are printed to the screen.
+
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(T);
+<fp semigroup presentation with 3 generators and 2 relations
+ with length 19>
+gap> StzSimplifyOnce(stz);
+#I  <Removing redundant generator a using relation : 1. a = b^5*c>
+true
+gap> stz;
+<fp semigroup presentation with 2 generators and 1 relation
+ with length 11>]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="StzSimplifyPresentation">
+  <ManSection>
+    <Oper Name="StzSimplifyPresentation" Arg="stz"/>
+    <Description>
+      If <A>stz</A> is an StzPresentation object, then
+      <C>StzSimplifyOnce</C> will repeatedly apply the best of a few possible 
+      reductions to <A>stz</A> until the reductions no longer lessen the legnth 
+      of the presentation.<P/>
+
+      <C>StzSimplifyPresentation</C> will repeatedly apply the function
+      <C>StzSimplifyOnce</C> to the presentation until
+      <C>StzSimplifyOnce</C> fails to find a transformation which can reduce the
+      length of <A>stz</A>.
+
+      <Log><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(T);
+<fp semigroup presentation with 3 generators and 2 relations
+ with length 19>
+gap> StzSimplifyPresentation(stz);
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 1, 1, 1 ], [ 3 ] ], [ [ 3, 3 ], [ 3 ] ] ]]]></Log>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="UnreducedFpSemigroupOfFpSemigroup">
+  <ManSection>
+    <Attr Name="UnreducedFpSemigroupOfFpSemigroup" Arg="S"/>
+    <Returns>
+      <A>T</A>, an fp semigroup object.
+    </Returns>
+    <Description>
+      If <A>S</A> is an fp semigroup object that has been obtained through
+      calling
+      <Ref Oper="SimplifiedFpSemigroup"/>
+      on some fp semigroup <A>T</A>
+      then <C>UnreducedFpSemigroupOfFpSemigroup</C> returns the original
+      semigroup object before simplification. These are unrelated semigroup 
+      objects, except for that <A>S</A> will have a
+      <Ref Oper="FpTietzeIsomorphism"/>
+      attribute that returns an isomorphic mapping from <A>T</A> to <A>S</A>.
+      <P/>
+
+      If <Ref Oper="SimplifyFpSemigroup"/>
+      has been called on an fp semigroup <A>T</A>,
+      then <C>UnreducedFpSemigroupOfFpSemigroup</C> can be used on the
+      <C>Range</C> of the resultant mapping to obtain the domain.
+      <Log><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> S := SimplifiedFpSemigroup(T);
+#I  Applying StzSimplifyPresentation...
+#I  StzSimplifyPresentation is verbose by default. Use SetInfoLevel(InfoFpSemigroup, 1) to hide
+#I  output while maintaining ability to use StzPrintRelations, StzPrintGenerators, etc.
+#I  Current: <fp semigroup presentation with 3 generators and 2 relations with length 19>
+#I  <Removing redundant generator a using relation : 1. a = b^5*c>
+#I  Current: <fp semigroup presentation with 2 generators and 1 relation with length 11>
+#I  <Creating new generator to replace instances of word: b^3>
+#I  Current: <fp semigroup presentation with 3 generators and 2 relations with length 10>
+<fp semigroup on the generators [ b, c, d ]>
+gap> UnreducedFpSemigroupOfFpSemigroup(S) = T;
+true]]></Log>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="FpTietzeIsomorphism">
+  <ManSection>
+    <Attr Name="FpTietzeIsomorphism" Arg="S"/>
+    <Returns>
+      A mapping object.
+    </Returns>
+    <Description>
+      If <A>S</A> is an fp semigroup object that has been obtained through
+      calling <Ref Oper="SimplifiedFpSemigroup"/>
+      on some fp semigroup <A>T</A>
+      then <C>FpTietzeIsomorphism</C> returns an isomorphic mapping from
+      <A>T</A> to <A>S</A>. Simplification produces an fp semigroup isomorphic 
+      to the original fp semigroup, and these two fp semigroup objects can 
+      interact with each other through the mapping given by this function.
+      <Log><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> S := SimplifiedFpSemigroup(T);
+#I  Applying StzSimplifyPresentation...
+#I  StzSimplifyPresentation is verbose by default. Use SetInfoLevel(InfoFpSemigroup, 1) to hide
+#I  output while maintaining ability to use StzPrintRelations, StzPrintGenerators, etc.
+#I  Current: <fp semigroup presentation with 3 generators and 2 relations with length 19>
+#I  <Removing redundant generator a using relation : 1. a = b^5*c>
+#I  Current: <fp semigroup presentation with 2 generators and 1 relation with length 11>
+#I  <Creating new generator to replace instances of word: b^3>
+#I  Current: <fp semigroup presentation with 3 generators and 2 relations with length 10>
+<fp semigroup on the generators [ b, c, d ]>
+gap> T.2;
+b
+gap> S.1;
+b
+gap> T.2 = S.1;
+false
+gap> map := FpTietzeIsomorphism(S);;
+gap> T.2 ^ map = S.1;
+true]]></Log>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="GeneratorsOfStzPresentation">
+  <ManSection>
+    <Attr Name="GeneratorsOfStzPresentation" Arg="stz"/>
+    <Returns>
+      A list of strings.
+    </Returns>
+    <Description>
+      If <A>stz</A> is an StzPresentation object, then
+      <C>GeneratorsOfStzPresentation</C> will return as strings the generators
+      of the fp semigroup that the presentation was created from. In the 
+      StzPresentation object it is only necessary to know how many generators
+      there are, but for the purposes of representing generators and relations 
+      of the presentation object and building a new fp semigroup from the
+      object,
+      the strings that the generators should appear as are stored.
+
+      <P/>
+
+      As Tietze transformations are performed on <A>stz</A>, the generators
+      will change, but the labels will remain as close to the original labels 
+      as possible, so that if a generator in the fp semigroup obtained from 
+      the presentation is the same as a generator in the original fp semigroup,
+      then they should have the same label.
+      
+
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(T);
+<fp semigroup presentation with 3 generators and 2 relations
+ with length 19>
+gap> GeneratorsOfStzPresentation(stz);
+[ "a", "b", "c" ]]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="RelationsOfStzPresentation">
+  <ManSection>
+    <Attr Name="RelationsOfStzPresentation" Arg="stz"/>
+    <Returns>
+      A list of pairs of words in LetterRep
+      (<Ref Oper="LetterRepAssocWord" BookName="ref"/>)
+      form.
+    </Returns>
+    <Description>
+      If <A>stz</A> is an StzPresentation object then
+      <C>RelationsOfStzPresentation</C> will return in letter rep form the 
+      current relations of the presentation object. When the presentation object
+      is first created, these will be the LetterRep forms of the relations of 
+      the fp semigroup object that is used to create <A>stz</A>. As Tietze 
+      transformations are performed on the presentation object, the relations 
+      returned by this function will change to reflect the transformations.
+      
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(T);
+<fp semigroup presentation with 3 generators and 2 relations
+ with length 19>
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 1 ], [ 2, 2, 2, 2, 2, 3 ] ], 
+  [ [ 2, 2, 2, 2, 2, 2 ], [ 2, 2, 2 ] ] ]]]>
+</Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="UnreducedSemigroupOfStzPresentation">
+  <ManSection>
+    <Attr Name="UnreducedSemigroupOfStzPresentation" Arg="stz"/>
+    <Returns>
+      An fp semigroup.
+    </Returns>
+    <Description>
+      If <A>stz</A> is an StzPresentation object then
+      <C>UnreducedSemigroupOfStzPresentation</C> will return the fp semigroup 
+      that was used to create <A>stz</A> using <Ref Oper="StzPresentation"/>.
+      
+
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(T);
+<fp semigroup presentation with 3 generators and 2 relations
+ with length 19>
+gap> UnreducedSemigroupOfStzPresentation(stz) = T;
+true]]>
+</Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="StzAddRelation">
+  <ManSection>
+    <Oper Name="StzAddRelation" Arg="stz, pair"/>
+    <Description>
+      If <A>stz</A> is an StzPresentation object and <A>pair</A> is a list
+      containing two LetterRep words over the generators of <A>stz</A>, then
+      <C>StzAddRelation</C> will perform a Tietze transformation of the first 
+      type and add a new relation to <A>stz</A>. This only happens if the
+      new relation that would 
+      be formed from <A>pair</A> can be constructed from the other existing
+      relations; that is, if we can perform elementary operations using the 
+      existing relations of <A>stz</A> to convert <C><A>pair</A>[1]</C> into
+      <C><A>pair</A>[2]</C>.
+
+      <P/>
+
+      If, instead, <A>pair</A> is a list containing two elements of the fp 
+      semigroup <A>S</A> that was used to create <A>stz</A>, and the two words
+      are equal in that semigroup, then this function
+      will add the LetterRep of these words as a new relation to <A>stz</A>.
+
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(T);
+<fp semigroup presentation with 3 generators and 2 relations
+ with length 19>
+gap> pair := [[2, 2, 2, 2, 2, 2, 2, 2, 2], [2, 2, 2]];;
+gap> StzAddRelation(stz, pair);
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 1 ], [ 2, 2, 2, 2, 2, 3 ] ], 
+  [ [ 2, 2, 2, 2, 2, 2 ], [ 2, 2, 2 ] ], 
+  [ [ 2, 2, 2, 2, 2, 2, 2, 2, 2 ], [ 2, 2, 2 ] ] ]
+gap> pair2 := [[1, 1], [3]];
+[ [ 1, 1 ], [ 3 ] ]
+gap> StzAddRelation(stz, pair2);
+Error, StzAddRelation: second argument <pair> must list two
+words that are equal in the presentation <stz>]]>
+</Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="StzAddRelationNC">
+  <ManSection>
+    <Oper Name="StzAddRelationNC" Arg="stz, pair"/>
+    <Description>
+      If <A>stz</A> is an StzPresentation object and <A>pair</A> is a list
+      containing two LetterRep words over the generators of <A>stz</A>, then
+      <C>StzAddRelationNC</C> will add <A>pair</A> to the relations of
+      <A>stz</A>. No checks are performed, so it may be that the derived
+      semigroup of <A>stz</A> is no longer isomorphic to its unreduced semigroup
+      (see <Ref Oper="UnreducedSemigroupOfStzPresentation"/>). <E>This should be 
+      used only at the user's own risk</E>.
+
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(T);
+<fp semigroup presentation with 3 generators and 2 relations
+ with length 19>
+gap> pair := [[1, 1], [3]];
+[ [ 1, 1 ], [ 3 ] ]
+gap> StzAddRelationNC(stz, pair);
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 1 ], [ 2, 2, 2, 2, 2, 3 ] ], 
+  [ [ 2, 2, 2, 2, 2, 2 ], [ 2, 2, 2 ] ], [ [ 1, 1 ], [ 3 ] ] ]]]>
+</Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="StzRemoveRelation">
+  <ManSection>
+    <Oper Name="StzRemoveRelation" Arg="stz, index"/>
+    <Description>
+      If <A>stz</A> is an StzPresentation object and <A>index</A> is a positive
+      integer less than or equal to the number of relations of <A>stz</A>, then
+      <C>StzRemoveRelation</C> will perform a Tietze transformation of the
+      second type and remove the <A>index</A>th relation of <A>stz</A> if that
+      relation is such that one side of it can be obtained from the other by a 
+      sequence of elementary operations using only the other relations of
+      <A>stz</A>.
+
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3], [F.2 ^ 2, F.2]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(T);
+<fp semigroup presentation with 3 generators and 3 relations
+ with length 22>
+gap> StzRemoveRelation(stz, 2);
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 1 ], [ 2, 2, 2, 2, 2, 3 ] ], [ [ 2, 2 ], [ 2 ] ] ]
+gap> StzRemoveRelation(stz, 2);
+Error, StzRemoveRelation: second argument <index> must point to
+a relation that is redundant in the presentation <stz>]]>
+</Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="StzRemoveRelationNC">
+  <ManSection>
+    <Oper Name="StzRemoveRelationNC" Arg="stz, index"/>
+    <Description>
+      If <A>stz</A> is an StzPresentation object and <A>index</A> is a positive
+      integer less than or equal to the number of relations of <A>stz</A>, then
+      <C>StzRemoveRelation</C> will remove the <A>index</A>th relation from
+      <A>stz</A>. No checks are performed, so it may be that the derived
+      semigroup of <A>stz</A> is no longer isomorphic to its unreduced semigroup
+      (see <Ref Oper="UnreducedSemigroupOfStzPresentation"/>). <E>This should be 
+      used only at the user's own risk</E>.
+
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3], [F.2 ^ 2, F.2]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(T);
+<fp semigroup presentation with 3 generators and 3 relations
+ with length 22>
+gap> StzRemoveRelationNC(stz, 1);
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 2, 2, 2, 2, 2, 2 ], [ 2, 2, 2 ] ], [ [ 2, 2 ], [ 2 ] ] ]
+]]>
+</Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="StzAddGenerator">
+  <ManSection>
+    <Oper Name="StzAddGenerator" Arg="stz, word[, name]"/>
+    <Description>
+      If <A>stz</A> is an StzPresentation object and <A>word</A> is a
+      LetterRep word over the generators of <A>stz</A>, then
+      <C>StzAddGenerator</C> will perform a Tietze transformation of the third 
+      type and add a new generator to <A>stz</A> and a new relation of the form 
+      <C>newgenerator = <A>word</A></C>.
+
+      <P/>
+
+      If, instead, <A>word</A> is a word over the fp semigroup <A>S</A> that was
+      used to create <A>stz</A>, then this function will add the new generator
+      and a new relation with the new generator equal to the LetterRep of this
+      word as a new relation to <A>stz</A>.
+
+      <P/>
+
+      A new name for the generator is chosen and added automatically based on
+      the names of the existing generators to 
+      <Ref Oper="GeneratorsOfStzPresentation"/> if the argument <A>name</A> is 
+      not included. If it is, and if <A>name</A> is a string that is not equal
+      to an existing generator, then the string added to the list of generators
+      will be <A>name</A> instead.
+
+      <P/>
+
+      There is no NC version of this function needed as there are no special
+      conditions that the input must fulfill in order to maintain the structure
+      of the semigroup derived from <A>stz</A>.
+
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3], [F.2 ^ 2, F.2]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(T);
+<fp semigroup presentation with 3 generators and 3 relations
+ with length 22>
+gap> StzAddGenerator(stz, [2, 2, 2]);
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 1 ], [ 2, 2, 2, 2, 2, 3 ] ], 
+  [ [ 2, 2, 2, 2, 2, 2 ], [ 2, 2, 2 ] ], [ [ 2, 2 ], [ 2 ] ], 
+  [ [ 2, 2, 2 ], [ 4 ] ] ]]]>
+</Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="StzRemoveGenerator">
+  <ManSection>
+    <Oper Name="StzRemoveGenerator" Arg="stz, gen/genname[, index]"/>
+    <Description>
+      If <A>stz</A> is an StzPresentation object and <A>gen</A> is a positive
+      integer less than or equal to the number of generators of <A>stz</A>, then
+      <C>StzRemoveGenerator</C> will perform a Tietze transformation of the
+      fourth type and remove the <A>gen</A>th generator of <A>stz</A> if there 
+      exists a relation of <A>stz</A> such that one side of the relation is only
+      <A>gen</A> and the other side is a word that does not contain <A>gen</A>,
+      in which case that relation is also removed and all instances of
+      <A>gen</A> in other relations is replaced by the aforementioned word.
+
+      <P/>
+
+      If instead the argument is a string <A>genname</A> rather than a positive 
+      integer <A>gen</A>, then the function searches the generators of
+      <A>stz</A> for a generator with the same name and attempts to remove the 
+      generator if the same conditions as above are met.
+
+      <P/>
+
+      If the argument <A>index</A> is included and is a positive integer less 
+      than or equal to the number of relations, then rather than searching the 
+      relations for the first to satisfy the necessary conditions, the function 
+      checks the <A>index</A>th relation to see if it satisfies those
+      conditions, and applies the Tietze transformation by removing this
+      relation.<P/>
+
+      There is no NC version of this function since there is no predictable way
+      to remove a generator if it does not fulfill the conditions above.
+
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3], [F.2 ^ 2, F.2]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(T);
+<fp semigroup presentation with 3 generators and 3 relations
+ with length 22>
+gap> StzRemoveGenerator(stz, 1);
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 1, 1, 1, 1, 1, 1 ], [ 1, 1, 1 ] ], [ [ 1, 1 ], [ 1 ] ] ]]]>
+</Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="StzSubstituteRelation">
+  <ManSection>
+    <Oper Name="StzSubstituteRelation" Arg="stz, index, side"/>
+    <Description>
+      If <A>stz</A> is an StzPresentation object and <A>index</A> is a positive
+      integer less than or equal to the number of relations of <A>stz</A> and 
+      <A>side</A> is either 1 or 2, then
+      <C>StzRemoveGenerator</C> will perform a sequence of Tietze
+      transformations in order to replace, for the <A>index</A>th relation
+      (say <C>[u, v]</C>), to replace all instances of the <A>side</A>th word of
+      the relation in all other relations by the other side (so, for
+      <C><A>side</A>=1</C>, all instances of <C>u</C> in all other relations of
+      <A>stz</A> are replaced by <C>v</C>). This requires two Tietze
+      transformations per relation containing <C>u</C>, one to add a new 
+      redundant relation with each <C>u</C> replaced by <C>v</C>, and another 
+      to remove the original (now redundant) relation.
+
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3], [F.2 ^ 2, F.2]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(T);
+<fp semigroup presentation with 3 generators and 3 relations
+ with length 22>
+gap> StzSubstituteRelation(stz, 3, 1);
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 1 ], [ 2, 2, 2, 3 ] ], [ [ 2, 2, 2 ], [ 2, 2 ] ], 
+  [ [ 2, 2 ], [ 2 ] ] ]
+gap> StzSubstituteRelation(stz, 3, 1);
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 1 ], [ 2, 2, 3 ] ], [ [ 2, 2 ], [ 2 ] ], [ [ 2, 2 ], [ 2 ] ] ]]]>
+</Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="Length">
+  <ManSection>
+    <Oper Name="Length" Arg="stz"/>
+    <Returns>
+      A non-negative integer.
+    </Returns>
+    <Description>
+      If <A>stz</A> is an <C>IsStzPresentation</C> object, then the
+      <C>Length</C> of the 
+      object is defined as the number of generators plus the lengths of each 
+      word in each relation of the relations of <A>stz</A>.
+
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3], [F.2 ^ 2, F.2]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(T);
+<fp semigroup presentation with 3 generators and 3 relations
+ with length 22>
+gap> Length(stz);
+22]]>
+</Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="StzPrintRelation">
+  <ManSection>
+    <Oper Name="StzPrintRelation" Arg="stz, int"/>
+    <Description>
+      If <A>stz</A> is an StzPresentation object, then <C>StzPrintRelation</C>
+      calls <C>StzPrintRelations</C> with parameters <A>stz</A> and
+      <C>[<A>int</A>]</C>.
+
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3], [F.2 ^ 2, F.2]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(T);
+<fp semigroup presentation with 3 generators and 3 relations
+ with length 22>
+gap> StzPrintRelation(stz, 2);
+#I  2. b^6 = b^3]]>
+</Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="StzPrintRelations">
+  <ManSection>
+    <Oper Name="StzPrintRelations" Arg="stz[, list]"/>
+    <Description>
+      If <A>stz</A> is an StzPresentation object, and if <A>list</A> is a list 
+      of positive integers,
+      then <C>StzPrintRelations</C> prints for each <A>i</A> in
+      <A>list</A> the <A>i</A>th relation to the console in terms of the stored 
+      labels for the generators (that is, as words over the alphabet consisting
+      of the generators of <A>stz</A>).<P/>
+
+      If <A>list</A> is not specified then <C>StzPrintRelations</C> prints all 
+      relations of <A>stz</A> in order.
+
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3], [F.2 ^ 2, F.2]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(T);
+<fp semigroup presentation with 3 generators and 3 relations
+ with length 22>
+gap> StzPrintRelations(stz, [2, 3]);
+#I  2. b^6 = b^3
+#I  3. b^2 = b
+gap> StzPrintRelations(stz);
+#I  1. a = b^5*c
+#I  2. b^6 = b^3
+#I  3. b^2 = b]]>
+</Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="StzPrintGenerators">
+  <ManSection>
+    <Oper Name="StzPrintGenerators" Arg="stz[, list]"/>
+    <Description>
+      If <A>stz</A> is an StzPresentation object, and if <A>list</A> is a list 
+      of positive integers,
+      then <C>StzPrintGenerators</C> for each <A>i</A> in
+      <A>list</A> the <A>i</A>th generator and the number of occurrences of that
+      generator in the relations is printed to the screen.<P/>
+
+      If <A>list</A> is not specified then <C>StzPrintGenerators</C> prints all 
+      generators of <A>stz</A> in order.
+
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3], [F.2 ^ 2, F.2]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(T);
+<fp semigroup presentation with 3 generators and 3 relations
+ with length 22>
+gap> StzPrintGenerators(stz, [1, 2]);
+#I  1.  a  1 occurrences
+#I  2.  b  17 occurrences
+gap> StzPrintGenerators(stz);
+#I  1.  a  1 occurrences
+#I  2.  b  17 occurrences
+#I  3.  c  1 occurrences]]>
+</Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="StzPrintPresentation">
+  <ManSection>
+    <Oper Name="StzPrintPresentation" Arg="stz"/>
+    <Description>
+      If <A>stz</A> is an StzPresentation object then
+      <C>StzPrintPresentation</C> prints a comprehensive overview of <A>stz</A>,
+      including the generators and number of occurrences of each generator in
+      the relations, the relations as words over the generators, and the forward
+      and backward maps that indicate how the unreduced semigroup maps to the 
+      semigroup currently described by <A>stz</A>.
+
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> T := F / [[F.1, F.2 ^ 5 * F.3],
+>              [F.2 ^ 6, F.2 ^ 3], [F.2 ^ 2, F.2]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(T);
+<fp semigroup presentation with 3 generators and 3 relations
+ with length 22>
+gap> StzPrintPresentation(stz);
+#I  Current generators:
+#I  1.  a  1 occurrences
+#I  2.  b  17 occurrences
+#I  3.  c  1 occurrences
+#I  
+#I  Current relations:
+#I  1. a = b^5*c
+#I  2. b^6 = b^3
+#I  3. b^2 = b
+#I  
+#I  There are 3 generators and 3 relations of total length 22.
+#I  
+#I  Generators of original fp semigroup expressed as
+#I  combinations of generators in current presentation:
+#I  1. a = a
+#I  2. b = b
+#I  3. c = c
+#I  
+#I  Generators of current presentation expressed as
+#I  combinations of generators of original fp semigroup:
+#I  1. a = a
+#I  2. b = b
+#I  3. c = c]]>
+</Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="TietzeForwardMap">
+  <ManSection>
+    <Attr Name="TietzeForwardMap" Arg="stz"/>
+    <Returns>
+      A list of lists of positive integers.
+    </Returns>
+    <Description>
+      If <A>stz</A> is an StzPresentation object then
+      <C>TietzeForwardMap</C> returns a list of lists of positive integers.
+      There is an element of this list for every generator of the 
+      unreduced semigroup of the presentation (see 
+      <Ref Attr="UnreducedSemigroupOfStzPresentation"/>) that indicates the 
+      word (in LetterRep form) in the semigroup object currently defined by the
+      presentation that the generator maps to.<P/>
+
+      This mapping is updated as the presentation object is transformed. It 
+      begins as a list of the form <C>[[1], [2], [3], . . ., [n]]</C> where
+      <C>n</C> is the number of generators of the unreduced semigroup.
+      
+
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> S := F / [[F.1, F.3 ^ 3], [F.2 ^ 2, F.3 ^ 2]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(S);
+<fp semigroup presentation with 3 generators and 2 relations
+ with length 11>
+gap> StzRemoveGenerator(stz, 1);
+gap> TietzeForwardMap(stz);
+[ [ 2, 2, 2 ], [ 1 ], [ 2 ] ]]]>
+</Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="TietzeBackwardMap">
+  <ManSection>
+    <Attr Name="TietzeBackwardMap" Arg="stz"/>
+    <Returns>
+      A list of lists of positive integers.
+    </Returns>
+    <Description>
+      If <A>stz</A> is an StzPresentation object then
+      <C>TietzeBackwardMap</C> returns a list of lists of positive integers.
+      There is an element of this list for every generator of the 
+      semigroup that the presentation currently defines that indicates the 
+      word (in LetterRep form) in the unreduced semigroup of the presentation 
+      (see <Ref Attr="UnreducedSemigroupOfStzPresentation"/>) that the 
+      generator maps to.<P/>
+
+      This mapping is updated as the presentation object is transformed. It 
+      begins as a list of the form <C>[[1], [2], [3], . . ., [n]]</C> where
+      <C>n</C> is the number of generators of the unreduced semigroup.
+      
+
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> S := F / [[F.1, F.3 ^ 3], [F.2 ^ 2, F.3 ^ 2]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(S);
+<fp semigroup presentation with 3 generators and 2 relations
+ with length 11>
+gap> StzRemoveGenerator(stz, 1);
+gap> TietzeBackwardMap(stz);
+[ [ 2 ], [ 3 ] ]]]>
+</Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="TietzeIsomorphism">
+  <ManSection>
+    <Oper Name="TietzeIsomorphism" Arg="stz"/>
+    <Returns>
+      A mapping object.
+    </Returns>
+    <Description>
+      If <A>stz</A> is an StzPresentation object then
+      <C>TietzeIsomorphism</C> returns a mapping object that maps the 
+      unreduced semigroup of the presentation (see
+      <Ref Attr="UnreducedSemigroupOfStzPresentation"/>)
+      to an FpSemigroup object that is defined by the generators and relations 
+      of the semigroup presentation at the moment this function is ran.<P/>
+
+      It is important to note that this mapping is specific to the presentation
+      when it is ran - if the presentation is altered further then the mapping 
+      no longer applies to the presentation and must be created again by running
+      this function.<P/>
+
+      This mapping is built from the <Ref Attr="TietzeForwardMap"/> and 
+      <Ref Attr="TietzeBackwardMap"/> attributes from the presentation object,
+      since if we know how to map the generators of the respective semigroups
+      then we know how to map any element of that semigroup.<P/>
+
+      This function is the primary way to obtain the simplified semigroup from 
+      the presentation object, by applying <C>Range</C> to the mapping that this
+      function returns.
+      
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> S := F / [[F.1, F.3 ^ 3], [F.2 ^ 2, F.3 ^ 2]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(S);
+<fp semigroup presentation with 3 generators and 2 relations
+ with length 11>
+gap> StzRemoveGenerator(stz, "a");
+gap> map := TietzeIsomorphism(stz);
+MappingByFunction( <fp semigroup on the generators 
+[ a, b, c ]>, <fp semigroup on the generators 
+[ b, c ]>, function( word ) ... end, function( word ) ... end )
+gap> S.1 ^ map;
+c^3]]>
+</Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>

--- a/doc/tietze.xml
+++ b/doc/tietze.xml
@@ -916,24 +916,24 @@ gap> TietzeBackwardMap(stz);
   </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="TietzeIsomorphism">
+<#GAPDoc Label="StzIsomorphism">
   <ManSection>
-    <Oper Name="TietzeIsomorphism" Arg="stz"/>
+    <Oper Name="StzIsomorphism" Arg="stz"/>
     <Returns>
       A mapping object.
     </Returns>
     <Description>
       If <A>stz</A> is an <Ref Oper="StzPresentation"/> object, then
-      <C>TietzeIsomorphism</C> returns a mapping object that maps the 
+      <C>StzIsomorphism</C> returns a mapping object that maps the 
       unreduced semigroup of the presentation (see
       <Ref Attr="UnreducedFpSemigroup" Label="for a presentation"/>)
       to an FpSemigroup object that is defined by the generators and relations 
       of the semigroup presentation at the moment this function is ran.<P/>
 
-      If a <C>TietzeIsomorphism</C> is generated from <A>stz</A>, and the
+      If a <C>StzIsomorphism</C> is generated from <A>stz</A>, and the
       presentation <A>stz</A> is further modified afterwards (for example by
       applying more Tietze transformations or <Ref Oper="StzSimplifyOnce"/> to
-      <A>stz</A>), then running <C>TietzeIsomorphism(<A>stz</A>)</C> a second
+      <A>stz</A>), then running <C>StzIsomorphism(<A>stz</A>)</C> a second
       time will produce a different result consistent with the <E>new</E>
       generators and relations of <A>stz</A>.<P/>
 
@@ -955,7 +955,7 @@ gap> stz := StzPresentation(S);
 <fp semigroup presentation with 3 generators and 2 relations
  with length 11>
 gap> StzRemoveGenerator(stz, "a");
-gap> map := TietzeIsomorphism(stz);
+gap> map := StzIsomorphism(stz);
 MappingByFunction( <fp semigroup on the generators 
 [ a, b, c ]>, <fp semigroup on the generators 
 [ b, c ]>, function( word ) ... end, function( word ) ... end )

--- a/doc/tietze.xml
+++ b/doc/tietze.xml
@@ -267,9 +267,9 @@ gap> RelationsOfStzPresentation(stz);
   </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="UnreducedFpSemigroupOfFpSemigroup">
+<#GAPDoc Label="UnreducedFpSemigroup-S">
   <ManSection>
-    <Attr Name="UnreducedFpSemigroupOfFpSemigroup" Arg="S"/>
+    <Attr Name="UnreducedFpSemigroup" Arg="S" Label="for a semigroup"/>
     <Returns>
       <A>T</A>, an fp semigroup object.
     </Returns>
@@ -278,7 +278,7 @@ gap> RelationsOfStzPresentation(stz);
       calling
       <Ref Oper="SimplifiedFpSemigroup"/>
       on some fp semigroup <A>T</A>
-      then <C>UnreducedFpSemigroupOfFpSemigroup</C> returns the original
+      then <C>UnreducedFpSemigroup</C> returns the original
       semigroup object before simplification. These are unrelated semigroup 
       objects, except that <A>S</A> will have a
       <Ref Oper="FpTietzeIsomorphism"/>
@@ -287,7 +287,7 @@ gap> RelationsOfStzPresentation(stz);
 
       If <Ref Oper="SimplifyFpSemigroup"/>
       has been called on an fp semigroup <A>T</A>,
-      then <C>UnreducedFpSemigroupOfFpSemigroup</C> can be used on the
+      then <C>UnreducedFpSemigroup</C> can be used on the
       <C>Range</C> of the resultant mapping to obtain the domain.
       <Log><![CDATA[
 gap> F := FreeSemigroup("a", "b", "c");
@@ -305,7 +305,7 @@ gap> S := SimplifiedFpSemigroup(T);
 #I  <Creating new generator to replace instances of word: b^3>
 #I  Current: <fp semigroup presentation with 3 generators and 2 relations with length 10>
 <fp semigroup on the generators [ b, c, d ]>
-gap> UnreducedFpSemigroupOfFpSemigroup(S) = T;
+gap> UnreducedFpSemigroup(S) = T;
 true]]></Log>
     </Description>
   </ManSection>
@@ -430,15 +430,15 @@ gap> RelationsOfStzPresentation(stz);
   </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="UnreducedSemigroupOfStzPresentation">
+<#GAPDoc Label="UnreducedFpSemigroup-stz">
   <ManSection>
-    <Attr Name="UnreducedSemigroupOfStzPresentation" Arg="stz"/>
+    <Attr Name="UnreducedFpSemigroup" Arg="stz" Label="for a presentation"/>
     <Returns>
       An fp semigroup.
     </Returns>
     <Description>
       If <A>stz</A> is an <Ref Oper="StzPresentation"/> object, then
-      <C>UnreducedSemigroupOfStzPresentation</C> will return the fp semigroup 
+      <C>UnreducedFpSemigroup</C> will return the fp semigroup 
       that was used to create <A>stz</A> using <Ref Oper="StzPresentation"/>.
       
 
@@ -451,7 +451,7 @@ gap> T := F / [[F.1, F.2 ^ 5 * F.3],
 gap> stz := StzPresentation(T);
 <fp semigroup presentation with 3 generators and 2 relations
  with length 19>
-gap> UnreducedSemigroupOfStzPresentation(stz) = T;
+gap> UnreducedFpSemigroup(stz) = T;
 true]]>
 </Example>
     </Description>
@@ -852,7 +852,8 @@ gap> StzPrintPresentation(stz);
       <C>TietzeForwardMap</C> returns a list of lists of positive integers.
       There is an element of this list for every generator of the 
       unreduced semigroup of the presentation (see 
-      <Ref Attr="UnreducedSemigroupOfStzPresentation"/>) that indicates the 
+      <Ref Attr="UnreducedFpSemigroup" Label="for a presentation"/>)
+      that indicates the 
       word (in <C>LetterRep</C> form) in the semigroup object currently defined
       by the
       presentation that the generator maps to.<P/>
@@ -891,8 +892,8 @@ gap> TietzeForwardMap(stz);
       semigroup that the presentation currently defines that indicates the 
       word (in <C>LetterRep</C> form) in the unreduced semigroup of the
       presentation 
-      (see <Ref Attr="UnreducedSemigroupOfStzPresentation"/>) that the 
-      generator maps to.<P/>
+      (see <Ref Attr="UnreducedFpSemigroup" Label="for a presentation"/>)
+      that the generator maps to.<P/>
 
       This mapping is updated as the presentation object is transformed. It 
       begins as a list of the form <C>[[1], [2], [3], . . ., [n]]</C> where
@@ -925,7 +926,7 @@ gap> TietzeBackwardMap(stz);
       If <A>stz</A> is an <Ref Oper="StzPresentation"/> object, then
       <C>TietzeIsomorphism</C> returns a mapping object that maps the 
       unreduced semigroup of the presentation (see
-      <Ref Attr="UnreducedSemigroupOfStzPresentation"/>)
+      <Ref Attr="UnreducedFpSemigroup" Label="for a presentation"/>)
       to an FpSemigroup object that is defined by the generators and relations 
       of the semigroup presentation at the moment this function is ran.<P/>
 

--- a/doc/tietze.xml
+++ b/doc/tietze.xml
@@ -11,15 +11,24 @@
 
 <#GAPDoc Label="StzPresentation">
   <ManSection>
-    <Oper Name="StzPresentation" Arg="s"/>
+    <Oper Name="StzPresentation" Arg="S"/>
     <Returns>
-      A Semigroup Tietze (Stz) object.
+      A semigroup Tietze (Stz) object.
     </Returns>
     <Description>
-      If <A>s</A> is a fp semigroup
+      If <A>s</A> is an fp semigroup
       (<Ref Filt="IsFpSemigroup" BookName="ref"/>),
       then this function returns a modifiable object representing the generators
       and relations of <A>s</A>.
+
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");;
+gap> AssignGeneratorVariables(F);;
+gap> S := F / [[a * b, c], [b * c, a], [c * a, b]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(S);
+<fp semigroup presentation with 3 generators and 3 relations
+ with length 12>]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -34,12 +43,11 @@
       Every semigroup Tietze object is an element of the category
       <C>IsStzPresentation</C>. Internally, each Stz object contains a list
       of generators (each represented as a string) and a list of relations
-      (each represented as a pair of LetterRep words, see
+      (each represented as a pair of <C>LetterRep</C> words, see
       <Ref Oper="LetterRepAssocWord" BookName="ref"/>).
       These generator and relation lists can be modified using Tietze
       transformations
       (<Ref Sect="Changing presentations"/>).
-
       <P/>
 
       When a <C>IsStzPresentation</C> object <A>stz</A> is created from an fp
@@ -49,6 +57,17 @@
       these lists may change, and their current state can be viewed using
       <Ref Oper="GeneratorsOfStzPresentation"/> and
       <Ref Oper="RelationsOfStzPresentation"/>.
+      
+      <Example><![CDATA[
+gap> F := FreeSemigroup("a", "b", "c");;
+gap> AssignGeneratorVariables(F);;
+gap> S := F / [[a * b, c], [b * c, a], [c * a, b]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(S);
+<fp semigroup presentation with 3 generators and 3 relations
+ with length 12>
+gap> IsStzPresentation(stz);
+true]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -57,10 +76,12 @@
   <ManSection>
     <Oper Name="SimplifiedFpSemigroup" Arg="S"/>
     <Returns>
-      <A>T</A>, an FpSemigroup object.
+      A finitely presented semigroup.
     </Returns>
     <Description>
-      If <A>S</A> is an FpSemigroup object, then <C>SimplifiedFpSemigroup</C> 
+      If <A>S</A> is an fp semigroup object
+      (<Ref Filt="IsFpSemigroup" BookName="ref"/>),
+      then <C>SimplifiedFpSemigroup</C> 
       will return an FpSemigroup object <A>T</A> which is isomorphic to <A>S</A>
       which has been reduced to minimise its length.
 
@@ -74,7 +95,7 @@
 
       For more information on the mapping between the semigroups and how it is 
       created, see
-      <Ref Oper="Converting a modified presentation into a semigroup"/>.
+      <Ref Sect="Converting a modified presentation into a semigroup"/>.
 
       <Log><![CDATA[
 gap> F := FreeSemigroup("a", "b", "c");;
@@ -117,8 +138,10 @@ false]]></Log>
       A mapping object.
     </Returns>
     <Description>
-      If <A>S</A> is an FpSemigroup object, then <C>SimplifyFpSemigroup</C> 
-      will return a mapping object which will map <A>S</A> to an FpSemigroup
+      If <A>S</A> is a finitely presented semigroup, then
+      <C>SimplifyFpSemigroup</C> 
+      will return a mapping object which will map <A>S</A> to a finitely
+      presented semigroup
       which has had its presentation simplified.
 
       <C>SimplifyFpSemigroup</C> creates an <C>StzPresentation</C> object
@@ -131,7 +154,7 @@ false]]></Log>
       to <A>stz</A>, which repeatedly checks
       whether a number of different possible transformations will cause a
       reduction in length, and if so applies the best one. This loop continues
-      until no transformations cause any possible reductions, in which case
+      until no transformations cause any reductions, in which case
       the mapping is returned. The newly reduced FpSemigroup can be accessed
       either by taking the range of the mapping or calling
       <C>SimplifiedFpSemigroup</C>, which first runs <C>SimplifyFpSemigroup</C>
@@ -139,7 +162,7 @@ false]]></Log>
       attribute.<P/>
 
       For more information on how the mapping is created and used, go to
-      <Ref Oper="Converting a modified presentation into a semigroup"/>.
+      <Ref Sect="Converting a modified presentation into a semigroup"/>.
 
       <Log><![CDATA[
 gap> F := FreeSemigroup("a", "b", "c");
@@ -175,32 +198,29 @@ gap> RelationsOfFpSemigroup(Range(map));
       <K>true</K> or <K>false</K>.
     </Returns>
     <Description>
-      If <A>stz</A> is an StzPresentation object, then
+      If <A>stz</A> is an <Ref Oper="StzPresentation"/> object, then
       <C>StzSimplifyOnce</C> will check the possible reductions in length for a
       number of different possible Tietze transformations, and apply the choice 
       which gives the least length. If a valid transformation was found then the 
       function returns <K>true</K>, and if no transformation was performed
-      because none would not lead to a reduction in length, then the function
+      because none would lead to a reduction in length, then the function
       returns <K>false</K>.<P/>
 
       There are four different possible transformations that
       <C>StzSimplifyOnce</C> may apply. The function searches for redundant 
-      generators and checks if removing them would give a lesser length, it 
+      generators and checks if removing them would reduce the overall length
+      of the presentation, it 
       checks whether substituting one side of each relation throughout the rest 
-      of the relations would give a lesser length, it checks whether there are 
+      of the relations would reduce the length, it checks whether there are 
       any trivial relations (of the form <A>w = w</A> for some word <A>w</A>)
       or any duplicated relations (relations which are formed from precisely the
       same words as another relation), and it checks whether any frequently
       occurring subwords in the relations can be replaced with a new generator 
-      to produce a lesser length. For more details, see
-      <Ref Oper="Changing presentations"/><P/>
-
-      It is simple to add a new check that <C>StzSimplifyOnce</C> can apply.
-      More details are found where the function is 
-      defined in <M>gap/fp/tietze.gi</M>.<P/>
+      to reduce the length. For more details, see
+      <Ref Sect="Changing presentations"/><P/>
 
       At <C>InfoLevel</C> 2 (which is the default value, and which can be set
-      using <C>SetInfoLevel(InfoFpSemigroup, 2)</C>, the precise transformations
+      using <C>SetInfoLevel(InfoFpSemigroup, 2)</C>), the precise transformations
       performed are printed to the screen.
 
       <Example><![CDATA[
@@ -226,16 +246,11 @@ gap> stz;
   <ManSection>
     <Oper Name="StzSimplifyPresentation" Arg="stz"/>
     <Description>
-      If <A>stz</A> is an StzPresentation object, then
-      <C>StzSimplifyOnce</C> will repeatedly apply the best of a few possible 
-      reductions to <A>stz</A> until the reductions no longer lessen the legnth 
+      If <A>stz</A> is an <C>StzPresentation</C> object, then
+      <C>StzSimplifyPresentation</C> will repeatedly apply the best of a few
+      possible
+      reductions to <A>stz</A> until it can no longer reduce the length
       of the presentation.<P/>
-
-      <C>StzSimplifyPresentation</C> will repeatedly apply the function
-      <C>StzSimplifyOnce</C> to the presentation until
-      <C>StzSimplifyOnce</C> fails to find a transformation which can reduce the
-      length of <A>stz</A>.
-
       <Log><![CDATA[
 gap> F := FreeSemigroup("a", "b", "c");
 <free semigroup on the generators [ a, b, c ]>
@@ -265,7 +280,7 @@ gap> RelationsOfStzPresentation(stz);
       on some fp semigroup <A>T</A>
       then <C>UnreducedFpSemigroupOfFpSemigroup</C> returns the original
       semigroup object before simplification. These are unrelated semigroup 
-      objects, except for that <A>S</A> will have a
+      objects, except that <A>S</A> will have a
       <Ref Oper="FpTietzeIsomorphism"/>
       attribute that returns an isomorphic mapping from <A>T</A> to <A>S</A>.
       <P/>
@@ -305,8 +320,8 @@ true]]></Log>
     <Description>
       If <A>S</A> is an fp semigroup object that has been obtained through
       calling <Ref Oper="SimplifiedFpSemigroup"/>
-      on some fp semigroup <A>T</A>
-      then <C>FpTietzeIsomorphism</C> returns an isomorphic mapping from
+      on some fp semigroup <A>T</A>,
+      then <C>FpTietzeIsomorphism</C> returns an isomorphism from
       <A>T</A> to <A>S</A>. Simplification produces an fp semigroup isomorphic 
       to the original fp semigroup, and these two fp semigroup objects can 
       interact with each other through the mapping given by this function.
@@ -346,14 +361,15 @@ true]]></Log>
       A list of strings.
     </Returns>
     <Description>
-      If <A>stz</A> is an StzPresentation object, then
-      <C>GeneratorsOfStzPresentation</C> will return as strings the generators
+      If <A>stz</A> is an <Ref Oper="StzPresentation"/> object, then
+      <C>GeneratorsOfStzPresentation</C> will return (as strings) the generators
       of the fp semigroup that the presentation was created from. In the 
-      StzPresentation object it is only necessary to know how many generators
+      <Ref Oper="StzPresentation"/> object, it is only necessary to know how
+      many generators
       there are, but for the purposes of representing generators and relations 
       of the presentation object and building a new fp semigroup from the
       object,
-      the strings that the generators should appear as are stored.
+      the strings representing the generators are stored.
 
       <P/>
 
@@ -383,15 +399,16 @@ gap> GeneratorsOfStzPresentation(stz);
   <ManSection>
     <Attr Name="RelationsOfStzPresentation" Arg="stz"/>
     <Returns>
-      A list of pairs of words in LetterRep
+      A list of pairs of words in <C>LetterRep</C>
       (<Ref Oper="LetterRepAssocWord" BookName="ref"/>)
       form.
     </Returns>
     <Description>
-      If <A>stz</A> is an StzPresentation object then
+      If <A>stz</A> is an <Ref Oper="StzPresentation"/> object, then
       <C>RelationsOfStzPresentation</C> will return in letter rep form the 
       current relations of the presentation object. When the presentation object
-      is first created, these will be the LetterRep forms of the relations of 
+      is first created, these will be the <C>LetterRep</C> forms of the relations
+      of 
       the fp semigroup object that is used to create <A>stz</A>. As Tietze 
       transformations are performed on the presentation object, the relations 
       returned by this function will change to reflect the transformations.
@@ -420,7 +437,7 @@ gap> RelationsOfStzPresentation(stz);
       An fp semigroup.
     </Returns>
     <Description>
-      If <A>stz</A> is an StzPresentation object then
+      If <A>stz</A> is an <Ref Oper="StzPresentation"/> object, then
       <C>UnreducedSemigroupOfStzPresentation</C> will return the fp semigroup 
       that was used to create <A>stz</A> using <Ref Oper="StzPresentation"/>.
       
@@ -445,8 +462,10 @@ true]]>
   <ManSection>
     <Oper Name="StzAddRelation" Arg="stz, pair"/>
     <Description>
-      If <A>stz</A> is an StzPresentation object and <A>pair</A> is a list
-      containing two LetterRep words over the generators of <A>stz</A>, then
+      If <A>stz</A> is an <Ref Oper="StzPresentation"/> object and
+      <A>pair</A> is a list
+      containing two <C>LetterRep</C> words over the generators of <A>stz</A>,
+      then
       <C>StzAddRelation</C> will perform a Tietze transformation of the first 
       type and add a new relation to <A>stz</A>. This only happens if the
       new relation that would 
@@ -454,13 +473,13 @@ true]]>
       relations; that is, if we can perform elementary operations using the 
       existing relations of <A>stz</A> to convert <C><A>pair</A>[1]</C> into
       <C><A>pair</A>[2]</C>.
-
       <P/>
 
       If, instead, <A>pair</A> is a list containing two elements of the fp 
-      semigroup <A>S</A> that was used to create <A>stz</A>, and the two words
+      semigroup <C>S</C> that was used to create <C>stz</C>, and the two words
       are equal in that semigroup, then this function
-      will add the LetterRep of these words as a new relation to <A>stz</A>.
+      will add the <C>LetterRep</C> of these words as a new relation to
+      <A>stz</A>.
 
       <Example><![CDATA[
 gap> F := FreeSemigroup("a", "b", "c");
@@ -487,43 +506,12 @@ words that are equal in the presentation <stz>]]>
   </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="StzAddRelationNC">
-  <ManSection>
-    <Oper Name="StzAddRelationNC" Arg="stz, pair"/>
-    <Description>
-      If <A>stz</A> is an StzPresentation object and <A>pair</A> is a list
-      containing two LetterRep words over the generators of <A>stz</A>, then
-      <C>StzAddRelationNC</C> will add <A>pair</A> to the relations of
-      <A>stz</A>. No checks are performed, so it may be that the derived
-      semigroup of <A>stz</A> is no longer isomorphic to its unreduced semigroup
-      (see <Ref Oper="UnreducedSemigroupOfStzPresentation"/>). <E>This should be 
-      used only at the user's own risk</E>.
-
-      <Example><![CDATA[
-gap> F := FreeSemigroup("a", "b", "c");
-<free semigroup on the generators [ a, b, c ]>
-gap> T := F / [[F.1, F.2 ^ 5 * F.3],
->              [F.2 ^ 6, F.2 ^ 3]];
-<fp semigroup on the generators [ a, b, c ]>
-gap> stz := StzPresentation(T);
-<fp semigroup presentation with 3 generators and 2 relations
- with length 19>
-gap> pair := [[1, 1], [3]];
-[ [ 1, 1 ], [ 3 ] ]
-gap> StzAddRelationNC(stz, pair);
-gap> RelationsOfStzPresentation(stz);
-[ [ [ 1 ], [ 2, 2, 2, 2, 2, 3 ] ], 
-  [ [ 2, 2, 2, 2, 2, 2 ], [ 2, 2, 2 ] ], [ [ 1, 1 ], [ 3 ] ] ]]]>
-</Example>
-    </Description>
-  </ManSection>
-<#/GAPDoc>
-
 <#GAPDoc Label="StzRemoveRelation">
   <ManSection>
     <Oper Name="StzRemoveRelation" Arg="stz, index"/>
     <Description>
-      If <A>stz</A> is an StzPresentation object and <A>index</A> is a positive
+      If <A>stz</A> is an <Ref Oper="StzPresentation"/> object
+      and <A>index</A> is a positive
       integer less than or equal to the number of relations of <A>stz</A>, then
       <C>StzRemoveRelation</C> will perform a Tietze transformation of the
       second type and remove the <A>index</A>th relation of <A>stz</A> if that
@@ -551,53 +539,23 @@ a relation that is redundant in the presentation <stz>]]>
   </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="StzRemoveRelationNC">
-  <ManSection>
-    <Oper Name="StzRemoveRelationNC" Arg="stz, index"/>
-    <Description>
-      If <A>stz</A> is an StzPresentation object and <A>index</A> is a positive
-      integer less than or equal to the number of relations of <A>stz</A>, then
-      <C>StzRemoveRelation</C> will remove the <A>index</A>th relation from
-      <A>stz</A>. No checks are performed, so it may be that the derived
-      semigroup of <A>stz</A> is no longer isomorphic to its unreduced semigroup
-      (see <Ref Oper="UnreducedSemigroupOfStzPresentation"/>). <E>This should be 
-      used only at the user's own risk</E>.
-
-      <Example><![CDATA[
-gap> F := FreeSemigroup("a", "b", "c");
-<free semigroup on the generators [ a, b, c ]>
-gap> T := F / [[F.1, F.2 ^ 5 * F.3],
->              [F.2 ^ 6, F.2 ^ 3], [F.2 ^ 2, F.2]];
-<fp semigroup on the generators [ a, b, c ]>
-gap> stz := StzPresentation(T);
-<fp semigroup presentation with 3 generators and 3 relations
- with length 22>
-gap> StzRemoveRelationNC(stz, 1);
-gap> RelationsOfStzPresentation(stz);
-[ [ [ 2, 2, 2, 2, 2, 2 ], [ 2, 2, 2 ] ], [ [ 2, 2 ], [ 2 ] ] ]
-]]>
-</Example>
-    </Description>
-  </ManSection>
-<#/GAPDoc>
-
 <#GAPDoc Label="StzAddGenerator">
   <ManSection>
     <Oper Name="StzAddGenerator" Arg="stz, word[, name]"/>
     <Description>
-      If <A>stz</A> is an StzPresentation object and <A>word</A> is a
-      LetterRep word over the generators of <A>stz</A>, then
-      <C>StzAddGenerator</C> will perform a Tietze transformation of the third 
-      type and add a new generator to <A>stz</A> and a new relation of the form 
+      If <A>stz</A> is an <Ref Oper="StzPresentation"/> object
+      and <A>word</A> is a
+      <C>LetterRep</C> word over the generators of <A>stz</A>, then
+      <C>StzAddGenerator</C> will perform a Tietze transformation  
+      which adds a new generator to <A>stz</A> and a new relation of the form 
       <C>newgenerator = <A>word</A></C>.
-
       <P/>
 
       If, instead, <A>word</A> is a word over the fp semigroup <A>S</A> that was
       used to create <A>stz</A>, then this function will add the new generator
-      and a new relation with the new generator equal to the LetterRep of this
+      and a new relation with the new generator equal to the <C>LetterRep</C>
+      of this
       word as a new relation to <A>stz</A>.
-
       <P/>
 
       A new name for the generator is chosen and added automatically based on
@@ -606,13 +564,6 @@ gap> RelationsOfStzPresentation(stz);
       not included. If it is, and if <A>name</A> is a string that is not equal
       to an existing generator, then the string added to the list of generators
       will be <A>name</A> instead.
-
-      <P/>
-
-      There is no NC version of this function needed as there are no special
-      conditions that the input must fulfill in order to maintain the structure
-      of the semigroup derived from <A>stz</A>.
-
       <Example><![CDATA[
 gap> F := FreeSemigroup("a", "b", "c");
 <free semigroup on the generators [ a, b, c ]>
@@ -636,22 +587,23 @@ gap> RelationsOfStzPresentation(stz);
   <ManSection>
     <Oper Name="StzRemoveGenerator" Arg="stz, gen/genname[, index]"/>
     <Description>
-      If <A>stz</A> is an StzPresentation object and <A>gen</A> is a positive
+      If <A>stz</A> is an <Ref Oper="StzPresentation"/> object
+      and <A>gen</A> is a positive
       integer less than or equal to the number of generators of <A>stz</A>, then
-      <C>StzRemoveGenerator</C> will perform a Tietze transformation of the
-      fourth type and remove the <A>gen</A>th generator of <A>stz</A> if there 
-      exists a relation of <A>stz</A> such that one side of the relation is only
-      <A>gen</A> and the other side is a word that does not contain <A>gen</A>,
-      in which case that relation is also removed and all instances of
-      <A>gen</A> in other relations is replaced by the aforementioned word.
+      <C>StzRemoveGenerator</C> will perform a Tietze transformation which
+      removes the <A>gen</A>th generator of <A>stz</A>.<P/>
+      
+      The argument <A>stz</A>
+      must contain a relation of the form <C><A>gen</A> = word</C> or
+      <C>word = <A>gen</A></C>, where <C>word</C> contains no occurrences of
+      the generator <A>gen</A> being removed. The generator is then removed
+      from the presentation by replacing every instance of <A>gen</A> with a
+      copy of <C>word</C>.<P/>
 
-      <P/>
-
-      If instead the argument is a string <A>genname</A> rather than a positive 
+      If the second argument is a string <A>genname</A> rather than a positive 
       integer <A>gen</A>, then the function searches the generators of
       <A>stz</A> for a generator with the same name and attempts to remove the 
       generator if the same conditions as above are met.
-
       <P/>
 
       If the argument <A>index</A> is included and is a positive integer less 
@@ -659,11 +611,7 @@ gap> RelationsOfStzPresentation(stz);
       relations for the first to satisfy the necessary conditions, the function 
       checks the <A>index</A>th relation to see if it satisfies those
       conditions, and applies the Tietze transformation by removing this
-      relation.<P/>
-
-      There is no NC version of this function since there is no predictable way
-      to remove a generator if it does not fulfill the conditions above.
-
+      relation.
       <Example><![CDATA[
 gap> F := FreeSemigroup("a", "b", "c");
 <free semigroup on the generators [ a, b, c ]>
@@ -685,7 +633,8 @@ gap> RelationsOfStzPresentation(stz);
   <ManSection>
     <Oper Name="StzSubstituteRelation" Arg="stz, index, side"/>
     <Description>
-      If <A>stz</A> is an StzPresentation object and <A>index</A> is a positive
+      If <A>stz</A> is an <Ref Oper="StzPresentation"/> object
+      and <A>index</A> is a positive
       integer less than or equal to the number of relations of <A>stz</A> and 
       <A>side</A> is either 1 or 2, then
       <C>StzRemoveGenerator</C> will perform a sequence of Tietze
@@ -726,10 +675,10 @@ gap> RelationsOfStzPresentation(stz);
       A non-negative integer.
     </Returns>
     <Description>
-      If <A>stz</A> is an <C>IsStzPresentation</C> object, then the
+      If <A>stz</A> is an <Ref Oper="StzPresentation"/> object, then the
       <C>Length</C> of the 
       object is defined as the number of generators plus the lengths of each 
-      word in each relation of the relations of <A>stz</A>.
+      word in each relation of <A>stz</A>.
 
       <Example><![CDATA[
 gap> F := FreeSemigroup("a", "b", "c");
@@ -751,7 +700,8 @@ gap> Length(stz);
   <ManSection>
     <Oper Name="StzPrintRelation" Arg="stz, int"/>
     <Description>
-      If <A>stz</A> is an StzPresentation object, then <C>StzPrintRelation</C>
+      If <A>stz</A> is an <Ref Oper="StzPresentation"/> object,
+      then <C>StzPrintRelation</C>
       calls <C>StzPrintRelations</C> with parameters <A>stz</A> and
       <C>[<A>int</A>]</C>.
 
@@ -775,7 +725,8 @@ gap> StzPrintRelation(stz, 2);
   <ManSection>
     <Oper Name="StzPrintRelations" Arg="stz[, list]"/>
     <Description>
-      If <A>stz</A> is an StzPresentation object, and if <A>list</A> is a list 
+      If <A>stz</A> is an <Ref Oper="StzPresentation"/> object and
+      <A>list</A> is a list 
       of positive integers,
       then <C>StzPrintRelations</C> prints for each <A>i</A> in
       <A>list</A> the <A>i</A>th relation to the console in terms of the stored 
@@ -810,7 +761,8 @@ gap> StzPrintRelations(stz);
   <ManSection>
     <Oper Name="StzPrintGenerators" Arg="stz[, list]"/>
     <Description>
-      If <A>stz</A> is an StzPresentation object, and if <A>list</A> is a list 
+      If <A>stz</A> is an <Ref Oper="StzPresentation"/> object and
+      <A>list</A> is a list 
       of positive integers,
       then <C>StzPrintGenerators</C> for each <A>i</A> in
       <A>list</A> the <A>i</A>th generator and the number of occurrences of that
@@ -844,7 +796,7 @@ gap> StzPrintGenerators(stz);
   <ManSection>
     <Oper Name="StzPrintPresentation" Arg="stz"/>
     <Description>
-      If <A>stz</A> is an StzPresentation object then
+      If <A>stz</A> is an <Ref Oper="StzPresentation"/> object, then
       <C>StzPrintPresentation</C> prints a comprehensive overview of <A>stz</A>,
       including the generators and number of occurrences of each generator in
       the relations, the relations as words over the generators, and the forward
@@ -896,12 +848,13 @@ gap> StzPrintPresentation(stz);
       A list of lists of positive integers.
     </Returns>
     <Description>
-      If <A>stz</A> is an StzPresentation object then
+      If <A>stz</A> is an <Ref Oper="StzPresentation"/> object, then
       <C>TietzeForwardMap</C> returns a list of lists of positive integers.
       There is an element of this list for every generator of the 
       unreduced semigroup of the presentation (see 
       <Ref Attr="UnreducedSemigroupOfStzPresentation"/>) that indicates the 
-      word (in LetterRep form) in the semigroup object currently defined by the
+      word (in <C>LetterRep</C> form) in the semigroup object currently defined
+      by the
       presentation that the generator maps to.<P/>
 
       This mapping is updated as the presentation object is transformed. It 
@@ -932,11 +885,12 @@ gap> TietzeForwardMap(stz);
       A list of lists of positive integers.
     </Returns>
     <Description>
-      If <A>stz</A> is an StzPresentation object then
+      If <A>stz</A> is an <Ref Oper="StzPresentation"/> object, then
       <C>TietzeBackwardMap</C> returns a list of lists of positive integers.
       There is an element of this list for every generator of the 
       semigroup that the presentation currently defines that indicates the 
-      word (in LetterRep form) in the unreduced semigroup of the presentation 
+      word (in <C>LetterRep</C> form) in the unreduced semigroup of the
+      presentation 
       (see <Ref Attr="UnreducedSemigroupOfStzPresentation"/>) that the 
       generator maps to.<P/>
 
@@ -968,21 +922,23 @@ gap> TietzeBackwardMap(stz);
       A mapping object.
     </Returns>
     <Description>
-      If <A>stz</A> is an StzPresentation object then
+      If <A>stz</A> is an <Ref Oper="StzPresentation"/> object, then
       <C>TietzeIsomorphism</C> returns a mapping object that maps the 
       unreduced semigroup of the presentation (see
       <Ref Attr="UnreducedSemigroupOfStzPresentation"/>)
       to an FpSemigroup object that is defined by the generators and relations 
       of the semigroup presentation at the moment this function is ran.<P/>
 
-      It is important to note that this mapping is specific to the presentation
-      when it is ran - if the presentation is altered further then the mapping 
-      no longer applies to the presentation and must be created again by running
-      this function.<P/>
+      If a <C>TietzeIsomorphism</C> is generated from <A>stz</A>, and the
+      presentation <A>stz</A> is further modified afterwards (for example by
+      applying more Tietze transformations or <Ref Oper="StzSimplifyOnce"/> to
+      <A>stz</A>), then running <C>TietzeIsomorphism(<A>stz</A>)</C> a second
+      time will produce a different result consistent with the <E>new</E>
+      generators and relations of <A>stz</A>.<P/>
 
       This mapping is built from the <Ref Attr="TietzeForwardMap"/> and 
       <Ref Attr="TietzeBackwardMap"/> attributes from the presentation object,
-      since if we know how to map the generators of the respective semigroups
+      since if we know how to map the generators of the respective semigroups,
       then we know how to map any element of that semigroup.<P/>
 
       This function is the primary way to obtain the simplified semigroup from 

--- a/doc/z-chap10.xml
+++ b/doc/z-chap10.xml
@@ -4,19 +4,8 @@
   </Heading>
 
   This chapter describes the functions in &Semigroups; for dealing with free
-  inverse semigroups and free bands. Sections
-  <Ref Sect="Free inverse semigroups" Style="Number"/>,
-  <Ref Sect="Displaying free inverse semigroup elements" Style="Number"/>,
-  <Ref Sect="Operators and operations for free inverse semigroup elements"
-  Style="Number"/>,
-  <Ref Sect="Free bands" Style="Number"/>, and
-  <Ref Sect="Operators and operations for free band elements" Style="Number"/>,
-  and the functions described therein, were written by Julius Jonu&#353;as.
-  Section <Ref Sect="Words and strings in finitely presented semigroups"
-  Style="Number"/> was written by Maria Tsalakou and Murray Whyte, and Section
-  <Ref Sect="Helper functions for creating semigroup and monoid presentations"
-  Style="Number"/> was written by Luke Elliott.
-  <P/>
+  inverse semigroups and free bands. This part of the manual and the functions
+  described herein were written by Julius Jonu&#353;as.<P/>
   
   <Section Label="Free inverse semigroups">
     <Heading>
@@ -191,33 +180,5 @@ x1x2x2^-1x1^-1x1x2]]></Example>
     </List>
 
     <#Include Label = "GreensDClassOfElement" >
-  </Section>
-
-
-  <Section Label="Words and strings in finitely presented semigroups">
-    <Heading> Words and strings in finitely presented semigroups
-    </Heading>
-    This section contains various methods for dealing with words, which for
-    these purposes are lists of positive integers.
-
-    <#Include Label = "WordToString" >
-    <#Include Label = "RandomWord" >
-    <#Include Label = "StandardiseWord" >
-    <#Include Label = "StringToWord" >
-  </Section>
-
-  <Section
-   Label="Helper functions for creating semigroup and monoid presentations">
-    <Heading> Helper functions for creating semigroup and monoid presentations
-    </Heading>
-    This section describes operations implemented in &Semigroups; that are
-    designed to interact with standard &GAP; methods for creating finitely
-    presented semigroups and monoids (see <Ref
-    Chap="Finitely Presented Semigroups and Monoids"
-    BookName="ref"/>).
-
-    <#Include Label = "ParseRelations">
-    <#Include Label = "ElementOfFpSemigroup">
-    <#Include Label = "ElementOfFpMonoid">
   </Section>
 </Chapter>

--- a/doc/z-chap19.xml
+++ b/doc/z-chap19.xml
@@ -187,11 +187,11 @@
     interest to map elements of <C>S</C> over to <C>T</C>, where they may be
     represented by different combinations of generators. The isomorphism
     achieving this is described in this section
-    (see <Ref Oper="TietzeIsomorphism"/>).
+    (see <Ref Oper="StzIsomorphism"/>).
 
     <#Include Label="TietzeForwardMap">
     <#Include Label="TietzeBackwardMap">
-    <#Include Label="TietzeIsomorphism">
+    <#Include Label="StzIsomorphism">
   </Section>
 
   <Section Label = "Automatically simplifying a presentation">

--- a/doc/z-chap19.xml
+++ b/doc/z-chap19.xml
@@ -1,75 +1,234 @@
-<Chapter Label = "Visualising semigroups and elements">
+<Chapter Label = "Finitely presented semigroups and Tietze transformations">
   <Heading>
-    Visualising semigroups and elements
+    Finitely presented semigroups and Tietze transformations
   </Heading>
 
-  There are two operations <Ref Oper = "TikzString"/> and <Ref Oper =
-    "DotString"/> in &Semigroups; for creating &LaTeX; and <C>dot</C> (also
-  known as GraphViz) format pictures of the Green's class structure of a
-  semigroup and for visualising certain types of elements of a semigroup. There
-  is also a function <Ref Func = "Splash" BookName = "Digraphs"/> for
-  automatically processing the output of <Ref Oper = "TikzString"/> and <Ref
-    Oper = "DotString"/> and opening the resulting pdf file.
+  In this chapter we describe the functions implemented in &Semigroups; that
+  extend the features available in &GAP; for dealing with finitely presented
+  semigroups.
 
-  <!--**********************************************************************-->
-  <!--**********************************************************************-->
+  <P/>
+  
+  Section
+  <Ref Sect="Words and strings in finitely presented semigroups"
+       Style="Number"/>
+  (written by Maria Tsalakou and Murray Whyte) and Section
+  <Ref Sect="Helper functions for creating semigroup and monoid presentations"
+       Style="Number"/>
+  (written by Luke Elliott)
+  demonstrate a number of helper functions that allow the user to convert
+  between different representations of words and relations.
 
-  <Section>
+  <P/>
 
-    <Heading>
-      <C>dot</C> pictures
-    </Heading>
-
-    In this section, we describe the operations in &Semigroups; for creating
-    pictures in <C>dot</C> format.
-    <P/>
+  In the later sections, written and implemented by Ben Spiers and Tom
+  Conti-Leslie, we describe how to change the relations of a finitely presented
+  semigroup either manually or automatically using "Semigroup Tietze" ("Stz")
+  transformations.
+  <P/>
  
-    The operations described in this section return strings, which
-    can be written to a file using the function <Ref Func = "FileString"
-      BookName = "GAPDoc"/> or viewed using <Ref Func = "Splash" BookName =
-      "Digraphs"/>.
-
-    <#Include Label = "DotString"/>
-    <#Include Label = "DotStringDigraph"/>
-    <#Include Label = "DotSemilatticeOfIdempotents"/>
-    <#Include Label = "DotLeftCayleyDigraph">
-
-  </Section>
- 
-  <!--**********************************************************************-->
-  <!--**********************************************************************-->
-
-  <Section>
-    <Heading>
-      <C>tex</C> output
+  <Section Label="Words and strings in finitely presented semigroups">
+    <Heading> Words and strings in finitely presented semigroups
     </Heading>
-    In this section, we describe the operations in &Semigroups; for creating
-    &LaTeX; representations of &GAP; objects. For pictures of &GAP; objects
-    please see Section <Ref Sect="tikz pictures"/>. 
+    This section contains various methods for dealing with words, which for
+    these purposes are lists of positive integers.
 
-    <#Include Label = "TexString">
+    <#Include Label = "WordToString" >
+    <#Include Label = "RandomWord" >
+    <#Include Label = "StandardiseWord" >
+    <#Include Label = "StringToWord" >
   </Section>
 
-  <!--**********************************************************************-->
-  <!--**********************************************************************-->
-
-  <Section Label="tikz pictures">
-    <Heading>
-      <C>tikz</C> pictures
+  <Section
+   Label="Helper functions for creating semigroup and monoid presentations">
+    <Heading> Helper functions for creating semigroup and monoid presentations
     </Heading>
+    This section describes operations implemented in &Semigroups; that are
+    designed to interact with standard &GAP; methods for creating finitely
+    presented semigroups and monoids (see <Ref
+    Chap="Finitely Presented Semigroups and Monoids"
+    BookName="ref"/>).
 
-    In this section, we describe the operations in &Semigroups; for creating
-    pictures in <C>tikz</C> format.
+    <#Include Label = "ParseRelations">
+  </Section>
+
+  <Section Label="Creating semigroup presentations">
+    <Heading>
+      Creating semigroup presentations
+    </Heading>
+    It is possible to use &GAP; to create finitely presented semigroups without
+    the &Semigroups; package, by creating a free semigroup, then
+    quotienting by a list of relations. This is described in the reference
+    manual
+    (<Ref Chap="Finitely Presented Semigroups and Monoids" BookName="ref"/>).
+
     <P/>
 
-    The functions described in this section return a string, which can be
-    written to a file using the function <Ref Func = "FileString"
-      BookName = "GAPDoc"/> or viewed using <Ref Func = "Splash" BookName =
-      "Digraph"/>.
+    However, finitely presented semigroups do not allow for their relations to
+    be simplified, so in the following sections, we describe how to create and
+    modify the "Semigroup Tietze" object associated with an fp semigroup.
+    This object can be automatically simplified, or the user can manually apply
+    Tietze transformations to add or remove relations or generators in the
+    presentation.
 
-    <#Include Label = "TikzString">
-    <#Include Label = "TikzLeftCayleyDigraph">
+    <P/>
 
+    This object is analogous to the "Tietze object" implemented for fp groups
+    in the main &GAP; distribution
+    (<Ref Chap="Presentations and Tietze Transformations" BookName="ref"/>),
+    but its features are semigroup-specific. Most of the functions used to
+    create, view and manipulate Semigroup Tietze objects are prefixed with
+    "Stz".
+
+    <#Include Label = "StzPresentation">
+    <#Include Label = "IsStzPresentation">
+    <#Include Label = "GeneratorsOfStzPresentation">
+    <#Include Label = "RelationsOfStzPresentation">
+    <#Include Label = "UnreducedSemigroupOfStzPresentation">
+    <#Include Label = "Length">
   </Section>
 
+  <Section Label = "Printing presentations">
+    <Heading>
+      Printing presentations
+    </Heading>
+    Since the relations are stored as flat lists of numbers, there are several 
+    methods installed to print the presentations in more user-friendly forms.
+
+    <P/>
+
+    All printing methods in this section are displayed as information
+    (<Ref Func="Info" BookName="ref"/>) in the class
+    <C>InfoFpSemigroup</C> at level 1. Setting
+    <C>SetInfoLevevl(InfoFpSemigroup, 0)</C> will suppress the messages, while
+    any higher number will display them.
+
+    <P/>
+
+    <#Include Label="StzPrintRelations">
+    <#Include Label="StzPrintRelation">
+    <#Include Label="StzPrintGenerators">
+    <#Include Label="StzPrintPresentation">
+  </Section>
+
+  <Section Label = "Changing presentations">
+    <Heading>
+      Changing presentations
+    </Heading>
+
+    Fundamentally, there are four different changes that can be made to a
+    presentation without changing the algebraic structure of the fp semigroup
+    that can be derived from it. These four changes are called Tietze
+    transformations, and they are primarily implemented in this section
+    as operations on an StzPresentation object that will throw 
+    errors if the conditions have not been met to perform the Tietze
+    transformation.
+
+    <P/>
+
+    However, the checks required in order to ensure that a Tietze
+    transformation is valid sometimes require verifying equality of two words
+    in an fp semigroup (for example, to ensure that a relation we are adding
+    to the list of relations can be derived from the relations already present).
+    Since these checks sometimes do not terminate, a second implementation of
+    Tietze transformations assumes good faith and does not perform any
+    checks to see whether the requested Tietze transformation actually maintains
+    the structure of the semigroup. This latter type should be used at the
+    user's discretion. If only the first type are used, the presentation will
+    always give a semigroup isomorphic to the one used to create the object,
+    but if instead one is not 
+    changing the presentation with the intention of maintaining algebraic
+    structure, these no-check functions are available for use.
+
+    <P/>
+
+    The four Tietze transformations on a presentation are adding a relation,
+    removing a relation, adding a generator, and removing a generator, with
+    particular conditions on what can 
+    be added/removed in order to maintain structure.
+    More details on each transformation and its arguments and conditions is
+    given in each entry below.
+    In addition to the four elementary
+    transformations, there is an additional function
+    <C>StzSubstituteRelation</C> which applies multiple Tietze transformations
+    in sequence to achieve a particular result.
+
+    <P/>
+
+    <#Include Label="StzAddRelation">
+    <#Include Label="StzAddRelationNC">
+    <#Include Label="StzRemoveRelation">
+    <#Include Label="StzRemoveRelationNC">
+    <#Include Label="StzAddGenerator">
+    <#Include Label="StzRemoveGenerator">
+    <#Include Label="StzSubstituteRelation">
+  </Section>
+
+  <Section Label = "Converting a modified presentation into a semigroup">
+    <Heading>
+      Converting a modified presentation into a semigroup
+    </Heading>
+    
+    Now that a presentation object has been established, we need to cover how 
+    this presentation (which is currently unrelated to any semigroup object)
+    can be used to both work with the old unreduced fp semigroup and create a 
+    new fp semigroup based on the presentation. This is achieved by the 
+    <C>TietzeIsomorphism</C> operation, which defines a map from the unreduced
+    fp semigroup to a newly defined one based on the altered presentation. In 
+    order to obtain this isomorphic, altered fp semigroup, the <C>Range</C> of 
+    this mapping object is taken.<P/>
+
+    <#Include Label="TietzeForwardMap">
+    <#Include Label="TietzeBackwardMap">
+    <#Include Label="TietzeIsomorphism">
+  </Section>
+
+  <Section Label = "Automatically simplifying a presentation">
+    <Heading>
+      Automatically simplifying a presentation
+    </Heading>
+    <P/>
+
+    It is possible to create a presentation object from an fp semigroup object 
+    and attempt to manually reduce it by applying Tietze transformations.
+    However, there may be many different reductions that can be applied, so 
+    <C>StzSimplifyOnce</C> can be used to automatically check a number of
+    different 
+    possible reductions and apply the best one. Then,
+    <C>StzSimplifyPresentation </C>
+    repeatedly applies StzSimplifyOnce to the presentation object until it fails
+    to reduce the presentation any further. The metric with respect to which
+    the <C>IsStzPresentation</C> object is reduced is
+    <Ref Oper="Length"/>.
+
+    <#Include Label="StzSimplifyOnce">
+    <#Include Label="StzSimplifyPresentation">
+  </Section>
+
+  <Section Label = "Automatically simplifying an fp semigroup">
+    <Heading>
+      Automatically simplifying an fp semigroup
+    </Heading>
+    <P/>
+
+    It may be the case that, rather than working with a presentation object, we 
+    want to start with an fp semigroup object and obtain the most simplified
+    version of that fp semigroup that StzSimplifyPresentation can produce. In 
+    this case, SimplifyFpSemigroup can be applied to obtain a mapping from its 
+    argument to a reduced fp semigroup. If the mapping is not of interest,
+    SimplifiedFpSemigroup can be 
+    used to directly obtain a new fp semigroup isomorphic to the first with
+    reduced 
+    relations and generators (the mapping is stored as an attribute of the
+    output). With these functions, the user never has to
+    consider precisely what Tietze transformations to perform, and never has to 
+    worry about using the StzPresentation object or its associated operations.
+    They can start with an fp semigroup and obtain a simplified fp semigroup.
+
+    <#Include Label="SimplifyFpSemigroup">
+    <#Include Label="SimplifiedFpSemigroup">
+    <#Include Label="UnreducedFpSemigroupOfFpSemigroup">
+    <#Include Label="FpTietzeIsomorphism">
+  </Section>
 </Chapter>
+

--- a/doc/z-chap19.xml
+++ b/doc/z-chap19.xml
@@ -50,6 +50,8 @@
     BookName="ref"/>).
 
     <#Include Label = "ParseRelations">
+    <#Include Label = "ElementOfFpSemigroup">
+    <#Include Label = "ElementOfFpMonoid">
   </Section>
 
   <Section Label="Creating semigroup presentations">

--- a/doc/z-chap19.xml
+++ b/doc/z-chap19.xml
@@ -5,7 +5,7 @@
 
   In this chapter we describe the functions implemented in &Semigroups; that
   extend the features available in &GAP; for dealing with finitely presented
-  semigroups.
+  semigroups and monoids.
 
   <P/>
   
@@ -68,18 +68,20 @@
 
     However, finitely presented semigroups do not allow for their relations to
     be simplified, so in the following sections, we describe how to create and
-    modify the "Semigroup Tietze" object associated with an fp semigroup.
+    modify the semigroup Tietze (<Ref Filt="IsStzPresentation"/>) object
+    associated with an fp semigroup.
     This object can be automatically simplified, or the user can manually apply
     Tietze transformations to add or remove relations or generators in the
     presentation.
 
     <P/>
 
-    This object is analogous to the "Tietze object" implemented for fp groups
+    This object is analogous to <Ref Oper="PresentationFpGroup" BookName="ref"/>
+    implemented for fp groups
     in the main &GAP; distribution
     (<Ref Chap="Presentations and Tietze Transformations" BookName="ref"/>),
     but its features are semigroup-specific. Most of the functions used to
-    create, view and manipulate Semigroup Tietze objects are prefixed with
+    create, view and manipulate semigroup Tietze objects are prefixed with
     "Stz".
 
     <#Include Label = "StzPresentation">
@@ -158,9 +160,7 @@
     <P/>
 
     <#Include Label="StzAddRelation">
-    <#Include Label="StzAddRelationNC">
     <#Include Label="StzRemoveRelation">
-    <#Include Label="StzRemoveRelationNC">
     <#Include Label="StzAddGenerator">
     <#Include Label="StzRemoveGenerator">
     <#Include Label="StzSubstituteRelation">
@@ -170,15 +170,24 @@
     <Heading>
       Converting a modified presentation into a semigroup
     </Heading>
-    
-    Now that a presentation object has been established, we need to cover how 
-    this presentation (which is currently unrelated to any semigroup object)
-    can be used to both work with the old unreduced fp semigroup and create a 
-    new fp semigroup based on the presentation. This is achieved by the 
-    <C>TietzeIsomorphism</C> operation, which defines a map from the unreduced
-    fp semigroup to a newly defined one based on the altered presentation. In 
-    order to obtain this isomorphic, altered fp semigroup, the <C>Range</C> of 
-    this mapping object is taken.<P/>
+    Semigroup Tietze (<Ref Filt="IsStzPresentation"/>) objects are not actual
+    fp semigroups in the sense of <Ref Filt="IsFpSemigroup" BookName="ref"/>.
+    This is because their generators and relations can be modified
+    (see section <Ref Sect="Changing presentations"/>).
+    However, an <Ref Oper="StzPresentation"/> can be converted back into an
+    actual finitely presented semigroup using the methods described in this
+    section.<P/>
+
+    The intended use of semigroup Tietze objects is as follows: given an fp
+    semigroup <C>S</C>, create a modifiable presentation using
+    <C>stz := StzPresentation(S)</C>, apply Tietze transformations to it
+    (perhaps in order to simplify the presentation), then generate a new
+    fp semigroup <C>T</C> given by <C>stz</C> which is isomorphic to <C>S</C>,
+    but has a simpler presentation. Once <C>T</C> is obtained, it may be of
+    interest to map elements of <C>S</C> over to <C>T</C>, where they may be
+    represented by different combinations of generators. The isomorphism
+    achieving this is described in this section
+    (see <Ref Oper="TietzeIsomorphism"/>).
 
     <#Include Label="TietzeForwardMap">
     <#Include Label="TietzeBackwardMap">

--- a/doc/z-chap19.xml
+++ b/doc/z-chap19.xml
@@ -88,7 +88,7 @@
     <#Include Label = "IsStzPresentation">
     <#Include Label = "GeneratorsOfStzPresentation">
     <#Include Label = "RelationsOfStzPresentation">
-    <#Include Label = "UnreducedSemigroupOfStzPresentation">
+    <#Include Label = "UnreducedFpSemigroup-stz">
     <#Include Label = "Length">
   </Section>
 
@@ -238,7 +238,7 @@
 
     <#Include Label="SimplifyFpSemigroup">
     <#Include Label="SimplifiedFpSemigroup">
-    <#Include Label="UnreducedFpSemigroupOfFpSemigroup">
+    <#Include Label="UnreducedFpSemigroup-S">
     <#Include Label="FpTietzeIsomorphism">
   </Section>
 </Chapter>

--- a/doc/z-chap20.xml
+++ b/doc/z-chap20.xml
@@ -1,28 +1,75 @@
-<Chapter Label="IO">
+<Chapter Label = "Visualising semigroups and elements">
   <Heading>
-    IO
+    Visualising semigroups and elements
   </Heading>
 
-  <Section><Heading>Reading and writing elements to a file</Heading>
-    The functions <Ref Func = "ReadGenerators"/> and <Ref Func =
-      "WriteGenerators"/> can be used to read or write, respectively, elements
-    of a semigroup to a file.
+  There are two operations <Ref Oper = "TikzString"/> and <Ref Oper =
+    "DotString"/> in &Semigroups; for creating &LaTeX; and <C>dot</C> (also
+  known as GraphViz) format pictures of the Green's class structure of a
+  semigroup and for visualising certain types of elements of a semigroup. There
+  is also a function <Ref Func = "Splash" BookName = "Digraphs"/> for
+  automatically processing the output of <Ref Oper = "TikzString"/> and <Ref
+    Oper = "DotString"/> and opening the resulting pdf file.
 
-    <#Include Label = "ReadGenerators">
-    <#Include Label = "WriteGenerators">
-    <#Include Label = "IteratorFromGeneratorsFile">
-  </Section>
+  <!--**********************************************************************-->
+  <!--**********************************************************************-->
 
   <Section>
-    <Heading>Reading and writing multiplication tables to a file</Heading>
-    The functions <Ref Func = "ReadMultiplicationTable"/> and 
-    <Ref Func = "WriteMultiplicationTable"/> can be used to read or write,
-    respectively, multiplication tables to a file.
 
-    <#Include Label = "ReadMultiplicationTable">
-    <#Include Label = "WriteMultiplicationTable">
-    <#Include Label = "IteratorFromMultiplicationTableFile">
+    <Heading>
+      <C>dot</C> pictures
+    </Heading>
+
+    In this section, we describe the operations in &Semigroups; for creating
+    pictures in <C>dot</C> format.
+    <P/>
+ 
+    The operations described in this section return strings, which
+    can be written to a file using the function <Ref Func = "FileString"
+      BookName = "GAPDoc"/> or viewed using <Ref Func = "Splash" BookName =
+      "Digraphs"/>.
+
+    <#Include Label = "DotString"/>
+    <#Include Label = "DotStringDigraph"/>
+    <#Include Label = "DotSemilatticeOfIdempotents"/>
+    <#Include Label = "DotLeftCayleyDigraph">
+
+  </Section>
+ 
+  <!--**********************************************************************-->
+  <!--**********************************************************************-->
+
+  <Section>
+    <Heading>
+      <C>tex</C> output
+    </Heading>
+    In this section, we describe the operations in &Semigroups; for creating
+    &LaTeX; representations of &GAP; objects. For pictures of &GAP; objects
+    please see Section <Ref Sect="tikz pictures"/>. 
+
+    <#Include Label = "TexString">
   </Section>
 
+  <!--**********************************************************************-->
+  <!--**********************************************************************-->
+
+  <Section Label="tikz pictures">
+    <Heading>
+      <C>tikz</C> pictures
+    </Heading>
+
+    In this section, we describe the operations in &Semigroups; for creating
+    pictures in <C>tikz</C> format.
+    <P/>
+
+    The functions described in this section return a string, which can be
+    written to a file using the function <Ref Func = "FileString"
+      BookName = "GAPDoc"/> or viewed using <Ref Func = "Splash" BookName =
+      "Digraph"/>.
+
+    <#Include Label = "TikzString">
+    <#Include Label = "TikzLeftCayleyDigraph">
+
+  </Section>
 
 </Chapter>

--- a/doc/z-chap21.xml
+++ b/doc/z-chap21.xml
@@ -1,31 +1,28 @@
-<Chapter Label="orbits">
+<Chapter Label="IO">
   <Heading>
-    Orbits
+    IO
   </Heading>
-  <Section><Heading>Looking for something in an orbit</Heading>
-    The functions described in this section supplement the &Orb; package by
-    providing methods for finding something in an orbit, with the possibility
-    of continuing the orbit enumeration at some later point.
 
-    <#Include Label="EnumeratePosition">
-    <#Include Label="LookForInOrb">
+  <Section><Heading>Reading and writing elements to a file</Heading>
+    The functions <Ref Func = "ReadGenerators"/> and <Ref Func =
+      "WriteGenerators"/> can be used to read or write, respectively, elements
+    of a semigroup to a file.
+
+    <#Include Label = "ReadGenerators">
+    <#Include Label = "WriteGenerators">
+    <#Include Label = "IteratorFromGeneratorsFile">
   </Section>
+
   <Section>
-    <Heading>Strongly connected components of orbits</Heading>
-    The functions described in this section supplement the &Orb; package by
-    providing methods for operations related to strongly connected
-    components of orbits.<P/>
+    <Heading>Reading and writing multiplication tables to a file</Heading>
+    The functions <Ref Func = "ReadMultiplicationTable"/> and 
+    <Ref Func = "WriteMultiplicationTable"/> can be used to read or write,
+    respectively, multiplication tables to a file.
 
-    If any of the functions is applied to an open orbit, then the orbit is
-    completely enumerated before any further calculation is performed. It is not
-    possible to calculate the strongly connected components of an orbit of a
-    semigroup acting on a set until the entire orbit has been found.
-
-    <#Include Label="OrbSCC">
-    <#Include Label="OrbSCCLookup">
-    <#Include Label="ReverseSchreierTreeOfSCC">
-    <#Include Label="SchreierTreeOfSCC">
-    <#Include Label="TraceSchreierTreeOfSCCBack">
-    <#Include Label="TraceSchreierTreeOfSCCForward">
+    <#Include Label = "ReadMultiplicationTable">
+    <#Include Label = "WriteMultiplicationTable">
+    <#Include Label = "IteratorFromMultiplicationTableFile">
   </Section>
+
+
 </Chapter>

--- a/doc/z-chap22.xml
+++ b/doc/z-chap22.xml
@@ -1,6 +1,31 @@
-<Chapter Label="Extending the package">
+<Chapter Label="orbits">
   <Heading>
-    Extending the package
+    Orbits
   </Heading>
- 
+  <Section><Heading>Looking for something in an orbit</Heading>
+    The functions described in this section supplement the &Orb; package by
+    providing methods for finding something in an orbit, with the possibility
+    of continuing the orbit enumeration at some later point.
+
+    <#Include Label="EnumeratePosition">
+    <#Include Label="LookForInOrb">
+  </Section>
+  <Section>
+    <Heading>Strongly connected components of orbits</Heading>
+    The functions described in this section supplement the &Orb; package by
+    providing methods for operations related to strongly connected
+    components of orbits.<P/>
+
+    If any of the functions is applied to an open orbit, then the orbit is
+    completely enumerated before any further calculation is performed. It is not
+    possible to calculate the strongly connected components of an orbit of a
+    semigroup acting on a set until the entire orbit has been found.
+
+    <#Include Label="OrbSCC">
+    <#Include Label="OrbSCCLookup">
+    <#Include Label="ReverseSchreierTreeOfSCC">
+    <#Include Label="SchreierTreeOfSCC">
+    <#Include Label="TraceSchreierTreeOfSCCBack">
+    <#Include Label="TraceSchreierTreeOfSCCForward">
+  </Section>
 </Chapter>

--- a/doc/z-chap23.xml
+++ b/doc/z-chap23.xml
@@ -1,0 +1,6 @@
+<Chapter Label="Extending the package">
+  <Heading>
+    Extending the package
+  </Heading>
+ 
+</Chapter>

--- a/gap/doc.g
+++ b/gap/doc.g
@@ -62,6 +62,7 @@ BindGlobal("SEMIGROUPS_DocXMLFiles",
             "semipperm.xml",
             "semiringmat.xml",
             "semitrans.xml",
+            "tietze.xml",
             "trans.xml",
             "utils.xml",
             "word.xml"]);

--- a/gap/fp/tietze.gd
+++ b/gap/fp/tietze.gd
@@ -1,0 +1,78 @@
+################################################################################
+# The Stz Object (name pending)
+# Idea is to have a single object containing generators and relations that can
+# have the relations be presented in a number of different computation-friendly
+# or user-friendly formats (LetterRepAssocWord, ExtRepOfObj, user-readable
+# strings). Ideally never seen by the user, but used internally to - among other
+# things - reduce the relations of an FP semigroup/monoid to a simple form
+#
+# I argue: no need for IsMutable/IsImmutable/etc, since StzPresentation likely
+# is never seen by the user, so as long as it is contained to the stz reduction
+# (as it likely will be) there will be no issues.
+################################################################################
+
+DeclareOperation("StzPresentation", [IsFpSemigroup]);
+DeclareCategory("IsStzPresentation", IsList);
+
+# Current relations in the process of being reduced
+DeclareAttribute("RelationsOfStzPresentation", IsStzPresentation);
+DeclareAttribute("GeneratorsOfStzPresentation", IsStzPresentation);
+
+# Stores original semigroup before reductions
+DeclareAttribute("UnreducedSemigroupOfStzPresentation", IsStzPresentation);
+
+# Stores a map between the words of each semigroup (how?)
+# Change as relations change
+# Otherwise must keep track of all tietze transforms i suppose
+DeclareAttribute("TietzeForwardMap", IsStzPresentation);
+DeclareAttribute("TietzeBackwardMap", IsStzPresentation);
+
+DeclareOperation("TietzeForwardMapReplaceSubword",
+[IsStzPresentation, IsList, IsList]);
+
+DeclareOperation("StzSimplifyOnce", [IsStzPresentation]);
+DeclareOperation("StzSimplifyPresentation", [IsStzPresentation]);
+
+DeclareOperation("SimplifiedFpSemigroup", [IsFpSemigroup]);
+DeclareOperation("SimplifyFpSemigroup", [IsFpSemigroup]);
+
+# FP semigroup attributes
+DeclareAttribute("UnreducedFpSemigroupOfFpSemigroup", IsFpSemigroup);
+DeclareAttribute("FpTietzeIsomorphism", IsFpSemigroup);
+
+DeclareOperation("TietzeIsomorphism", [IsStzPresentation]);
+
+## Tietze Transformations - various implementations
+# Tietze 1 (add relation)
+DeclareOperation("StzAddRelation", [IsStzPresentation, IsList]);
+DeclareOperation("StzAddRelationNC", [IsStzPresentation, IsList]);
+# Tietze 2 (remove relation)
+DeclareOperation("StzRemoveRelation", [IsStzPresentation, IsPosInt]);
+DeclareOperation("StzRemoveRelationNC", [IsStzPresentation, IsPosInt]);
+# Tietze 3 (add generator)
+DeclareOperation("StzAddGenerator", [IsStzPresentation, IsList]);
+DeclareOperation("StzAddGenerator", [IsStzPresentation,
+                                     IsElementOfFpSemigroup]);
+DeclareOperation("StzAddGenerator", [IsStzPresentation, IsList, IsString]);
+DeclareOperation("StzAddGenerator", [IsStzPresentation,
+                                     IsElementOfFpSemigroup,
+                                     IsString]);
+# Tietze 4 (remove generator)
+DeclareOperation("StzRemoveGenerator", [IsStzPresentation, IsPosInt]);
+DeclareOperation("StzRemoveGenerator", [IsStzPresentation, IsString]);
+DeclareOperation("StzRemoveGenerator", [IsStzPresentation, IsPosInt, IsPosInt]);
+DeclareOperation("StzRemoveGenerator", [IsStzPresentation, IsString, IsPosInt]);
+# Tietze 1/2 (substitute relation)
+DeclareOperation("StzSubstituteRelation",
+[IsStzPresentation, IsPosInt, IsPosInt]);
+
+DeclareOperation("StzPrintRelations", [IsStzPresentation]);
+DeclareOperation("StzPrintRelations", [IsStzPresentation, IsList]);
+DeclareOperation("StzPrintRelation", [IsStzPresentation, IsPosInt]);
+DeclareOperation("StzPrintGenerators", [IsStzPresentation]);
+DeclareOperation("StzPrintGenerators", [IsStzPresentation, IsList]);
+DeclareOperation("StzPrintPresentation", [IsStzPresentation]);
+
+# Information class for relation printing etc
+DeclareInfoClass("InfoFpSemigroup");
+SetInfoLevel(InfoFpSemigroup, 2);

--- a/gap/fp/tietze.gd
+++ b/gap/fp/tietze.gd
@@ -40,7 +40,7 @@ DeclareOperation("SimplifyFpSemigroup", [IsFpSemigroup]);
 DeclareAttribute("UnreducedFpSemigroup", IsFpSemigroup);
 DeclareAttribute("FpTietzeIsomorphism", IsFpSemigroup);
 
-DeclareOperation("TietzeIsomorphism", [IsStzPresentation]);
+DeclareOperation("StzIsomorphism", [IsStzPresentation]);
 
 ## Tietze Transformations - various implementations
 # Tietze 1 (add relation)

--- a/gap/fp/tietze.gd
+++ b/gap/fp/tietze.gd
@@ -19,7 +19,7 @@ DeclareAttribute("RelationsOfStzPresentation", IsStzPresentation);
 DeclareAttribute("GeneratorsOfStzPresentation", IsStzPresentation);
 
 # Stores original semigroup before reductions
-DeclareAttribute("UnreducedSemigroupOfStzPresentation", IsStzPresentation);
+DeclareAttribute("UnreducedFpSemigroup", IsStzPresentation);
 
 # Stores a map between the words of each semigroup (how?)
 # Change as relations change
@@ -37,7 +37,7 @@ DeclareOperation("SimplifiedFpSemigroup", [IsFpSemigroup]);
 DeclareOperation("SimplifyFpSemigroup", [IsFpSemigroup]);
 
 # FP semigroup attributes
-DeclareAttribute("UnreducedFpSemigroupOfFpSemigroup", IsFpSemigroup);
+DeclareAttribute("UnreducedFpSemigroup", IsFpSemigroup);
 DeclareAttribute("FpTietzeIsomorphism", IsFpSemigroup);
 
 DeclareOperation("TietzeIsomorphism", [IsStzPresentation]);

--- a/gap/fp/tietze.gi
+++ b/gap/fp/tietze.gi
@@ -100,7 +100,7 @@ function(stz, newGens)
 end);
 
 # TODO: TCL: maybe better to call this StzIsomorphism?
-InstallMethod(TietzeIsomorphism,
+InstallMethod(StzIsomorphism,
 [IsStzPresentation],
 function(stz)
   local source, range, forward_dict, forward_map, backward_dict, backward_map;
@@ -1604,7 +1604,7 @@ function(S)
   local stz;
   stz := StzPresentation(S);
   StzSimplifyPresentation(stz);
-  return TietzeIsomorphism(stz);
+  return StzIsomorphism(stz);
 end);
 
 ########################################################################

--- a/gap/fp/tietze.gi
+++ b/gap/fp/tietze.gi
@@ -52,7 +52,7 @@ function(S)
                                   out!.rels,
                                   GeneratorsOfStzPresentation,
                                   out!.gens,
-                                  UnreducedSemigroupOfStzPresentation,
+                                  UnreducedFpSemigroup,
                                   out!.unreducedSemigroup,
                                   TietzeForwardMap,
                                   out!.tietzeForwardMap,
@@ -79,7 +79,7 @@ function(stz)
     return stz!.rels;
 end);
 
-InstallMethod(UnreducedSemigroupOfStzPresentation,
+InstallMethod(UnreducedFpSemigroup,
 [IsStzPresentation],
 function(stz)
     return stz!.unreducedSemigroup;
@@ -114,7 +114,7 @@ InstallMethod(TietzeIsomorphism,
 [IsStzPresentation],
 function(stz)
   local source, range, forward_dict, forward_map, backward_dict, backward_map;
-  source := UnreducedSemigroupOfStzPresentation(stz);
+  source := UnreducedFpSemigroup(stz);
   range  := SEMIGROUPS.StzConvertObjToFpSemigroup(stz);
 
   # build forward map
@@ -357,7 +357,7 @@ function(stz)
   Info(InfoFpSemigroup, 1, status);
 
   # build free semigroup of old gens for display
-  oldgens := GeneratorsOfSemigroup(UnreducedSemigroupOfStzPresentation(stz));
+  oldgens := GeneratorsOfSemigroup(UnreducedFpSemigroup(stz));
   oldgens := List(oldgens, ViewString);
   oldfree := FreeSemigroup(oldgens);
   oldelms := GeneratorsOfSemigroup(oldfree);
@@ -648,7 +648,7 @@ InstallMethod(StzAddRelation,
 function(stz, pair)
   local s, pairwords, word;
   # retrieve original semigroup
-  s := UnreducedSemigroupOfStzPresentation(stz);
+  s := UnreducedFpSemigroup(stz);
   for word in pair do
     if not word in s then
       TryNextMethod();
@@ -711,7 +711,7 @@ InstallMethod(StzAddRelationNC,
 function(stz, pair)
   local s, pairwords, word;
   # retrieve original semigroup
-  s := UnreducedSemigroupOfStzPresentation(stz);
+  s := UnreducedFpSemigroup(stz);
   for word in pair do
     if not word in s then
       TryNextMethod();
@@ -833,7 +833,7 @@ function(stz, word)
   local letterrepword;
   # argument check: word should be an element of the unreduced semigroup
   # (that way we can express it as a word on the current tietze generators)
-  if not word in UnreducedSemigroupOfStzPresentation(stz) then
+  if not word in UnreducedFpSemigroup(stz) then
     TryNextMethod();
   fi;
 
@@ -886,7 +886,7 @@ function(stz, word, name)
   local letterrepword;
   # argument check: word should be an element of the unreduced semigroup
   # (that way we can express it as a word on the current tietze generators)
-  if not word in UnreducedSemigroupOfStzPresentation(stz) then
+  if not word in UnreducedFpSemigroup(stz) then
     TryNextMethod();
   fi;
 
@@ -1596,7 +1596,7 @@ function(S)
   local T, map;
   map := SimplifyFpSemigroup(S);
   T := Range(map);
-  SetUnreducedFpSemigroupOfFpSemigroup(T, S);
+  SetUnreducedFpSemigroup(T, S);
   SetFpTietzeIsomorphism(T, map);
   return T;
 end);

--- a/gap/fp/tietze.gi
+++ b/gap/fp/tietze.gi
@@ -1,0 +1,1636 @@
+############################################################################
+##
+##  tietze.gi
+##  Copyright (C) 2021                                    Tom Conti-Leslie
+##                                                              Ben Spiers
+##
+##  Licensing information can be found in the README file of this package.
+##
+############################################################################
+##
+
+########################################################################
+# This file is organised as follows:
+#
+# 1.  Definition of the Semigroup Tietze (IsStzPresentation) object
+# 2.  Viewing methods for IsStzPresentation objects
+# 3.  Internal Tietze transformation functions
+# 4.  User-accessible Tietze transformation functions (wrappers)
+# 5.  Internal helper functions for word/relation manipulation etc.
+# 6.  Internal auto-checkers and appliers for presentation simplifying
+# 7.  SimplifyPresentation etc.
+# 8.  Other
+########################################################################
+
+########################################################################
+# 1. Definition of the Semigroup Tietze (IsStzPresentation) object
+########################################################################
+
+InstallMethod(StzPresentation, "for a finitely presented semigroup",
+[IsFpSemigroup],
+function(S)
+  local gens, out, rels, type;
+
+  type := NewType(NewFamily("StzFamily", IsStzPresentation),
+                  IsStzPresentation and IsComponentObjectRep);
+
+  rels := List(RelationsOfFpSemigroup(S),
+              x -> [LetterRepAssocWord(x[1]), LetterRepAssocWord(x[2])]);
+  gens := List(GeneratorsOfSemigroup(S), x -> ViewString(x));
+
+  out := rec(gens               := gens,
+             rels               := rels,
+             unreducedSemigroup := S,
+             tietzeForwardMap   := List([1 .. Length(GeneratorsOfSemigroup(S))],
+                                        x -> [x]),
+             tietzeBackwardMap  := List([1 .. Length(GeneratorsOfSemigroup(S))],
+                                        x -> [x]),
+             usedGens           := Set(gens));
+
+  return ObjectifyWithAttributes(out, type,
+                                  RelationsOfStzPresentation,
+                                  out!.rels,
+                                  GeneratorsOfStzPresentation,
+                                  out!.gens,
+                                  UnreducedSemigroupOfStzPresentation,
+                                  out!.unreducedSemigroup,
+                                  TietzeForwardMap,
+                                  out!.tietzeForwardMap,
+                                  TietzeBackwardMap,
+                                  out!.tietzeBackwardMap);
+end);
+
+InstallMethod(SetRelationsOfStzPresentation,
+[IsStzPresentation, IsList],
+function(stz, arg)
+  if not ForAll(arg, IsList) or
+      not ForAll(arg, x -> Length(x) = 2 and ForAll(x, IsList)) or
+      not ForAll(arg, x -> ForAll(x, y -> ForAll(y, IsPosInt))) then
+        ErrorNoReturn("SetRelationsOfStzPresentation:\n",
+                      "parameter <arg> must be a list of pairs of words in\n",
+                      "LetterRep format");
+  fi;
+  stz!.rels := arg;
+end);
+
+InstallMethod(RelationsOfStzPresentation,
+[IsStzPresentation],
+function(stz)
+    return stz!.rels;
+end);
+
+InstallMethod(UnreducedSemigroupOfStzPresentation,
+[IsStzPresentation],
+function(stz)
+    return stz!.unreducedSemigroup;
+end);
+
+InstallMethod(TietzeForwardMap,
+[IsStzPresentation],
+function(stz)
+    return stz!.tietzeForwardMap;
+end);
+
+InstallMethod(TietzeBackwardMap,
+[IsStzPresentation],
+function(stz)
+    return stz!.tietzeBackwardMap;
+end);
+
+InstallMethod(GeneratorsOfStzPresentation,
+[IsStzPresentation],
+function(stz)
+    return stz!.gens;
+end);
+
+InstallMethod(SetGeneratorsOfStzPresentation,
+[IsStzPresentation, IsList],
+function(stz, newGens)
+    stz!.gens := newGens;
+end);
+
+# TODO: TCL: maybe better to call this StzIsomorphism?
+InstallMethod(TietzeIsomorphism,
+[IsStzPresentation],
+function(stz)
+  local source, range, forward_dict, forward_map, backward_dict, backward_map;
+  source := UnreducedSemigroupOfStzPresentation(stz);
+  range  := SEMIGROUPS.StzConvertObjToFpSemigroup(stz);
+
+  # build forward map
+  forward_dict := TietzeForwardMap(stz);
+  forward_map  := function(word)
+    local new_word;
+    new_word := SEMIGROUPS.StzExpandWord(
+                LetterRepAssocWord(UnderlyingElement(word)), forward_dict);
+    return Product(new_word, x -> GeneratorsOfSemigroup(range)[x]);
+  end;
+
+  # build backward map
+  backward_dict := TietzeBackwardMap(stz);
+  backward_map  := function(word)
+    local new_word;
+    new_word := SEMIGROUPS.StzExpandWord(
+                LetterRepAssocWord(UnderlyingElement(word)), backward_dict);
+    return Product(new_word, x -> GeneratorsOfSemigroup(source)[x]);
+  end;
+
+  # TODO: are we okay to assume this is necessarily an isomorphism?
+  return MagmaIsomorphismByFunctionsNC(source,
+                                       range,
+                                       forward_map,
+                                       backward_map);
+
+end);
+
+InstallMethod(SetTietzeForwardMap,
+[IsStzPresentation, IsList],
+function(stz, newMaps)
+    if not ForAll(newMaps, x -> IsList(x) and ForAll(x, IsPosInt)) then
+      ErrorNoReturn("SetTietzeForwardMap: second argument <newMaps> must\n",
+                    "be a list of lists of positive integers");
+    fi;
+    stz!.tietzeForwardMap := newMaps;
+end);
+
+InstallMethod(SetTietzeBackwardMap,
+[IsStzPresentation, IsList],
+function(stz, newMaps)
+    if not ForAll(newMaps, x -> IsList(x) and ForAll(x, IsPosInt)) then
+      ErrorNoReturn("SetTietzeBackwardMap: second argument <newMaps> must\n",
+                    "be a list of lists of positive integers");
+    fi;
+    stz!.tietzeBackwardMap := newMaps;
+end);
+
+InstallMethod(TietzeForwardMapReplaceSubword,
+[IsStzPresentation, IsList, IsList],
+function(stz, subWord, newSubWord)
+    local newMaps;
+    newMaps := List(stz!.tietzeForwardMap,
+                    x -> SEMIGROUPS.StzReplaceSubwordRel(x,
+                                                         subWord,
+                                                         newSubWord));
+    stz!.tietzeForwardMap := newMaps;
+end);
+
+# Length of an StzPresentation is defined as the number of generators plus the
+# length of every word in the defining relations
+InstallMethod(Length,
+[IsStzPresentation],
+function(stz)
+    local out, rels, rel;
+    out := Length(stz!.gens);
+    rels := RelationsOfStzPresentation(stz);
+    for rel in rels do
+        out := out + Length(rel[1]) + Length(rel[2]);
+    od;
+    return out;
+end);
+
+InstallMethod(\<,
+[IsStzPresentation, IsStzPresentation],
+function(stz1, stz2)
+    return Length(stz1) < Length(stz2);
+end);
+
+########################################################################
+# 2. Viewing methods for IsStzPresentation objects
+########################################################################
+
+InstallMethod(ViewString,
+[IsStzPresentation],
+function(stz)
+    local str;
+    str := "<fp semigroup presentation with ";
+    Append(str, String(Length(stz!.gens)));
+    Append(str, " generator");
+    if Length(stz!.gens) > 1 then
+        Append(str, "s");
+    fi;
+    Append(str, " and ");
+    Append(str, String(Length(stz!.rels)));
+    Append(str, " relation");
+    if Length(stz!.rels) <> 1 then
+        Append(str, "s");
+    fi;
+    Append(str, "\< with length ");
+    Append(str, String(Length(stz)));
+    Append(str, ">");
+    return str;
+end);
+
+SEMIGROUPS.StzRelationDisplayString := function(stz, i)
+  local rels, f, gens, w1, w2, out;
+  rels := RelationsOfStzPresentation(stz);
+  if i > Length(rels) then
+    return fail;
+  else
+    # We'd like patterns to be grouped, i.e. abab=(ab)^2 when displayed. To
+    # do this we sneakily piggyback off display methods for the free semigroup.
+    f    := FreeSemigroup(GeneratorsOfStzPresentation(stz));
+    gens := GeneratorsOfSemigroup(f);
+    w1   := Product(rels[i][1], x -> gens[x]);
+    w2   := Product(rels[i][2], x -> gens[x]);
+    out  := Concatenation(PrintString(i),
+                          ". ",
+                          PrintString(w1),
+                          " = ",
+                          PrintString(w2));
+    return out;
+  fi;
+end;
+
+InstallMethod(StzPrintRelations,
+"For an stz presentation and a list of pos ints",
+[IsStzPresentation, IsList],
+function(stz, list)
+  local i;
+  # This function displays the current relations in terms of the current
+  # generators for a semigroup Tietze presentation.
+  if RelationsOfStzPresentation(stz) = [] then
+    Info(InfoFpSemigroup, 1, "There are no relations in the presentation <stz>");
+  fi;
+
+  # Print relations at each index of the list, unless incorrect index,
+  # in which case skip.
+  for i in list do
+    if IsPosInt(i) and i <= Length(RelationsOfStzPresentation(stz)) then
+      Info(InfoFpSemigroup, 1, SEMIGROUPS.StzRelationDisplayString(stz, i));
+    fi;
+  od;
+end);
+
+InstallMethod(StzPrintRelations, "For an stz presentation",
+[IsStzPresentation],
+function(stz)
+  StzPrintRelations(stz, [1 .. Length(RelationsOfStzPresentation(stz))]);
+end);
+
+InstallMethod(StzPrintRelation, "For an stz presentation and a pos int",
+[IsStzPresentation, IsPosInt],
+function(stz, int)
+  StzPrintRelations(stz, [int]);
+end);
+
+InstallMethod(StzPrintGenerators,
+"For an stz presentation and a list of pos ints",
+[IsStzPresentation, IsList],
+function(stz, list)
+  local flat, gens, out, rel, i;
+  # This function displays a list of generators and number of occurences
+  # of each
+
+  # warn if there are no generators in the list (not sure this could happen)
+  if GeneratorsOfStzPresentation(stz) = [] then
+    Info(InfoFpSemigroup, 1,
+         "There are no generators in the presentation <stz>");
+  fi;
+
+  # create flat flat list of relations to count occurrences
+  flat := [];
+  for rel in RelationsOfStzPresentation(stz) do
+    Append(flat, rel[1]);
+    Append(flat, rel[2]);
+  od;
+
+  # enumerate and count generators
+  gens := GeneratorsOfStzPresentation(stz);
+  for i in list do
+    # only print if requested index is valid
+    if IsPosInt(i) and i <= Length(gens) then
+      out := Concatenation(PrintString(i),
+                           ".  ",
+                           gens[i],
+                           "  ",
+                           PrintString(Number(flat, x -> x = i)),
+                           " occurrences");
+      Info(InfoFpSemigroup, 1, out);
+    fi;
+  od;
+end);
+
+InstallMethod(StzPrintGenerators, "For an stz presentation",
+[IsStzPresentation],
+function(stz)
+  StzPrintGenerators(stz, [1 .. Length(GeneratorsOfStzPresentation(stz))]);
+end);
+
+InstallMethod(StzPrintPresentation, "For an stz presentation",
+[IsStzPresentation],
+function(stz)
+  local status, oldgens, oldfree, oldelms, newgens, newfree, newelms, w, i;
+  # prints everything that is known about the presentation.
+
+  # current generators
+  Info(InfoFpSemigroup, 1, "Current generators:");
+  StzPrintGenerators(stz);
+
+  # current relations
+  Info(InfoFpSemigroup, 1, "");
+  Info(InfoFpSemigroup, 1, "Current relations:");
+  StzPrintRelations(stz);
+
+  # total number and total length
+  Info(InfoFpSemigroup, 1, "");
+  status := "There ";
+  if Length(stz!.gens) = 1 then
+    status := Concatenation(status, "is 1 generator");
+  else
+    status := Concatenation(status,
+                            "are ",
+                            PrintString(Length(stz!.gens)),
+                            " generators");
+  fi;
+  status := Concatenation(status, " and ");
+  if Length(stz!.rels) = 1 then
+    status := Concatenation(status, "1 relation");
+  else
+    status := Concatenation(status,
+                            PrintString(Length(stz!.rels)),
+                            " relations");
+  fi;
+  status := Concatenation(status,
+                          " of total length ",
+                          PrintString(Length(stz)),
+                          ".");
+  Info(InfoFpSemigroup, 1, status);
+
+  # build free semigroup of old gens for display
+  oldgens := GeneratorsOfSemigroup(UnreducedSemigroupOfStzPresentation(stz));
+  oldgens := List(oldgens, ViewString);
+  oldfree := FreeSemigroup(oldgens);
+  oldelms := GeneratorsOfSemigroup(oldfree);
+
+  # build free semigroup of new gens for display
+  newgens := GeneratorsOfStzPresentation(stz);
+  newfree := FreeSemigroup(newgens);
+  newelms := GeneratorsOfSemigroup(newfree);
+
+  # old generators expressed using current ones
+  Info(InfoFpSemigroup, 1, "");
+  Info(InfoFpSemigroup, 1, "Generators of original fp semigroup expressed as");
+  Info(InfoFpSemigroup, 1,
+       "combinations of generators in current presentation:");
+  for i in [1 .. Length(oldgens)] do
+    w := Product(TietzeForwardMap(stz)[i], x -> newelms[x]);
+    Info(InfoFpSemigroup, 1, Concatenation(PrintString(i),
+                                       ". ",
+                                       oldgens[i],
+                                       " = ",
+                                       PrintString(w)));
+  od;
+
+  # new generators expressed using old ones
+  Info(InfoFpSemigroup, 1, "");
+  Info(InfoFpSemigroup, 1, "Generators of current presentation expressed as");
+  Info(InfoFpSemigroup, 1,
+       "combinations of generators of original fp semigroup:");
+  for i in [1 .. Length(newgens)] do
+    w := Product(TietzeBackwardMap(stz)[i], x -> oldelms[x]);
+    Info(InfoFpSemigroup, 1, Concatenation(PrintString(i),
+                                       ". ",
+                                       newgens[i],
+                                       " = ",
+                                       PrintString(w)));
+  od;
+end);
+
+########################################################################
+# 3. Internal Tietze transformation functions
+########################################################################
+
+# TIETZE TRANSFORMATION 1: INTERNAL: ADD REDUNDANT RELATION - NO CHECK
+SEMIGROUPS.TietzeTransformation1 := function(stz, pair)
+  local rels_copy;
+  # Arguments:
+  # - <stz> should be a Semigroup Tietze (IsStzPresentation) object.
+  # - <pair> should be a list containing two LetterRep words.
+  #
+  # This function returns nothing, and modifies <stz> in place by adding a new
+  # relation given by <pair>. This relation is assumed to be redundant based
+  # on the relations already present in RelationsOfStzPresentation(<stz>)
+  # (although this is not checked).
+  #
+  # WARNING: this is an internal function and performs only minimal argument
+  # checks. Entering arguments in the wrong format may result in errors that
+  # are difficult to interpret. Argument checks are carried out in the
+  # analogous, documented function: StzAddRelation. However, these checks
+  # may not terminate in some cases.
+
+  # Add relation
+  rels_copy := ShallowCopy(RelationsOfStzPresentation(stz));
+  Add(rels_copy, pair);
+  stz!.rels := rels_copy;
+  return;
+end;
+
+# TIETZE TRANSFORMATION 2: INTERNAL: REMOVE REDUNDANT RELATION - NO CHECK
+SEMIGROUPS.TietzeTransformation2 := function(stz, index)
+  local rels_copy;
+  # Arguments:
+  # - <stz> should be a Semigroup Tietze (IsStzPresentation) object.
+  # - <index> should be the index of the relation in
+  #   RelationsOfStzPresentation(<stz>) that needs to be removed.
+  #
+  # This function returns nothing, and modifies <stz> in place by removing
+  # relation number <index>, assumed to be redundant (though redundancy of
+  # that relation is not checked).
+  #
+  # WARNING: this is an internal function and performs only minimal argument
+  # checks. Entering arguments in the wrong format may result in errors that
+  # are difficult to interpret. Argument checks are carried out in the
+  # analogous, documented function: StzRemoveRelation. However, these checks
+  # may not terminate in some cases.
+
+  # Remove relation
+  rels_copy := ShallowCopy(RelationsOfStzPresentation(stz));
+  Remove(rels_copy, index);
+  stz!.rels := rels_copy;
+end;
+
+# TIETZE TRANSFORMATION 3: INTERNAL: ADD NEW GENERATOR - NO CHECK
+SEMIGROUPS.TietzeTransformation3 := function(stz, word, name)
+  local new_gens, new_rels, back_word, new_maps, letter;
+  # Arguments:
+  # - <stz> should be a Semigroup Tietze (IsStzPresentation) object.
+  # - <word> should be a LetterRep word.
+  # - <name> should be a string, or fail.
+  #
+  # This function returns nothing, and modifies <stz> in place by adding a new
+  # generator and the relation gen = <word>.
+  # The name for the new generator is <name>, unless this argument is fail,
+  # in which case the name is automatically generated using
+  # SEMIGROUPS.NewGeneratorName.
+  # This function also updates the Tietze backwards map so that the new
+  # generator can be expressed as a word on the generators of the original
+  # semigroup.
+  #
+  # WARNING: this is an internal function and performs only minimal argument
+  # checks. Entering arguments in the wrong format may result in errors that
+  # are difficult to interpret. Argument checks are carried out in the
+  # analogous, documented function: StzAddGenerator.
+
+  # Add new generator string to the list of gens in similar format
+  new_gens := ShallowCopy(stz!.gens);
+  new_rels := ShallowCopy(stz!.rels);
+  if name = fail or name in stz!.gens then
+    # either name was not specified, or it was but is already a generator.
+    # generate a new generator name, as of yet unused.
+    Add(new_gens, SEMIGROUPS.NewGeneratorName(List(stz!.usedGens)));
+  else
+    # this must mean the argument is a string as of yet unused, so add that
+    Add(new_gens, ShallowCopy(name));
+  fi;
+
+  # in either case we have added a new generator: for cosmetic reasons,
+  # prohibit that generator name from being auto-used again (in case we delete
+  # it)
+  UniteSet(stz!.usedGens, new_gens);
+
+  # Add relation setting new gen equal to <word>
+  Add(new_rels, [word, [Length(stz!.gens) + 1]]);
+
+  # Update internal representation of the stz object
+  SetGeneratorsOfStzPresentation(stz, new_gens);
+  SetRelationsOfStzPresentation(stz, new_rels);
+
+  # Now we need to update the backwards map to express the new generator in
+  # terms of the original generators.
+  back_word := [];
+  new_maps  := ShallowCopy(TietzeBackwardMap(stz));
+  for letter in word do
+    Append(back_word, new_maps[letter]);
+  od;
+  Add(new_maps, back_word);
+  SetTietzeBackwardMap(stz, new_maps);
+end;
+
+# TIETZE TRANSFORMATION 4: INTERNAL: REMOVE GENERATOR - MINIMAL CHECKS
+SEMIGROUPS.TietzeTransformation4 := function(stz, gen, index)
+  local found_expr, expr, decrement, tempMaps, tempRels, tempGens;
+  # Arguments:
+  # - <stz> should be a Semigroup Tietze (IsStzPresentation) object.
+  # - <gen> should be a pos int.
+  # - <index> should be a pos int.
+  #
+  # This function returns nothing, and modifies <stz> in place by removing
+  # generator number <gen> using relation number <index>.
+  # If relation number <index> of <stz> is not of the form
+  # [<gen>] = *some word not including <gen>* (or that relation flipped),
+  # then this function throws ErrorNoReturn.
+  # This function also updates the Tietze forward map, so that any generator
+  # in the original semigroup expressed as a combination of generators
+  # including <gen> is now represented without using <gen> (since <gen>
+  # has been removed).
+  #
+  # WARNING: this is an internal function and performs only minimal argument
+  # checks. Entering arguments in the wrong format may result in errors that
+  # are difficult to interpret. Argument checks are carried out in the
+  # analogous, documented function: StzRemoveGenerator.
+
+  # check we can express <gen> using only other generators with relation
+  # number <index>
+  found_expr := false;
+  if stz!.rels[index][1] = [gen] and not gen in stz!.rels[index][2] then
+    expr := stz!.rels[index][2];
+    found_expr := true;
+  elif stz!.rels[index][2] = [gen] and not gen in stz!.rels[index][1] then
+    expr := stz!.rels[index][1];
+    found_expr := true;
+  fi;
+
+  # check we found an expression for <gen>. If not, nothing can be done.
+  if not found_expr then
+    ErrorNoReturn("TietzeTransformation4, internal function: third argument\n",
+                  "<index> does not point to a relation expressing second\n",
+                  "argument <gen> as a combination of other generators");
+  fi;
+
+  # Define decrement function to bump down generator numbers past the one
+  # we're going to remove
+  decrement := function(z)
+    if z <= gen then  # shouldn't be equal but just in case
+      return z;
+    else
+      return z - 1;
+    fi;
+  end;
+
+  # update forward mapping component
+  # TODO: do we really need TietzeForwardMapReplaceSubword?
+  TietzeForwardMapReplaceSubword(stz, [gen], expr);
+  tempMaps := ShallowCopy(TietzeForwardMap(stz));
+  Apply(tempMaps, x -> List(x, decrement));
+  SetTietzeForwardMap(stz, tempMaps);
+
+  # remove generator from backward mapping component
+  tempMaps := ShallowCopy(TietzeBackwardMap(stz));
+  Remove(tempMaps, gen);
+  SetTietzeBackwardMap(stz, tempMaps);
+
+  # sub in expression we found and remove relation we used for gen
+  tempRels := ShallowCopy(RelationsOfStzPresentation(stz));
+  Remove(tempRels, index);
+  tempRels := SEMIGROUPS.StzReplaceSubword(tempRels, [gen], expr);
+  SetRelationsOfStzPresentation(stz, tempRels);
+  Apply(stz!.rels, x -> List(x, y -> List(y, decrement)));
+
+  # remove generator.
+  tempGens := ShallowCopy(GeneratorsOfStzPresentation(stz));
+  Remove(tempGens, gen);
+  SetGeneratorsOfStzPresentation(stz, tempGens);
+end;
+
+########################################################################
+# 4. User-accessible Tietze transformation functions (wrappers)
+########################################################################
+
+# Tietze Transformation 1: Add relation
+InstallMethod(StzAddRelation, "For an stz presentation and a pair of words",
+[IsStzPresentation, IsList],
+1,  # bump ahead of next implementation and do the list size arg check here
+function(stz, pair)
+  local n, f, free_fam, r, s, fp_fam, w1, w2, p1, p2, word, letter;
+  # <pair> should be a pair of LetterRep words.
+
+  # argument checks:
+  if Length(pair) <> 2 then
+    ErrorNoReturn("StzAddRelation: second argument <pair> should be a list\n",
+                  "of length 2");
+  fi;
+  n := Length(stz!.gens);
+  for word in pair do
+    if not IsList(word) then
+      TryNextMethod();  # pass this on to the case where the list may be a pair
+                        # of words in OG semigroup
+    elif Length(word) = 0 then
+      ErrorNoReturn("StzAddRelation: words in second argument <pair> should\n",
+                    "be non-empty");
+    else
+      for letter in word do
+        if not (IsPosInt(letter) and letter <= n) then
+          ErrorNoReturn("StzAddRelation: words in second argument <pair>\n",
+                        "should be lists of pos ints no greater than the\n",
+                        "number of generators of first argument <stz>");
+        fi;
+      od;
+    fi;
+  od;
+
+  # check that the pair can be deduced from the other relations, by
+  # creating fp semigroup with current relations.
+  f        := FreeSemigroup(stz!.gens);  # base free semigroup
+  free_fam := FamilyObj(f.1);            # marrow for creating free semigp words
+  r        := List(stz!.rels,
+                   x -> List(x, y -> AssocWordByLetterRep(free_fam, y)));
+  s        := f / r;                    # fp semigroup
+  fp_fam   := FamilyObj(s.1);           # marrow for creating fp words
+  # words first in free semigroup, then map to fp semigroup:
+  w1       := AssocWordByLetterRep(free_fam, pair[1]);
+  w2       := AssocWordByLetterRep(free_fam, pair[2]);
+  p1       := ElementOfFpSemigroup(fp_fam, w1);
+  p2       := ElementOfFpSemigroup(fp_fam, w2);
+  # check if words are equal in the fp semigroup
+  # WARNING: may run forever if undecidable
+  if p1 = p2 then
+    SEMIGROUPS.TietzeTransformation1(stz, pair);
+    return;
+  else
+    ErrorNoReturn("StzAddRelation: second argument <pair> must list two\n",
+                  "words that are equal in the presentation <stz>");
+  fi;
+end);
+
+InstallMethod(StzAddRelation,
+"For an stz presentation and a pair of semigroup elements",
+[IsStzPresentation, IsList],
+function(stz, pair)
+  local s, pairwords, word;
+  # retrieve original semigroup
+  s := UnreducedSemigroupOfStzPresentation(stz);
+  for word in pair do
+    if not word in s then
+      TryNextMethod();
+    fi;
+  od;
+
+  # convert into words in original semigroup
+  pairwords := List(pair, UnderlyingElement);
+  Apply(pairwords, LetterRepAssocWord);
+  # map to words in new semigroup
+  Apply(pairwords, x -> SEMIGROUPS.StzExpandWord(x, TietzeForwardMap(stz)));
+
+  # apply tietze1, with argument checks
+  StzAddRelation(stz, pairwords);
+  return;
+end);
+
+# Tietze Transformation 1: Add relation (NO REDUNDANCY CHECK)
+InstallMethod(StzAddRelationNC, "For an stz presentation and a pair of words",
+[IsStzPresentation, IsList],
+1,  # bump priority, do list size check here
+function(stz, pair)
+  local n, word, letter;
+  # <pair> should be a pair of LetterRep words.
+
+  # argument checks:
+  if Length(pair) <> 2 then
+    ErrorNoReturn("StzAddRelationNC: second argument <pair> should be a list\n",
+                  "of length 2");
+  fi;
+  n := Length(stz!.gens);
+  for word in pair do
+    if not IsList(word) then
+      TryNextMethod();  # pass this on to the case where the list may be a pair
+                        # of words in OG semigroup
+    elif Length(word) = 0 then
+      ErrorNoReturn("StzAddRelationNC: words in second argument <pair>\n",
+                    "should be non-empty");
+    else
+      for letter in word do
+        if not (IsPosInt(letter) and letter <= n) then
+          ErrorNoReturn("StzAddRelationNC: words in second argument <pair>\n",
+                        "should be lists of pos ints no greater than the\n",
+                        "number of generators of first argument <stz>");
+        fi;
+      od;
+    fi;
+  od;
+
+  # WARNING: no checks are run to verify that the pair is redundant. This
+  # may result in an output semigroup which is non-isomorphic to the
+  # starting semigroup.
+  SEMIGROUPS.TietzeTransformation1(stz, pair);
+  return;
+end);
+
+InstallMethod(StzAddRelationNC,
+"For an stz presentation and a pair of semigroup elements",
+[IsStzPresentation, IsList],
+function(stz, pair)
+  local s, pairwords, word;
+  # retrieve original semigroup
+  s := UnreducedSemigroupOfStzPresentation(stz);
+  for word in pair do
+    if not word in s then
+      TryNextMethod();
+    fi;
+  od;
+
+  # convert into words in original semigroup
+  pairwords := List(pair, UnderlyingElement);
+  Apply(pairwords, LetterRepAssocWord);
+  # map to words in new semigroup
+  Apply(pairwords, x -> SEMIGROUPS.StzExpandWord(x, TietzeForwardMap(stz)));
+
+  # apply tietze1, without argument checks
+  # WARNING: no checks are run to verify that the pair is redundant. This
+  # may result in an output semigroup which is non-isomorphic to the
+  # starting semigroup.
+  SEMIGROUPS.TietzeTransformation1(stz, pairwords);
+  return;
+end);
+
+# Tietze Transformation 2: Remove relation
+InstallMethod(StzRemoveRelation,
+"For an stz presentation and a pos int",
+[IsStzPresentation, IsPosInt],
+function(stz, index)
+  local rels, pair, new_f, new_gens, new_s, free_fam, w1, w2, fp_fam, p1, p2;
+  # <index> should be the index of the relation needing removing in the
+  # overall list of relations.
+
+  # argument check: valid index
+  rels := ShallowCopy(stz!.rels);
+  if index > Length(rels) then
+    ErrorNoReturn("StzRemoveRelation: second argument <index> must be less\n",
+                  "than or equal to the number of relations of the first\n",
+                  "argument <stz>");
+  fi;
+
+  # create hypothetical fp semigroup that would be the result of removing
+  # the requested pair
+  pair := rels[index];
+  Remove(rels, index);
+  new_f    := FreeSemigroup(stz!.gens);
+  new_gens := GeneratorsOfSemigroup(new_f);
+  new_s    := new_f / List(rels,
+                           x -> List(x,
+                                     y -> Product(List(y,
+                                                       z -> new_gens[z]))));
+
+  # create two associative words
+  free_fam := FamilyObj(new_f.1);
+  w1       := AssocWordByLetterRep(free_fam, pair[1]);
+  w2       := AssocWordByLetterRep(free_fam, pair[2]);
+
+  # map these words to hypothetical fp semigroup words and check equality
+  fp_fam := FamilyObj(new_s.1);
+  p1     := ElementOfFpSemigroup(fp_fam, w1);
+  p2     := ElementOfFpSemigroup(fp_fam, w2);
+
+  # WARNING: may run forever if undecidable
+  if p1 = p2 then
+    SEMIGROUPS.TietzeTransformation2(stz, index);
+    return;
+  else
+    ErrorNoReturn("StzRemoveRelation: second argument <index> must point to\n",
+                  "a relation that is redundant in the presentation <stz>");
+  fi;
+end);
+
+# Tietze Transformation 2: Remove relation (NO REDUNDANCY CHECK)
+InstallMethod(StzRemoveRelationNC,
+"For an stz presentation and a pos int",
+[IsStzPresentation, IsPosInt],
+function(stz, index)
+  if index > Length(RelationsOfStzPresentation(stz)) then
+    ErrorNoReturn("StzRemoveRelationNC: second argument <index> must be less\n",
+                  "than or equal to the number of relations of the first\n",
+                  "argument <stz>");
+  fi;
+
+  # WARNING: no checks are run to verify that the pair is redundant. This
+  # may result in an output semigroup which is non-isomorphic to the
+  # starting semigroup.
+  SEMIGROUPS.TietzeTransformation2(stz, index);
+  return;
+end);
+
+# Tietze Transformation 3: Add generator
+InstallMethod(StzAddGenerator,
+"For an stz presentation and a LetterRep word",
+[IsStzPresentation, IsList],
+function(stz, word)
+  local n, letter;
+  # argument checks
+  if Length(word) = 0 then
+    ErrorNoReturn("StzAddGenerator: cannot add generator equal to the empty\n",
+                  "word");
+  fi;
+  n := Length(GeneratorsOfStzPresentation(stz));
+  for letter in word do
+    if not (IsPosInt(letter) and letter <= n) then
+      # the argument has not been entered as a list of pos ints. Pass off to
+      # potential future methods for Tietze3, but this is likely to be a
+      # mistake.
+      ErrorNoReturn("StzAddGenerator: second argument <word> is not a\n",
+                    "list of pos ints at most equal to the number of\n",
+                    "generators of the first argument <stz>");
+    fi;
+  od;
+
+  # at this point all is good, so request new generator to be added with
+  # a new generator name auto-created.
+  SEMIGROUPS.TietzeTransformation3(stz, word, fail);
+end);
+
+InstallMethod(StzAddGenerator,
+"For an stz presentation and a fp semigroup element",
+[IsStzPresentation, IsElementOfFpSemigroup],
+function(stz, word)
+  local letterrepword;
+  # argument check: word should be an element of the unreduced semigroup
+  # (that way we can express it as a word on the current tietze generators)
+  if not word in UnreducedSemigroupOfStzPresentation(stz) then
+    TryNextMethod();
+  fi;
+
+  # if we do have an element of s, use the forward map to express it as a word
+  # on the current generators, then run the original implementation of Tietze 3.
+  letterrepword := SEMIGROUPS.StzExpandWord(
+                     LetterRepAssocWord(UnderlyingElement(word)),
+                     TietzeForwardMap(stz));
+  StzAddGenerator(stz, letterrepword);
+end);
+
+# Tietze Transformation 3: Add generator (with specified new generator name)
+InstallMethod(StzAddGenerator,
+"For an stz presentation, a LetterRep word and a string",
+[IsStzPresentation, IsList, IsString],
+function(stz, word, name)
+  local n, letter;
+  # argument check 0: new word is non-empty
+  if Length(word) = 0 then
+    ErrorNoReturn("StzAddGenerator: cannot add generator equal to the empty\n",
+                  "word");
+  fi;
+  # argument check 1: word is a valid word
+  n := Length(GeneratorsOfStzPresentation(stz));
+  for letter in word do
+    if not (IsPosInt(letter) and letter <= n) then
+      # the argument has not been entered as a list of pos ints. Pass off to
+      # potential future methods for Tietze3, but this is likely to be a
+      # mistake.
+      ErrorNoReturn("StzAddGenerator: second argument <word> is not a\n",
+                    "list of pos ints at most equal to the number of\n",
+                    "generators of the first argument <stz>");
+    fi;
+  od;
+
+  # argument check 2: requested generator name not yet used
+  if name in GeneratorsOfStzPresentation(stz) then
+    ErrorNoReturn("StzAddGenerator: third argument <name> should not be the\n",
+                  "name of a pre-existing generator");
+  fi;
+
+  # otherwise we are all good
+  SEMIGROUPS.TietzeTransformation3(stz, word, name);
+end);
+
+InstallMethod(StzAddGenerator,
+"For an stz presentation, a fp semigroup element and a string",
+[IsStzPresentation, IsElementOfFpSemigroup, IsString],
+function(stz, word, name)
+  local letterrepword;
+  # argument check: word should be an element of the unreduced semigroup
+  # (that way we can express it as a word on the current tietze generators)
+  if not word in UnreducedSemigroupOfStzPresentation(stz) then
+    TryNextMethod();
+  fi;
+
+  # if we do have an element of s, use the forward map to express it as a word
+  # on the current generators, then run the original implementation of Tietze 3.
+  letterrepword := SEMIGROUPS.StzExpandWord(
+                     LetterRepAssocWord(UnderlyingElement(word)),
+                     TietzeForwardMap(stz));
+  StzAddGenerator(stz, letterrepword, name);
+end);
+
+# Tietze Transformation 4: Remove generator
+InstallMethod(StzRemoveGenerator,
+"For an stz presentation and a positive integer",
+[IsStzPresentation, IsPosInt],
+function(stz, gen)
+  local found, index, i, rels;
+  # argument check 1: requested removal is potentially possible
+  if Length(GeneratorsOfStzPresentation(stz)) = 1 then
+    ErrorNoReturn("StzRemoveGenerator: cannot remove only remaining\n",
+                  "generator \"",
+                  GeneratorsOfStzPresentation(stz)[1],
+                  "\"");
+  elif gen > Length(GeneratorsOfStzPresentation(stz)) then
+    ErrorNoReturn("StzRemoveGenerator: second argument <gen> must be no\n",
+                  "greater than the total number of generators");
+  fi;
+
+  # argument check 2: generator can be expressed as a product of others.
+  # this check has to be repeated inside Tietze4, but we include it here to
+  # ensure that an incorrect input is clearly reported to the user.
+  found := false;
+  rels  := RelationsOfStzPresentation(stz);
+  for i in [1 .. Length(rels)] do
+    if  (rels[i][1] = [gen] and not gen in rels[i][2]) or
+        (rels[i][2] = [gen] and not gen in rels[i][1]) then
+      found := true;
+      index := i;
+      continue;
+    fi;
+  od;
+  if not found then
+    ErrorNoReturn("StzRemoveGenerator: there is no relation in first\n",
+                  "argument <stz> expressing second argument <gen> as a\n",
+                  "product of other generators");
+  fi;
+
+  # otherwise all good; apply internal Tietze 4 function (it will check
+  # whether any relation can actually express that generator as a combination
+  # of others)
+  SEMIGROUPS.TietzeTransformation4(stz, gen, index);
+end);
+
+InstallMethod(StzRemoveGenerator,
+"For an stz presentation and a generator name",
+[IsStzPresentation, IsString],
+function(stz, genname)
+  local gen;
+  # find index of genname in stz gens
+  gen := Position(GeneratorsOfStzPresentation(stz), genname);
+  if gen = fail then
+    ErrorNoReturn("StzRemoveGenerator: second argument <gen> does not\n",
+                  "correspond to a generator name in first argument <stz>");
+  else
+    StzRemoveGenerator(stz, gen);
+  fi;
+end);
+
+# Tietze transformation 4 with specified index (e.g. if there are several
+# relations allowing the generator to be removed and the user wants a specific
+# one)
+InstallMethod(StzRemoveGenerator,
+"For an stz presentation and two pos ints",
+[IsStzPresentation, IsPosInt, IsPosInt],
+function(stz, gen, index)
+  # first argument check: requested generator exists
+  if Length(GeneratorsOfStzPresentation(stz)) = 1 then
+    ErrorNoReturn("StzRemoveGenerator: cannot remove only remaining\n",
+                  "generator \"",
+                  GeneratorsOfStzPresentation(stz)[1],
+                  "\"");
+  elif gen > Length(GeneratorsOfStzPresentation(stz)) then
+    ErrorNoReturn("StzRemoveGenerator: second argument <gen> must be no\n",
+                  "greater than the total number of generators");
+  fi;
+
+  # second argument check: index exists
+  if index > Length(RelationsOfStzPresentation(stz)) then
+    ErrorNoReturn("StzRemoveGenerator: third argument <index> must be no\n",
+                  "greater than the total number of relations in first\n",
+                  "argument <stz>");
+  fi;
+
+  # third argument check: a reasonable relation number has been supplied
+  if not ((stz!.rels[index][1] = [gen] and not gen in stz!.rels[index][2]) or
+          (stz!.rels[index][2] = [gen] and not gen in stz!.rels[index][1])) then
+    ErrorNoReturn("StzRemoveGenerator: third argument <index> does not point\n",
+                  "to a relation expressing second argument <gen> as a\n",
+                  "combination of other generators in first argument <stz>");
+  fi;
+
+  # if we made it this far then the substitution can be made
+  SEMIGROUPS.TietzeTransformation4(stz, gen, index);
+end);
+
+InstallMethod(StzRemoveGenerator,
+"For an stz presentation, a generator name and a pos int",
+[IsStzPresentation, IsString, IsPosInt],
+function(stz, genname, index)
+  local gen;
+  # find index of genname in stz gens
+  gen := Position(GeneratorsOfStzPresentation(stz), genname);
+  if gen = fail then
+    ErrorNoReturn("StzRemoveGenerator: second argument <gen> does not\n",
+                  "correspond to a generator name in first argument <stz>");
+  else
+    StzRemoveGenerator(stz, gen, index);
+  fi;
+end);
+
+# Tietze Transformation 1/2: substitute relation
+InstallMethod(StzSubstituteRelation,
+"For an stz presentation and two positive integers",
+[IsStzPresentation, IsPosInt, IsPosInt],
+function(stz, index, side)
+  local oldword, newword, new_rel, i;
+  # argument check
+  if index > Length(RelationsOfStzPresentation(stz)) then
+    ErrorNoReturn("StzSubstituteRelation: second argument <index> must be no\n",
+                  "greater than the number of relations in first argument\n",
+                  "<stz>");
+  fi;
+  if not side in [1, 2] then
+    ErrorNoReturn("StzSubstituteRelation: third argument <side> must be\n",
+                  "either 1 or 2");
+  fi;
+
+  oldword := ShallowCopy(RelationsOfStzPresentation(stz)[index][side]);
+  newword := ShallowCopy(RelationsOfStzPresentation(stz)[index][[2, 1][side]]);
+
+  # Push relations onto the end of the stack of relations, each time replacing
+  # the relation at the front by that relation, with oldword -> newword.
+  # Each time, immediately delete the replaced relation at the front of the
+  # stack, and do this as many times as there are relations, so that order
+  # is preserved.
+  # Special case for relation number <index> itself: it should not be changed.
+  for i in [1 .. Length(RelationsOfStzPresentation(stz))] do
+    if i = index then
+      new_rel := [oldword, newword];
+    else
+      new_rel := List(stz!.rels[1],
+                      x -> SEMIGROUPS.StzReplaceSubwordRel(x,
+                                                           oldword,
+                                                           newword));
+    fi;
+    SEMIGROUPS.TietzeTransformation1(stz, new_rel);
+    SEMIGROUPS.TietzeTransformation2(stz, 1);
+  od;
+end);
+
+########################################################################
+# 5. Internal helper functions for word/relation manipulation etc.
+########################################################################
+
+SEMIGROUPS.StzReplaceSubword := function(rels, subword, newWord)
+  local newRels, rel1, rel2, i;
+
+  newRels := List([1 .. Length(rels)], x -> []);
+  for i in [1 .. Length(rels)] do
+    rel1 := SEMIGROUPS.StzReplaceSubwordRel(rels[i][1], subword, newWord);
+    rel2 := SEMIGROUPS.StzReplaceSubwordRel(rels[i][2], subword, newWord);
+    newRels[i] := [rel1, rel2];
+  od;
+  return newRels;
+end;
+
+SEMIGROUPS.StzReplaceSubwordRel := function(word, subword, newWord)
+  local out, k, l, i;
+  # Searches a single LetterRepAssocWord list and replaces instances of
+  # subword with newWord.
+
+  # build word up as we read through the old word.
+  out := [];
+  k   := Length(subword);
+  l   := Length(word);
+  i   := 1;  # current index that we are looking at when trying to see subword
+  while i <= l do
+    if word{[i .. Minimum(i + k - 1, l)]} = subword then
+      # in this, case the word starting at i needs to be substituted out.
+      # (the minimum is there to make sure we don't fall off the end of word)
+      Append(out, newWord);
+      # jump to end of occurrence
+      i := i + k;
+    else
+      # move over by one and append the original letter, since the word is not
+      # seen here.
+      Add(out, word[i]);
+      i := i + 1;
+    fi;
+  od;
+  return out;
+end;
+
+# takes in a letterrep word and replaces every letter with its expression in
+# dict.
+# NOTE: does not check arguments. Assumes in good faith that every integer
+# in word has an entry in the list <dict>.
+SEMIGROUPS.StzExpandWord := function(word, dict)
+  local out, letter;
+  out := [];
+  for letter in word do
+    Append(out, dict[letter]);
+  od;
+  return out;
+end;
+
+SEMIGROUPS.NewGeneratorName := function(names_immut)
+  local alph, Alph, na, nA, names_prefx, names_suffx, int_positions, prefixes,
+  prefixes_collected, p, ints, i, name, names;
+  names := [];
+  for name in names_immut do
+    Add(names, ShallowCopy(name));
+  od;
+
+  # useful helper variables
+  alph := "abcdefghijklmnopqrstuvwxyz";
+  Alph := "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+  # SPECIAL CASE 0: empty list
+  if Length(names) = 0 then
+    return "a";
+  fi;
+
+  # SPECIAL CASE 1: only one generator
+  if Length(names) = 1 then
+    if Length(names[1]) = 1 then
+      if names[1][1] in Alph then
+        return [First(Alph, x -> not [x] in names)];
+      elif names[1][1] in alph then
+        return [First(alph, x -> not [x] in names)];
+      else
+        return "a";
+      fi;
+    else
+      return "a";
+    fi;
+  fi;
+
+  # SPECIAL CASE 2: single letter names are present. Add an unused letter
+  # with the most common capitalisation
+  na := Length(Filtered(names, x -> Length(x) = 1 and x[1] in alph));
+  nA := Length(Filtered(names, x -> Length(x) = 1 and x[1] in Alph));
+  if 2 <= na and na < 26 then
+    if na <= nA and nA < 26 then
+      return [First(Alph, x -> not [x] in names)];
+    else
+      return [First(alph, x -> not [x] in names)];
+    fi;
+  elif 2 <= nA and nA < 26 then
+    return [First(Alph, x -> not [x] in names)];
+  fi;
+
+  # SPECIAL CASE 3: there are names like s1, s3, s23, etc or x12, etc
+  names_prefx := [];
+  names_suffx := [];
+  for name in names do
+    Add(names_prefx, [name[1]]);
+    Add(names_suffx, name{[2 .. Length(name)]});
+  od;
+  int_positions := PositionsProperty(names_suffx, x -> Int(x) <> fail
+                                              and x <> ""
+                                              and x[1] <> '-');
+  if Length(int_positions) >= 2 then
+    prefixes           := names_prefx{int_positions};
+    prefixes_collected := Collected(prefixes);
+    # look for highest frequency in collected list
+    p := prefixes_collected[PositionMaximum(prefixes_collected, x -> x[2])][1];
+    # find maximum suffix int, even amongst those with prefix not p
+    ints := List(names_suffx{int_positions}, Int);
+    i    := Maximum(ints) + 1;
+    return Concatenation(p, String(i));
+  fi;
+
+  # if none of the special cases are covered, just try s1, s2,... until good
+  for i in [1 .. Length(names) + 1] do
+    if not Concatenation("s", String(i)) in names then
+      return Concatenation("s", String(i));
+    fi;
+  od;
+end;
+
+# Counts the number of times a subword appears in the relations of an stz
+# presentation, ensuring that the subwords do not overlap
+# (Eg, for relations [[1,1,1,1],[1,1]], the subword [1,1] would return 3 and not
+# 4)
+SEMIGROUPS.StzCountRelationSubwords := function(stz, subWord)
+  local count, relSide, rel, rels, pos, len, relSideCopy;
+  rels := RelationsOfStzPresentation(stz);
+  len := Length(subWord);
+  count := 0;
+  for rel in rels do
+    for relSide in rel do
+      pos := PositionSublist(relSide, subWord);
+      relSideCopy := ShallowCopy(relSide);
+      while pos <> fail do
+        count := count + 1;
+        relSideCopy := List([(pos + len) .. Length(relSideCopy)],
+                            x -> relSideCopy[x]);
+        pos := PositionSublist(relSideCopy, subWord);
+      od;
+    od;
+  od;
+  return count;
+end;
+
+# Converts an Stz presentation into an fp semigroup.
+SEMIGROUPS.StzConvertObjToFpSemigroup := function(stz)
+  local out, F, rels, gens;
+  F    := FreeSemigroup(stz!.gens);
+  rels := RelationsOfStzPresentation(stz);
+  gens := GeneratorsOfSemigroup(F);
+  out  := F / List(rels, x -> List(x, y -> Product(List(y, z -> gens[z]))));
+  return out;
+end;
+
+########################################################################
+# 6.  Internal auto-checkers and appliers for presentation simplifying
+########################################################################
+
+## Format to add a new reduction check:
+## StzCheck: function that takes an stz presentation as input and checks all
+##           possible instances of the desired reduction, and outputs as a
+##           record the least length of the possible reductions together with
+##           the arguments required to achieve that length
+## StzApply: function that takes an stz presentation and the above record as
+##           input and applies the arguments from the record to achieve the
+##           desired reduction
+## Add the above two functions to the list results in StzSimplifyOnce as the
+## pair [StzApply, StzCheck(stz)]
+
+SEMIGROUPS.StzFrequentSubwordCheck := function(stz)
+  local best_gain, best_word, flat, count_occurrences, n, c, gain, word,
+        pair, i, j;
+  # SUPER INEFFICIENT (~n^3), do something about this eventually (@Reinis?)
+  # Look at every subword, count how many times it appears, and see whether
+  # introducing a new generator equal to a given subword would make the
+  # whole presentation shorter
+  best_gain := 0;   # best reduction seen so far
+  best_word := [];  # word currently holding record
+
+  # flat list of words (don't care about which one is related to which)
+  flat := [];
+  for pair in stz!.rels do
+    Append(flat, ShallowCopy(pair));  # TODO might not need shallow copy
+  od;
+
+  # function to count occurrences of subword in list of lists
+  count_occurrences := function(list, subword)
+    local count, k, l, i, word;
+    count := 0;
+    k     := Length(subword);
+    for word in list do
+      l := Length(word);
+      i := 1;  # index at which to start counting
+      while i <= l - k + 1 do
+        if word{[i .. i + k - 1]} = subword then
+          count := count + 1;
+          # jump to end of occurrence
+          i := i + k;
+        else
+          # move over by one
+          i := i + 1;
+        fi;
+      od;
+    od;
+    return count;
+  end;
+
+  # now check for every subword, how many times it appears
+  for word in flat do
+    # N.B. ASSUMES WORDS NON-EMPTY
+    n := Length(word);
+    for i in [1 .. n - 1] do
+      for j in [i + 1 .. n] do
+        c := count_occurrences(flat, word{[i .. j]});
+        # now calculate what a gain that would be:
+        # subbing out every instance of word{[i .. j]} for a word of length 1
+        # makes us gain j - i characters per substitution
+        # BUT, we also have a new generator cost of 1
+        # AND a new relation cost of 3 + j - i
+        gain := (c - 1) * (j - i) - 3;
+        if gain > best_gain then
+          best_gain := gain;
+          best_word := word{[i .. j]};
+        fi;
+      od;
+    od;
+  od;
+  return rec(reduction := Length(stz) - best_gain,
+             word := best_word);
+end;
+
+SEMIGROUPS.StzFrequentSubwordApply := function(stz, metadata)
+  local word, rels, n, gens, k, shortened_rels, new_rel, i, str, f, aWord;
+
+  # have received instruction to sub out metadata.word for something shorter.
+  word := metadata.word;
+  rels := ShallowCopy(RelationsOfStzPresentation(stz));
+  n    := Length(rels);
+  gens := ShallowCopy(GeneratorsOfStzPresentation(stz));
+  k    := Length(gens);
+
+  # Build message
+  str := "<Creating new generator to replace instances of word: ";
+  f := FreeSemigroup(gens);
+  aWord := AssocWordByLetterRep(FamilyObj(f.1), metadata.word);
+  Append(str, PrintString(aWord));
+  Append(str, ">");
+  Info(InfoFpSemigroup, 2, PRINT_STRINGIFY(str));
+
+  # first, add new generator.
+  SEMIGROUPS.TietzeTransformation3(stz, word, fail);
+
+  # then, go through and add loads of relations which are the old ones but
+  # with the old word subbed out.
+  shortened_rels := SEMIGROUPS.StzReplaceSubword(rels, word, [k + 1]);
+  for new_rel in shortened_rels do
+    SEMIGROUPS.TietzeTransformation1(stz, new_rel);
+  od;
+
+  # finally, remove the original relations.
+  for i in [1 .. n] do
+    SEMIGROUPS.TietzeTransformation2(stz, 1);
+  od;
+  return;
+end;
+
+# Checks each relation in the stz presentation in turn and determines if
+# replacing the longer side by the shorter side reduces the length of the
+# presentation
+SEMIGROUPS.StzRelsSubCheck := function(stz)
+  local rels, currentMin, currentRel, tempRel, len, relLenDiff, numInstances,
+        newLen, i;
+  rels := RelationsOfStzPresentation(stz);
+  currentMin := Length(stz);
+  currentRel := 0;
+  for i in [1 .. Length(rels)] do
+    tempRel := ShallowCopy(rels[i]);
+    SortBy(tempRel, Length);
+    len := Length(stz);
+    relLenDiff := Length(tempRel[2]) - Length(tempRel[1]);
+    numInstances := SEMIGROUPS.StzCountRelationSubwords(stz, tempRel[2]) - 1;
+    newLen := len - numInstances * relLenDiff;
+    if newLen < currentMin then
+      currentMin := newLen;
+      currentRel := i;
+    fi;
+  od;
+  return rec(reduction := currentMin,
+              argument := currentRel);
+end;
+
+# Checks each relation of the stz presentation to see if any are of the form
+# a = w, where a is a generator and w is a word not containing a, then
+# determines the length if the generator and relation were removed
+SEMIGROUPS.StzRedundantGeneratorCheck := function(stz)
+  local rel, rels, numInstances, relPos, tempPositions, r, out, redLen,
+        genToRemove, wordToReplace, foundRedundant, currentMin, currentGen,
+        currentRel;
+  rels := RelationsOfStzPresentation(stz);
+  out := [];
+  currentMin := Length(stz);
+  currentGen := 0;
+  currentRel := 0;
+  for rel in rels do
+    foundRedundant := false;
+    if Length(rel[1]) = 1 and Length(rel[2]) = 1 and rel[1] <> rel[2] then
+      genToRemove := rel[1][1];
+      wordToReplace := rel[2];
+      Append(out, [Length(stz) - 3]);
+      if Length(stz) - 3 < currentMin then
+        currentMin := Length(stz) - 3;
+        currentGen := genToRemove;
+        currentRel := Position(rels, rel);
+      fi;
+      continue;
+    elif Length(rel[1]) = 1 and Length(rel[2]) > 1 and
+          (not (rel[1][1] in rel[2])) then
+      genToRemove := rel[1][1];
+      wordToReplace := rel[2];
+      foundRedundant := true;
+    elif Length(rel[2]) = 1 and Length(rel[1]) > 1 and
+          (not (rel[2][1] in rel[1])) then
+      genToRemove := rel[2][1];
+      wordToReplace := rel[1];
+      foundRedundant := true;
+    fi;
+    if foundRedundant then
+      relPos := Position(rels, rel);
+      numInstances := 0;
+      for r in Concatenation([1 .. relPos - 1], [relPos + 1 .. Length(rels)]) do
+        tempPositions := Length(Positions(Concatenation(rels[r][1], rels[r][2]),
+                                          genToRemove));
+        numInstances  := numInstances + tempPositions;
+      od;
+      redLen := Length(stz) + (numInstances * (Length(wordToReplace) - 1)) -
+                2 - Length(wordToReplace);
+      if redLen < currentMin then
+        currentMin := redLen;
+        currentGen := genToRemove;
+        currentRel := Position(rels, rel);
+      fi;
+    fi;
+  od;
+  return rec(reduction := currentMin,
+              argument := currentGen,
+              infoRel := currentRel);
+end;
+
+# Checks each relation to determine if it is a direct duplicate of another
+# (ie does not check equivalence in terms of other relations, just whether they
+# are literally the same relation)
+SEMIGROUPS.StzDuplicateRelsCheck := function(stz)
+  local rel, rels, i, tempRel, j, currentMin, currentRel, len;
+  rels := RelationsOfStzPresentation(stz);
+  currentMin := Length(stz);
+  currentRel := 0;
+  if Length(rels) < 2 then
+    return rec(reduction := Length(stz),
+                argument := 1);
+  else
+    for j in [1 .. Length(rels)] do
+      rel := rels[j];
+      for i in Concatenation([1 .. j - 1],
+                              [j + 1 .. Length(rels)]) do
+        tempRel := rels[i];
+        if (tempRel[1] = rel[1] and tempRel[2] = rel[2]) or
+            (tempRel[1] = rel[2] and tempRel[2] = rel[1]) then
+          len := Length(stz) - Length(rel[1]) - Length(rel[2]);
+          if len < currentMin then
+            currentMin := len;
+            currentRel := j;
+          fi;
+        fi;
+      od;
+    od;
+    return rec(reduction := currentMin,
+                argument := currentRel);
+  fi;
+end;
+
+# Checks each relation to determine if any are of the form w = w, where w is a
+# word over the generators
+SEMIGROUPS.StzTrivialRelationCheck := function(stz)
+  local rels, len, i, currentMin, currentRel, newLen;
+  rels := RelationsOfStzPresentation(stz);
+  len := Length(stz);
+  currentMin := len;
+  currentRel := 0;
+  for i in [1 .. Length(rels)] do
+    if rels[i][1] = rels[i][2] then
+      newLen := len - Length(rels[i][1]) - Length(rels[i][2]);
+      if newLen < currentMin then
+        currentMin := newLen;
+        currentRel := i;
+      fi;
+    fi;
+  od;
+  return rec(reduction := currentMin,
+              argument := currentRel);
+end;
+
+# Removes a trivial relation
+SEMIGROUPS.StzTrivialRelationApply := function(stz, args)
+  local str;
+  str := "<Removing trivial relation: ";
+  Append(str, SEMIGROUPS.StzRelationDisplayString(stz, args.argument));
+  Append(str, ">");
+  Info(InfoFpSemigroup, 2, PRINT_STRINGIFY(str));
+  SEMIGROUPS.TietzeTransformation2(stz, args.argument);
+end;
+
+# Removes a duplicated relation
+SEMIGROUPS.StzDuplicateRelsApply := function(stz, args)
+  local str;
+  str := "<Removing duplicate relation: ";
+  Append(str, SEMIGROUPS.StzRelationDisplayString(stz, args.argument));
+  Append(str, ">");
+  Info(InfoFpSemigroup, 2, PRINT_STRINGIFY(str));
+  SEMIGROUPS.TietzeTransformation2(stz, args.argument);
+end;
+
+# Removes a redundant generator
+SEMIGROUPS.StzGensRedundantApply := function(stz, args)
+  local str;
+  str := "<Removing redundant generator ";
+  Append(str, GeneratorsOfStzPresentation(stz)[args.argument]);
+  Append(str, " using relation : ");
+  Append(str, SEMIGROUPS.StzRelationDisplayString(stz, args.infoRel));
+  Append(str, ">");
+  Info(InfoFpSemigroup, 2, PRINT_STRINGIFY(str));
+  SEMIGROUPS.TietzeTransformation4(stz, args.argument, args.infoRel);
+end;
+
+# Replaces all instances of one side of a relation with the other inside each
+# other relation
+SEMIGROUPS.StzRelsSubApply := function(stz, args)
+  local str, relIndex, rels, rel, subword, replaceWord, containsRel, newRel, i,
+        j;
+  str := "<Replacing all instances in other relations of relation: ";
+  Append(str, SEMIGROUPS.StzRelationDisplayString(stz, args.argument));
+  Append(str, ">");
+  Info(InfoFpSemigroup, 2, PRINT_STRINGIFY(str));
+
+  relIndex := args.argument;
+  rels := RelationsOfStzPresentation(stz);
+  rel := ShallowCopy(rels[relIndex]);
+  SortBy(rel, Length);
+  # TODO line above: potential edge cases where we are not substituting the
+  # longer for the shorter, but rather two words of equal length? I guess not,
+  # since the checker function would only suggest this applier function if
+  # there was an actual reduction? In that case, careful to use correctly
+
+  # record words to sub out (one we are searching for) and to replace with
+  subword := rel[2];
+  replaceWord := rel[1];
+
+  # keep track of relation indices where we substituted
+  containsRel := [];
+  for i in [1 .. Length(rels)] do
+    if  i <> relIndex and
+        (PositionSublist(rels[i][1], subword) <> fail or
+         PositionSublist(rels[i][2], subword) <> fail) then
+      Add(containsRel, i);
+    fi;
+  od;
+
+  for i in containsRel do
+    newRel := List([1 .. 2], x -> ShallowCopy(rels[i][x]));
+    newRel := List(newRel, x -> SEMIGROUPS.StzReplaceSubwordRel(x, subword,
+                                                                replaceWord));
+    SEMIGROUPS.TietzeTransformation1(stz, newRel);
+  od;
+  for j in [1 .. Length(containsRel)] do
+    SEMIGROUPS.TietzeTransformation2(stz, containsRel[j]);
+    containsRel := containsRel - 1;
+  od;
+end;
+
+########################################################################
+# 7. SimplifyPresentation etc.
+########################################################################
+
+InstallMethod(StzSimplifyOnce,
+[IsStzPresentation],
+function(stz)
+  local rels, results, len, mins, result, func, args;
+  rels := RelationsOfStzPresentation(stz);
+  if Length(rels) = 0 then
+    return false;
+  else
+    results := [[SEMIGROUPS.StzGensRedundantApply,
+                  SEMIGROUPS.StzRedundantGeneratorCheck(stz)],
+                [SEMIGROUPS.StzDuplicateRelsApply,
+                  SEMIGROUPS.StzDuplicateRelsCheck(stz)],
+                [SEMIGROUPS.StzRelsSubApply,
+                  SEMIGROUPS.StzRelsSubCheck(stz)],
+                [SEMIGROUPS.StzFrequentSubwordApply,
+                  SEMIGROUPS.StzFrequentSubwordCheck(stz)],
+                [SEMIGROUPS.StzTrivialRelationApply,
+                  SEMIGROUPS.StzTrivialRelationCheck(stz)]];
+    len := Length(stz);
+    mins := List(results, x -> x[2].reduction);
+    if Minimum(mins) < len then
+      result := results[Position(mins, Minimum(mins))];
+      func := result[1];
+      args := result[2];
+      func(stz, args);
+      return true;
+    fi;
+    return false;
+  fi;
+end);
+
+InstallMethod(StzSimplifyPresentation,
+[IsStzPresentation],
+function(stz)
+  local transformApplied;
+  transformApplied := true;
+  Info(InfoFpSemigroup, 2, "Applying StzSimplifyPresentation...");
+  Info(InfoFpSemigroup, 2, "StzSimplifyPresentation is verbose by default. ",
+                           "Use SetInfoLevel(InfoFpSemigroup, 1) to hide");
+  Info(InfoFpSemigroup, 2, "output while maintaining ability to use ",
+                           "StzPrintRelations, StzPrintGenerators, etc.");
+  Info(InfoFpSemigroup, 2, Concatenation("Current: ", ViewString(stz)));
+  while transformApplied do
+    transformApplied := StzSimplifyOnce(stz);
+    if transformApplied then
+      Info(InfoFpSemigroup, 2, Concatenation("Current: ", ViewString(stz)));
+    fi;
+  od;
+end);
+
+InstallMethod(SimplifiedFpSemigroup,
+[IsFpSemigroup],
+function(S)
+  local T, map;
+  map := SimplifyFpSemigroup(S);
+  T := Range(map);
+  SetUnreducedFpSemigroupOfFpSemigroup(T, S);
+  SetFpTietzeIsomorphism(T, map);
+  return T;
+end);
+
+InstallMethod(SimplifyFpSemigroup,
+[IsFpSemigroup],
+function(S)
+  local stz;
+  stz := StzPresentation(S);
+  StzSimplifyPresentation(stz);
+  return TietzeIsomorphism(stz);
+end);
+
+########################################################################
+# 8. Other
+########################################################################
+
+#### TODO
+# For testing purposes, remove before merge (also possibly a duplicate of an
+# existing function)
+# SEMIGROUPS.RandomFpSemigroup := function(maxgen, maxrel, maxwordlen)
+#   local ngens, nrels, F, gens, rels, nwordlen, lside, rside, i;
+#   ngens := Random([1 .. maxgen]);
+#   nrels := Random([1 .. maxrel]);
+#   F     := FreeSemigroup(ngens);
+#   gens  := GeneratorsOfSemigroup(F);
+#   rels  := [];
+#   for i in [1 .. nrels] do
+#     nwordlen := Random([1 .. maxwordlen]);
+#     lside    := Product(List([1 .. nwordlen],
+#                         x -> gens[Random([1 .. ngens])]));
+#     rside    := Product(List([1 .. nwordlen],
+#                               x -> gens[Random([1 .. ngens])]));
+#     Append(rels, [[lside, rside]]);
+#   od;
+#   return F / rels;
+# end;

--- a/gap/fp/tietze.gi
+++ b/gap/fp/tietze.gi
@@ -38,26 +38,16 @@ function(S)
               x -> [LetterRepAssocWord(x[1]), LetterRepAssocWord(x[2])]);
   gens := List(GeneratorsOfSemigroup(S), x -> ViewString(x));
 
-  out := rec(gens               := gens,
-             rels               := rels,
-             unreducedSemigroup := S,
-             tietzeForwardMap   := List([1 .. Length(GeneratorsOfSemigroup(S))],
-                                        x -> [x]),
-             tietzeBackwardMap  := List([1 .. Length(GeneratorsOfSemigroup(S))],
-                                        x -> [x]),
-             usedGens           := Set(gens));
+  out := rec(GeneratorsOfStzPresentation := gens,
+             RelationsOfStzPresentation  := rels,
+             UnreducedFpSemigroup        := S,
+             TietzeForwardMap            := List(
+               [1 .. Length(GeneratorsOfSemigroup(S))], x -> [x]),
+             TietzeBackwardMap           := List(
+               [1 .. Length(GeneratorsOfSemigroup(S))], x -> [x]),
+             usedGens                    := Set(gens));
 
-  return ObjectifyWithAttributes(out, type,
-                                  RelationsOfStzPresentation,
-                                  out!.rels,
-                                  GeneratorsOfStzPresentation,
-                                  out!.gens,
-                                  UnreducedFpSemigroup,
-                                  out!.unreducedSemigroup,
-                                  TietzeForwardMap,
-                                  out!.tietzeForwardMap,
-                                  TietzeBackwardMap,
-                                  out!.tietzeBackwardMap);
+  return Objectify(type, out);
 end);
 
 InstallMethod(SetRelationsOfStzPresentation,
@@ -70,43 +60,43 @@ function(stz, arg)
                       "parameter <arg> must be a list of pairs of words in\n",
                       "LetterRep format");
   fi;
-  stz!.rels := arg;
+  stz!.RelationsOfStzPresentation := arg;
 end);
 
 InstallMethod(RelationsOfStzPresentation,
 [IsStzPresentation],
 function(stz)
-    return stz!.rels;
+    return stz!.RelationsOfStzPresentation;
 end);
 
 InstallMethod(UnreducedFpSemigroup,
 [IsStzPresentation],
 function(stz)
-    return stz!.unreducedSemigroup;
+    return stz!.UnreducedFpSemigroup;
 end);
 
 InstallMethod(TietzeForwardMap,
 [IsStzPresentation],
 function(stz)
-    return stz!.tietzeForwardMap;
+    return stz!.TietzeForwardMap;
 end);
 
 InstallMethod(TietzeBackwardMap,
 [IsStzPresentation],
 function(stz)
-    return stz!.tietzeBackwardMap;
+    return stz!.TietzeBackwardMap;
 end);
 
 InstallMethod(GeneratorsOfStzPresentation,
 [IsStzPresentation],
 function(stz)
-    return stz!.gens;
+    return stz!.GeneratorsOfStzPresentation;
 end);
 
 InstallMethod(SetGeneratorsOfStzPresentation,
 [IsStzPresentation, IsList],
 function(stz, newGens)
-    stz!.gens := newGens;
+    stz!.GeneratorsOfStzPresentation := newGens;
 end);
 
 # TODO: TCL: maybe better to call this StzIsomorphism?
@@ -150,7 +140,7 @@ function(stz, newMaps)
       ErrorNoReturn("SetTietzeForwardMap: second argument <newMaps> must\n",
                     "be a list of lists of positive integers");
     fi;
-    stz!.tietzeForwardMap := newMaps;
+    stz!.TietzeForwardMap := newMaps;
 end);
 
 InstallMethod(SetTietzeBackwardMap,
@@ -160,18 +150,18 @@ function(stz, newMaps)
       ErrorNoReturn("SetTietzeBackwardMap: second argument <newMaps> must\n",
                     "be a list of lists of positive integers");
     fi;
-    stz!.tietzeBackwardMap := newMaps;
+    stz!.TietzeBackwardMap := newMaps;
 end);
 
 InstallMethod(TietzeForwardMapReplaceSubword,
 [IsStzPresentation, IsList, IsList],
 function(stz, subWord, newSubWord)
     local newMaps;
-    newMaps := List(stz!.tietzeForwardMap,
+    newMaps := List(stz!.TietzeForwardMap,
                     x -> SEMIGROUPS.StzReplaceSubwordRel(x,
                                                          subWord,
                                                          newSubWord));
-    stz!.tietzeForwardMap := newMaps;
+    stz!.TietzeForwardMap := newMaps;
 end);
 
 # Length of an StzPresentation is defined as the number of generators plus the
@@ -180,7 +170,7 @@ InstallMethod(Length,
 [IsStzPresentation],
 function(stz)
     local out, rels, rel;
-    out := Length(stz!.gens);
+    out := Length(stz!.GeneratorsOfStzPresentation);
     rels := RelationsOfStzPresentation(stz);
     for rel in rels do
         out := out + Length(rel[1]) + Length(rel[2]);
@@ -203,15 +193,15 @@ InstallMethod(ViewString,
 function(stz)
     local str;
     str := "<fp semigroup presentation with ";
-    Append(str, String(Length(stz!.gens)));
+    Append(str, String(Length(stz!.GeneratorsOfStzPresentation)));
     Append(str, " generator");
-    if Length(stz!.gens) > 1 then
+    if Length(stz!.GeneratorsOfStzPresentation) > 1 then
         Append(str, "s");
     fi;
     Append(str, " and ");
-    Append(str, String(Length(stz!.rels)));
+    Append(str, String(Length(stz!.RelationsOfStzPresentation)));
     Append(str, " relation");
-    if Length(stz!.rels) <> 1 then
+    if Length(stz!.RelationsOfStzPresentation) <> 1 then
         Append(str, "s");
     fi;
     Append(str, "\< with length ");
@@ -334,20 +324,21 @@ function(stz)
   # total number and total length
   Info(InfoFpSemigroup, 1, "");
   status := "There ";
-  if Length(stz!.gens) = 1 then
+  if Length(stz!.GeneratorsOfStzPresentation) = 1 then
     status := Concatenation(status, "is 1 generator");
   else
     status := Concatenation(status,
                             "are ",
-                            PrintString(Length(stz!.gens)),
+                            PrintString(
+                            Length(GeneratorsOfStzPresentation(stz))),
                             " generators");
   fi;
   status := Concatenation(status, " and ");
-  if Length(stz!.rels) = 1 then
+  if Length(stz!.RelationsOfStzPresentation) = 1 then
     status := Concatenation(status, "1 relation");
   else
     status := Concatenation(status,
-                            PrintString(Length(stz!.rels)),
+                            PrintString(Length(stz!.RelationsOfStzPresentation)),
                             " relations");
   fi;
   status := Concatenation(status,
@@ -421,7 +412,7 @@ SEMIGROUPS.TietzeTransformation1 := function(stz, pair)
   # Add relation
   rels_copy := ShallowCopy(RelationsOfStzPresentation(stz));
   Add(rels_copy, pair);
-  stz!.rels := rels_copy;
+  stz!.RelationsOfStzPresentation := rels_copy;
   return;
 end;
 
@@ -446,7 +437,7 @@ SEMIGROUPS.TietzeTransformation2 := function(stz, index)
   # Remove relation
   rels_copy := ShallowCopy(RelationsOfStzPresentation(stz));
   Remove(rels_copy, index);
-  stz!.rels := rels_copy;
+  stz!.RelationsOfStzPresentation := rels_copy;
 end;
 
 # TIETZE TRANSFORMATION 3: INTERNAL: ADD NEW GENERATOR - NO CHECK
@@ -472,9 +463,9 @@ SEMIGROUPS.TietzeTransformation3 := function(stz, word, name)
   # analogous, documented function: StzAddGenerator.
 
   # Add new generator string to the list of gens in similar format
-  new_gens := ShallowCopy(stz!.gens);
-  new_rels := ShallowCopy(stz!.rels);
-  if name = fail or name in stz!.gens then
+  new_gens := ShallowCopy(stz!.GeneratorsOfStzPresentation);
+  new_rels := ShallowCopy(stz!.RelationsOfStzPresentation);
+  if name = fail or name in stz!.GeneratorsOfStzPresentation then
     # either name was not specified, or it was but is already a generator.
     # generate a new generator name, as of yet unused.
     Add(new_gens, SEMIGROUPS.NewGeneratorName(List(stz!.usedGens)));
@@ -489,7 +480,7 @@ SEMIGROUPS.TietzeTransformation3 := function(stz, word, name)
   UniteSet(stz!.usedGens, new_gens);
 
   # Add relation setting new gen equal to <word>
-  Add(new_rels, [word, [Length(stz!.gens) + 1]]);
+  Add(new_rels, [word, [Length(stz!.GeneratorsOfStzPresentation) + 1]]);
 
   # Update internal representation of the stz object
   SetGeneratorsOfStzPresentation(stz, new_gens);
@@ -532,11 +523,13 @@ SEMIGROUPS.TietzeTransformation4 := function(stz, gen, index)
   # check we can express <gen> using only other generators with relation
   # number <index>
   found_expr := false;
-  if stz!.rels[index][1] = [gen] and not gen in stz!.rels[index][2] then
-    expr := stz!.rels[index][2];
+  if RelationsOfStzPresentation(stz)[index][1] = [gen] and
+      not gen in RelationsOfStzPresentation(stz)[index][2] then
+    expr := RelationsOfStzPresentation(stz)[index][2];
     found_expr := true;
-  elif stz!.rels[index][2] = [gen] and not gen in stz!.rels[index][1] then
-    expr := stz!.rels[index][1];
+  elif RelationsOfStzPresentation(stz)[index][2] = [gen] and
+      not gen in RelationsOfStzPresentation(stz)[index][1] then
+    expr := RelationsOfStzPresentation(stz)[index][1];
     found_expr := true;
   fi;
 
@@ -574,7 +567,7 @@ SEMIGROUPS.TietzeTransformation4 := function(stz, gen, index)
   Remove(tempRels, index);
   tempRels := SEMIGROUPS.StzReplaceSubword(tempRels, [gen], expr);
   SetRelationsOfStzPresentation(stz, tempRels);
-  Apply(stz!.rels, x -> List(x, y -> List(y, decrement)));
+  Apply(stz!.RelationsOfStzPresentation, x -> List(x, y -> List(y, decrement)));
 
   # remove generator.
   tempGens := ShallowCopy(GeneratorsOfStzPresentation(stz));
@@ -599,7 +592,7 @@ function(stz, pair)
     ErrorNoReturn("StzAddRelation: second argument <pair> should be a list\n",
                   "of length 2");
   fi;
-  n := Length(stz!.gens);
+  n := Length(stz!.GeneratorsOfStzPresentation);
   for word in pair do
     if not IsList(word) then
       TryNextMethod();  # pass this on to the case where the list may be a pair
@@ -620,9 +613,11 @@ function(stz, pair)
 
   # check that the pair can be deduced from the other relations, by
   # creating fp semigroup with current relations.
-  f        := FreeSemigroup(stz!.gens);  # base free semigroup
+
+  # base free semigroup
+  f        := FreeSemigroup(stz!.GeneratorsOfStzPresentation);
   free_fam := FamilyObj(f.1);            # marrow for creating free semigp words
-  r        := List(stz!.rels,
+  r        := List(stz!.RelationsOfStzPresentation,
                    x -> List(x, y -> AssocWordByLetterRep(free_fam, y)));
   s        := f / r;                    # fp semigroup
   fp_fam   := FamilyObj(s.1);           # marrow for creating fp words
@@ -679,7 +674,7 @@ function(stz, pair)
     ErrorNoReturn("StzAddRelationNC: second argument <pair> should be a list\n",
                   "of length 2");
   fi;
-  n := Length(stz!.gens);
+  n := Length(stz!.GeneratorsOfStzPresentation);
   for word in pair do
     if not IsList(word) then
       TryNextMethod();  # pass this on to the case where the list may be a pair
@@ -742,7 +737,7 @@ function(stz, index)
   # overall list of relations.
 
   # argument check: valid index
-  rels := ShallowCopy(stz!.rels);
+  rels := ShallowCopy(stz!.RelationsOfStzPresentation);
   if index > Length(rels) then
     ErrorNoReturn("StzRemoveRelation: second argument <index> must be less\n",
                   "than or equal to the number of relations of the first\n",
@@ -753,7 +748,7 @@ function(stz, index)
   # the requested pair
   pair := rels[index];
   Remove(rels, index);
-  new_f    := FreeSemigroup(stz!.gens);
+  new_f    := FreeSemigroup(stz!.GeneratorsOfStzPresentation);
   new_gens := GeneratorsOfSemigroup(new_f);
   new_s    := new_f / List(rels,
                            x -> List(x,
@@ -981,8 +976,10 @@ function(stz, gen, index)
   fi;
 
   # third argument check: a reasonable relation number has been supplied
-  if not ((stz!.rels[index][1] = [gen] and not gen in stz!.rels[index][2]) or
-          (stz!.rels[index][2] = [gen] and not gen in stz!.rels[index][1])) then
+  if not ((RelationsOfStzPresentation(stz)[index][1] = [gen]
+      and not gen in RelationsOfStzPresentation(stz)[index][2]) or
+      (RelationsOfStzPresentation(stz)[index][2] = [gen]
+      and not gen in RelationsOfStzPresentation(stz)[index][1])) then
     ErrorNoReturn("StzRemoveGenerator: third argument <index> does not point\n",
                   "to a relation expressing second argument <gen> as a\n",
                   "combination of other generators in first argument <stz>");
@@ -1037,7 +1034,7 @@ function(stz, index, side)
     if i = index then
       new_rel := [oldword, newword];
     else
-      new_rel := List(stz!.rels[1],
+      new_rel := List(stz!.RelationsOfStzPresentation[1],
                       x -> SEMIGROUPS.StzReplaceSubwordRel(x,
                                                            oldword,
                                                            newword));
@@ -1205,7 +1202,7 @@ end;
 # Converts an Stz presentation into an fp semigroup.
 SEMIGROUPS.StzConvertObjToFpSemigroup := function(stz)
   local out, F, rels, gens;
-  F    := FreeSemigroup(stz!.gens);
+  F    := FreeSemigroup(stz!.GeneratorsOfStzPresentation);
   rels := RelationsOfStzPresentation(stz);
   gens := GeneratorsOfSemigroup(F);
   out  := F / List(rels, x -> List(x, y -> Product(List(y, z -> gens[z]))));
@@ -1239,7 +1236,7 @@ SEMIGROUPS.StzFrequentSubwordCheck := function(stz)
 
   # flat list of words (don't care about which one is related to which)
   flat := [];
-  for pair in stz!.rels do
+  for pair in stz!.RelationsOfStzPresentation do
     Append(flat, ShallowCopy(pair));  # TODO might not need shallow copy
   od;
 

--- a/init.g
+++ b/init.g
@@ -118,6 +118,7 @@ ReadPackage("semigroups", "gap/congruences/congfpmon.gd");
 ReadPackage("semigroups", "gap/fp/freeinverse.gd");
 ReadPackage("semigroups", "gap/fp/freeband.gd");
 ReadPackage("semigroups", "gap/fp/word.gd");
+ReadPackage("semigroups", "gap/fp/tietze.gd");
 
 ReadPackage("semigroups", "gap/obsolete.gd");
 

--- a/read.g
+++ b/read.g
@@ -92,6 +92,7 @@ ReadPackage("semigroups", "gap/congruences/congfpmon.gi");
 ReadPackage("semigroups", "gap/fp/freeinverse.gi");
 ReadPackage("semigroups", "gap/fp/freeband.gi");
 ReadPackage("semigroups", "gap/fp/word.gi");
+ReadPackage("semigroups", "gap/fp/tietze.gi");
 
 ReadPackage("semigroups", "gap/obsolete.gi");
 

--- a/tst/standard/tietze.tst
+++ b/tst/standard/tietze.tst
@@ -1,0 +1,818 @@
+#############################################################################
+##
+#W  standard/tietze.tst
+#Y  Copyright (C) 2021                                      Tom Conti-Leslie
+#Y                                                          Ben Spiers
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+gap> START_TEST("Semigroups package: standard/tietze.tst");
+gap> LoadPackage("semigroups", false);;
+
+# Whenever Stz Print methods are tested, the previous InfoLevel for
+# InfoFpSemigroup is saved, set to whatever level is needed for the test, then
+# set back. This is done in each chunk so that every chunk is independent.
+gap> SEMIGROUPS.StartTest();
+
+# Test StzPresentation, basic attributes, viewing methods
+gap> f := FreeSemigroup(["a", "b", "c"]);;
+gap> r := [[(f.1 ^ 2 * f.2) ^ 2, f.1 ^ 2 * f.2], [f.3, f.1 ^ 2 * f.2]];;
+gap> s := f / r;;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 3 generators and 2 relations with length 16>
+gap> IsStzPresentation(stz);
+true
+gap> IsStzPresentation(s);
+false
+gap> GeneratorsOfStzPresentation(stz);
+[ "a", "b", "c" ]
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 1, 1, 2, 1, 1, 2 ], [ 1, 1, 2 ] ], [ [ 3 ], [ 1, 1, 2 ] ] ]
+gap> s = UnreducedSemigroupOfStzPresentation(stz);
+true
+gap> Length(stz);
+16
+gap> TietzeForwardMap(stz);
+[ [ 1 ], [ 2 ], [ 3 ] ]
+gap> TietzeBackwardMap(stz);
+[ [ 1 ], [ 2 ], [ 3 ] ]
+
+# Test StzPresentation viewing methods
+gap> prevFpSemigroupInfoLevel := InfoLevel(InfoFpSemigroup);;
+gap> SetInfoLevel(InfoFpSemigroup, 1);;
+gap> f := FreeSemigroup(["a", "b", "c"]);;
+gap> r := [[(f.1 ^ 2 * f.2) ^ 2, f.1 ^ 2 * f.2], [f.3, f.1 ^ 2 * f.2]];;
+gap> s := f / r;;
+gap> stz := StzPresentation(s);;
+gap> StzPrintGenerators(stz, [1, 3, 1, 4, 5, s]);
+#I  1.  a  8 occurrences
+#I  3.  c  1 occurrences
+#I  1.  a  8 occurrences
+gap> StzPrintGenerators(stz);
+#I  1.  a  8 occurrences
+#I  2.  b  4 occurrences
+#I  3.  c  1 occurrences
+gap> StzPrintRelation(stz, 2);
+#I  2. c = a^2*b
+gap> StzPrintRelations(stz, [2, 2, 1, 3, "t"]);
+#I  2. c = a^2*b
+#I  2. c = a^2*b
+#I  1. (a^2*b)^2 = a^2*b
+gap> StzPrintRelations(stz);
+#I  1. (a^2*b)^2 = a^2*b
+#I  2. c = a^2*b
+gap> StzPrintPresentation(stz);
+#I  Current generators:
+#I  1.  a  8 occurrences
+#I  2.  b  4 occurrences
+#I  3.  c  1 occurrences
+#I  
+#I  Current relations:
+#I  1. (a^2*b)^2 = a^2*b
+#I  2. c = a^2*b
+#I  
+#I  There are 3 generators and 2 relations of total length 16.
+#I  
+#I  Generators of original fp semigroup expressed as
+#I  combinations of generators in current presentation:
+#I  1. a = a
+#I  2. b = b
+#I  3. c = c
+#I  
+#I  Generators of current presentation expressed as
+#I  combinations of generators of original fp semigroup:
+#I  1. a = a
+#I  2. b = b
+#I  3. c = c
+gap> SEMIGROUPS.StzRelationDisplayString(stz, 4);
+fail
+gap> SetInfoLevel(InfoFpSemigroup, prevFpSemigroupInfoLevel);;
+
+# Multiple small Stz presentations, comparisons, display words in singular
+gap> prevFpSemigroupInfoLevel := InfoLevel(InfoFpSemigroup);;
+gap> SetInfoLevel(InfoFpSemigroup, 1);;
+gap> f1 := FreeSemigroup("fred");;
+gap> f2 := FreeSemigroup("foo", "bar");;
+gap> s1 := f1 / [[f1.1 * f1.1, f1.1]];;
+gap> s2 := f2 / [[f2.1 * f2.2, f2.2 * f2.1]];;
+gap> s3 := f2 / [];;
+gap> stz1 := StzPresentation(s1);
+<fp semigroup presentation with 1 generator and 1 relation with length 4>
+gap> stz2 := StzPresentation(s2);
+<fp semigroup presentation with 2 generators and 1 relation with length 6>
+gap> stz3 := StzPresentation(s3);
+<fp semigroup presentation with 2 generators and 0 relations with length 2>
+gap> stz1 < stz2;
+true
+gap> stz1 > stz2;
+false
+gap> StzPrintRelation(stz2, 1);
+#I  1. foo*bar = bar*foo
+gap> StzPrintRelations(stz3);
+#I  There are no relations in the presentation <stz>
+gap> SetGeneratorsOfStzPresentation(stz3, []);
+gap> GeneratorsOfStzPresentation(stz3);
+[  ]
+gap> StzPrintGenerators(stz3);
+#I  There are no generators in the presentation <stz>
+gap> StzPrintPresentation(stz1);
+#I  Current generators:
+#I  1.  fred  3 occurrences
+#I  
+#I  Current relations:
+#I  1. fred^2 = fred
+#I  
+#I  There is 1 generator and 1 relation of total length 4.
+#I  
+#I  Generators of original fp semigroup expressed as
+#I  combinations of generators in current presentation:
+#I  1. fred = fred
+#I  
+#I  Generators of current presentation expressed as
+#I  combinations of generators of original fp semigroup:
+#I  1. fred = fred
+gap> SetInfoLevel(InfoFpSemigroup, prevFpSemigroupInfoLevel);;
+
+# Test SetRelationsOfStzPresentation
+gap> prevFpSemigroupInfoLevel := InfoLevel(InfoFpSemigroup);;
+gap> SetInfoLevel(InfoFpSemigroup, 1);;
+gap> f := FreeSemigroup("s1", "s2", "s3");;
+gap> s := f / [[f.1 * f.2, f.3], [f.2 * f.3, f.1], [f.3 * f.1, f.2]];;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 3 generators and 3 relations with length 12>
+gap> SetRelationsOfStzPresentation(stz, "yeet");
+Error, SetRelationsOfStzPresentation:
+parameter <arg> must be a list of pairs of words in
+LetterRep format
+gap> SetRelationsOfStzPresentation(stz, [[1, "yeet"]]);
+Error, SetRelationsOfStzPresentation:
+parameter <arg> must be a list of pairs of words in
+LetterRep format
+gap> SetRelationsOfStzPresentation(stz, [[1, 2, 3]]);
+Error, SetRelationsOfStzPresentation:
+parameter <arg> must be a list of pairs of words in
+LetterRep format
+gap> SetRelationsOfStzPresentation(stz, [[[1], [2], [3]]]);
+Error, SetRelationsOfStzPresentation:
+parameter <arg> must be a list of pairs of words in
+LetterRep format
+gap> SetRelationsOfStzPresentation(stz, [[["yeet"], [2]]]);
+Error, SetRelationsOfStzPresentation:
+parameter <arg> must be a list of pairs of words in
+LetterRep format
+gap> SetRelationsOfStzPresentation(stz,
+>    [[[1, 2], [3, 3, 2]], [[1, 3], [3, 1]]]);
+gap> StzPrintRelations(stz);
+#I  1. s1*s2 = s3^2*s2
+#I  2. s1*s3 = s3*s1
+gap> SetInfoLevel(InfoFpSemigroup, prevFpSemigroupInfoLevel);;
+
+# Test SetTietzeForwardMap
+gap> f := FreeSemigroup("s1", "s2", "s3");;
+gap> s := f / [[f.1 * f.2, f.3], [f.2 * f.3, f.1], [f.3 * f.1, f.2]];;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 3 generators and 3 relations with length 12>
+gap> TietzeForwardMap(stz);
+[ [ 1 ], [ 2 ], [ 3 ] ]
+gap> SetTietzeForwardMap(stz, [1, 2, 3]);
+Error, SetTietzeForwardMap: second argument <newMaps> must
+be a list of lists of positive integers
+gap> SetTietzeForwardMap(stz, [["yeet", 1]]);
+Error, SetTietzeForwardMap: second argument <newMaps> must
+be a list of lists of positive integers
+gap> SetTietzeForwardMap(stz, [[1], [2], [1, 1]]);
+gap> TietzeForwardMap(stz);
+[ [ 1 ], [ 2 ], [ 1, 1 ] ]
+
+# Test SetTietzeBackwardMap
+gap> f := FreeSemigroup("s1", "s2", "s3");;
+gap> s := f / [[f.1 * f.2, f.3], [f.2 * f.3, f.1], [f.3 * f.1, f.2]];;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 3 generators and 3 relations with length 12>
+gap> TietzeBackwardMap(stz);
+[ [ 1 ], [ 2 ], [ 3 ] ]
+gap> SetTietzeBackwardMap(stz, [1, 2, 3]);
+Error, SetTietzeBackwardMap: second argument <newMaps> must
+be a list of lists of positive integers
+gap> SetTietzeBackwardMap(stz, [["yeet", 1]]);
+Error, SetTietzeBackwardMap: second argument <newMaps> must
+be a list of lists of positive integers
+gap> SetTietzeBackwardMap(stz, [[1], [2], [3], [1, 2, 3]]);
+gap> TietzeBackwardMap(stz);
+[ [ 1 ], [ 2 ], [ 3 ], [ 1, 2, 3 ] ]
+
+# Test TietzeForwardMapReplaceSubword
+gap> prevFpSemigroupInfoLevel := InfoLevel(InfoFpSemigroup);;
+gap> SetInfoLevel(InfoFpSemigroup, 1);;
+gap> f := FreeSemigroup("f", "g", "h", "i");;
+gap> s := f / [[(f.1 * f.2) ^ 2 * f.1 * f.3 * f.1 * f.2 * f.1, f.4]];;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 4 generators and 1 relation with length 14>
+gap> TietzeForwardMap(stz);
+[ [ 1 ], [ 2 ], [ 3 ], [ 4 ] ]
+gap> StzRemoveGenerator(stz, "i");
+gap> TietzeForwardMap(stz);
+[ [ 1 ], [ 2 ], [ 3 ], [ 1, 2, 1, 2, 1, 3, 1, 2, 1 ] ]
+gap> TietzeForwardMapReplaceSubword(stz, [1, 2, 1], [3, 3]);
+gap> TietzeForwardMap(stz);
+[ [ 1 ], [ 2 ], [ 3 ], [ 3, 3, 2, 1, 3, 3, 3 ] ]
+gap> StzPrintPresentation(stz);
+#I  Current generators:
+#I  1.  f  0 occurrences
+#I  2.  g  0 occurrences
+#I  3.  h  0 occurrences
+#I  
+#I  Current relations:
+#I  There are no relations in the presentation <stz>
+#I  
+#I  There are 3 generators and 0 relations of total length 3.
+#I  
+#I  Generators of original fp semigroup expressed as
+#I  combinations of generators in current presentation:
+#I  1. f = f
+#I  2. g = g
+#I  3. h = h
+#I  4. i = h^2*g*f*h^3
+#I  
+#I  Generators of current presentation expressed as
+#I  combinations of generators of original fp semigroup:
+#I  1. f = f
+#I  2. g = g
+#I  3. h = h
+gap> SetInfoLevel(InfoFpSemigroup, prevFpSemigroupInfoLevel);;
+
+# Test StzAddRelation and StzAddRelationNC
+# (and SEMIGROUPS.TietzeTransformation1)
+# Undecidable example (justifies NC although it can still verify some rels)
+gap> prevFpSemigroupInfoLevel := InfoLevel(InfoFpSemigroup);;
+gap> SetInfoLevel(InfoFpSemigroup, 1);;
+gap> f := FreeSemigroup("a", "b", "c", "d", "e");;
+gap> g := GeneratorsOfSemigroup(f);;
+gap> bad := "ac=ca, bc=cb, ce=eca, ad=da, bd=db, de=edb, cca=ccae";;
+gap> rels := ParseRelations(g, bad);;
+gap> s := f / rels;;
+gap> a := s.1;;b := s.2;;c := s.3;;d := s.4;;e := s.5;;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 5 generators and 7 relations with length 38>
+gap> StzAddRelation(stz, [[3, 5], [5, 1, 3]]);
+gap> StzAddRelation(stz, [d * a * b, a * b * d]);
+gap> StzAddRelationNC(stz, [[1, 5, 2, 1, 4], [1, 4, 5, 1]]);
+gap> StzAddRelationNC(stz, [a * c * c * d * b, c * c * d * a * e]);
+gap> StzPrintRelations(stz);
+#I  1. a*c = c*a
+#I  2. b*c = c*b
+#I  3. c*e = e*c*a
+#I  4. a*d = d*a
+#I  5. b*d = d*b
+#I  6. d*e = e*d*b
+#I  7. c^2*a = c^2*a*e
+#I  8. c*e = e*a*c
+#I  9. d*a*b = a*b*d
+#I  10. a*e*b*a*d = a*d*e*a
+#I  11. a*c^2*d*b = c^2*d*a*e
+gap> StzAddRelation(stz, [[1], [2], [3]]);
+Error, StzAddRelation: second argument <pair> should be a list
+of length 2
+gap> StzAddRelation(stz, [[], [2]]);
+Error, StzAddRelation: words in second argument <pair> should
+be non-empty
+gap> StzAddRelation(stz, [[1, 2, 3], [6]]);
+Error, StzAddRelation: words in second argument <pair>
+should be lists of pos ints no greater than the
+number of generators of first argument <stz>
+gap> StzAddRelation(stz, [a * b, b * c, c * d]);
+Error, StzAddRelation: second argument <pair> should be a list
+of length 2
+gap> StzAddRelationNC(stz, [[1], [2], [3]]);
+Error, StzAddRelationNC: second argument <pair> should be a list
+of length 2
+gap> StzAddRelationNC(stz, [[], [2]]);
+Error, StzAddRelationNC: words in second argument <pair>
+should be non-empty
+gap> StzAddRelationNC(stz, [[1, 2, 3], [6]]);
+Error, StzAddRelationNC: words in second argument <pair>
+should be lists of pos ints no greater than the
+number of generators of first argument <stz>
+gap> StzAddRelationNC(stz, [a * b, b * c, c * d]);
+Error, StzAddRelationNC: second argument <pair> should be a list
+of length 2
+gap> StzAddRelation(stz, [42, 42]);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 3rd choice method found for `StzAddRelation' on 2 arguments
+gap> StzAddRelationNC(stz, [42, 42]);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 3rd choice method found for `StzAddRelationNC' on 2 arguments
+gap> SetInfoLevel(InfoFpSemigroup, prevFpSemigroupInfoLevel);;
+
+# Test StzAddRelation (with decidable problem, so that it rejects a
+# non-redundant rel)
+gap> f := FreeSemigroup("a", "b");;
+gap> s := f / [[f.1 * f.2, f.2 * f.1]];;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 2 generators and 1 relation with length 6>
+gap> StzAddRelation(stz, [[1, 1], [1]]);
+Error, StzAddRelation: second argument <pair> must list two
+words that are equal in the presentation <stz>
+gap> StzAddRelation(stz, [s.1 * s.1, s.1]);
+Error, StzAddRelation: second argument <pair> must list two
+words that are equal in the presentation <stz>
+
+# Test StzRemoveRelation and StzRemoveRelationNC
+gap> prevFpSemigroupInfoLevel := InfoLevel(InfoFpSemigroup);;
+gap> SetInfoLevel(InfoFpSemigroup, 1);;
+gap> f := FreeSemigroup("x", "y");;
+gap> r := ParseRelations([f.1, f.2],
+>         "xx=x, yy=y, xyxy=xy, yxyx=yx, xyxyx=xyx");;
+gap> s := f / r;;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 2 generators and 5 relations with length 28>
+gap> StzRemoveRelation(stz, 5);
+gap> StzRemoveRelation(stz, 4);
+Error, StzRemoveRelation: second argument <index> must point to
+a relation that is redundant in the presentation <stz>
+gap> StzRemoveRelationNC(stz, 4);
+gap> StzRemoveRelation(stz, 4);
+Error, StzRemoveRelation: second argument <index> must be less
+than or equal to the number of relations of the first
+argument <stz>
+gap> StzRemoveRelationNC(stz, 4);
+Error, StzRemoveRelationNC: second argument <index> must be less
+than or equal to the number of relations of the first
+argument <stz>
+gap> StzPrintPresentation(stz);
+#I  Current generators:
+#I  1.  x  6 occurrences
+#I  2.  y  6 occurrences
+#I  
+#I  Current relations:
+#I  1. x^2 = x
+#I  2. y^2 = y
+#I  3. (x*y)^2 = x*y
+#I  
+#I  There are 2 generators and 3 relations of total length 14.
+#I  
+#I  Generators of original fp semigroup expressed as
+#I  combinations of generators in current presentation:
+#I  1. x = x
+#I  2. y = y
+#I  
+#I  Generators of current presentation expressed as
+#I  combinations of generators of original fp semigroup:
+#I  1. x = x
+#I  2. y = y
+gap> SetInfoLevel(InfoFpSemigroup, prevFpSemigroupInfoLevel);;
+
+# Test StzAddGenerator (on 2 arguments, auto generator name creation)
+gap> f := FreeSemigroup("a", "b");;
+gap> s := f / [[(f.1 * f.1 * f.2) ^ 2, f.1 * f.1 * f.2]];;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 2 generators and 1 relation with length 11>
+gap> StzAddGenerator(stz, ["what?", "how?"]);
+Error, StzAddGenerator: second argument <word> is not a
+list of pos ints at most equal to the number of
+generators of the first argument <stz>
+gap> StzAddGenerator(stz, [1, 3, 1]);
+Error, StzAddGenerator: second argument <word> is not a
+list of pos ints at most equal to the number of
+generators of the first argument <stz>
+gap> StzAddGenerator(stz, []);
+Error, StzAddGenerator: cannot add generator equal to the empty
+word
+gap> StzAddGenerator(stz, [1, 1, 2]);
+gap> TietzeBackwardMap(stz);
+[ [ 1 ], [ 2 ], [ 1, 1, 2 ] ]
+gap> elm := (f / []).1;;  # fp smgp elm but not in s
+gap> StzAddGenerator(stz, elm);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `StzAddGenerator' on 2 arguments
+gap> StzAddGenerator(stz, s.1 * s.2);
+gap> TietzeBackwardMap(stz);
+[ [ 1 ], [ 2 ], [ 1, 1, 2 ], [ 1, 2 ] ]
+gap> GeneratorsOfStzPresentation(stz);
+[ "a", "b", "c", "d" ]
+
+# Test StzAddGenerator (on 3 arguments: specified new generator name)
+gap> f := FreeSemigroup("a", "b");;
+gap> s := f / [[(f.1 * f.1 * f.2) ^ 2, f.1 * f.1 * f.2]];;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 2 generators and 1 relation with length 11>
+gap> StzAddGenerator(stz, ["what?", "how?"], "hehe");
+Error, StzAddGenerator: second argument <word> is not a
+list of pos ints at most equal to the number of
+generators of the first argument <stz>
+gap> StzAddGenerator(stz, [1, 3, 1], "dd");
+Error, StzAddGenerator: second argument <word> is not a
+list of pos ints at most equal to the number of
+generators of the first argument <stz>
+gap> StzAddGenerator(stz, [], "x");
+Error, StzAddGenerator: cannot add generator equal to the empty
+word
+gap> StzAddGenerator(stz, [1, 1, 2], "a");
+Error, StzAddGenerator: third argument <name> should not be the
+name of a pre-existing generator
+gap> StzAddGenerator(stz, [1, 1, 2], "newgenname");
+gap> TietzeBackwardMap(stz);
+[ [ 1 ], [ 2 ], [ 1, 1, 2 ] ]
+gap> elm := (f / []).1;;  # fp smgp elm but not in s
+gap> StzAddGenerator(stz, elm, "somethingweird");
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `StzAddGenerator' on 3 arguments
+gap> StzAddGenerator(stz, s.1 * s.2, "ff");
+gap> TietzeBackwardMap(stz);
+[ [ 1 ], [ 2 ], [ 1, 1, 2 ], [ 1, 2 ] ]
+gap> GeneratorsOfStzPresentation(stz);
+[ "a", "b", "newgenname", "ff" ]
+
+# Test StzRemoveGenerator on 2 arguments (index of relation unspecified)
+gap> f := FreeSemigroup("x", "y", "z");;
+gap> r := ParseRelations([f.1, f.2, f.3], "yx=xz, x=zy, y=z^3");;
+gap> s := f / r;;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 3 generators and 3 relations with length 14>
+gap> StzRemoveGenerator(stz, 4);
+Error, StzRemoveGenerator: second argument <gen> must be no
+greater than the total number of generators
+gap> StzRemoveGenerator(stz, "a");
+Error, StzRemoveGenerator: second argument <gen> does not
+correspond to a generator name in first argument <stz>
+gap> StzRemoveGenerator(stz, 1);
+gap> GeneratorsOfStzPresentation(stz);
+[ "y", "z" ]
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 1, 2, 1 ], [ 2, 1, 2 ] ], [ [ 1 ], [ 2, 2, 2 ] ] ]
+gap> TietzeForwardMap(stz);
+[ [ 2, 1 ], [ 1 ], [ 2 ] ]
+gap> TietzeBackwardMap(stz);
+[ [ 2 ], [ 3 ] ]
+gap> StzRemoveGenerator(stz, 2);
+Error, StzRemoveGenerator: there is no relation in first
+argument <stz> expressing second argument <gen> as a
+product of other generators
+gap> StzRemoveGenerator(stz, "y");
+gap> GeneratorsOfStzPresentation(stz);
+[ "z" ]
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 1, 1, 1, 1, 1, 1, 1 ], [ 1, 1, 1, 1, 1 ] ] ]
+gap> TietzeForwardMap(stz);
+[ [ 1, 1, 1, 1 ], [ 1, 1, 1 ], [ 1 ] ]
+gap> TietzeBackwardMap(stz);
+[ [ 3 ] ]
+gap> StzRemoveGenerator(stz, 2);
+Error, StzRemoveGenerator: cannot remove only remaining
+generator "z"
+gap> StzRemoveGenerator(stz, "y");
+Error, StzRemoveGenerator: second argument <gen> does not
+correspond to a generator name in first argument <stz>
+gap> StzRemoveGenerator(stz, 1);
+Error, StzRemoveGenerator: cannot remove only remaining
+generator "z"
+
+# Test StzRemoveGenerator on 3 arguments (specified relation)
+gap> f := FreeSemigroup(3);;
+gap> s := f / [[f.1, f.2 ^ 2], [f.1, f.3 ^ 2], [f.2, f.3 ^ 2]];;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 3 generators and 3 relations with length 12>
+gap> StzRemoveGenerator(stz, 4, 1);
+Error, StzRemoveGenerator: second argument <gen> must be no
+greater than the total number of generators
+gap> StzRemoveGenerator(stz, 1, 4);
+Error, StzRemoveGenerator: third argument <index> must be no
+greater than the total number of relations in first
+argument <stz>
+gap> StzRemoveGenerator(stz, 1, 3);
+Error, StzRemoveGenerator: third argument <index> does not point
+to a relation expressing second argument <gen> as a
+combination of other generators in first argument <stz>
+gap> SEMIGROUPS.TietzeTransformation4(stz, 1, 3);
+Error, TietzeTransformation4, internal function: third argument
+<index> does not point to a relation expressing second
+argument <gen> as a combination of other generators
+gap> StzRemoveGenerator(stz, "a", 1);
+Error, StzRemoveGenerator: second argument <gen> does not
+correspond to a generator name in first argument <stz>
+gap> StzRemoveGenerator(stz, 1, 2);
+gap> GeneratorsOfStzPresentation(stz);
+[ "s2", "s3" ]
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 2, 2 ], [ 1, 1 ] ], [ [ 1 ], [ 2, 2 ] ] ]
+gap> TietzeForwardMap(stz);
+[ [ 2, 2 ], [ 1 ], [ 2 ] ]
+gap> TietzeBackwardMap(stz);
+[ [ 2 ], [ 3 ] ]
+gap> StzRemoveGenerator(stz, "s2", 2);
+gap> GeneratorsOfStzPresentation(stz);
+[ "s3" ]
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 1, 1 ], [ 1, 1, 1, 1 ] ] ]
+gap> TietzeForwardMap(stz);
+[ [ 1, 1 ], [ 1, 1 ], [ 1 ] ]
+gap> TietzeBackwardMap(stz);
+[ [ 3 ] ]
+gap> StzRemoveGenerator(stz, 1, 1);
+Error, StzRemoveGenerator: cannot remove only remaining
+generator "s3"
+
+# Test all four Tietze transformations on trivial example
+gap> f := FreeSemigroup("x");;
+gap> s := f / [];;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 1 generator and 0 relations with length 1>
+gap> StzAddRelation(stz, [[1, 1], [1]]);
+Error, StzAddRelation: second argument <pair> must list two
+words that are equal in the presentation <stz>
+gap> StzAddRelation(stz, [[1, 1], [1, 1]]);
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 1, 1 ], [ 1, 1 ] ] ]
+gap> StzAddGenerator(stz, s.1 ^ 2, "y");
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 1, 1 ], [ 1, 1 ] ], [ [ 1, 1 ], [ 2 ] ] ]
+gap> GeneratorsOfStzPresentation(stz);
+[ "x", "y" ]
+gap> StzRemoveRelation(stz, 1);
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 1, 1 ], [ 2 ] ] ]
+gap> StzRemoveGenerator(stz, "y");
+gap> RelationsOfStzPresentation(stz);
+[  ]
+
+# Test StzSubstituteRelation
+gap> f := FreeSemigroup("x", "y", "z");;
+gap> r := ParseRelations([f.1, f.2, f.3], "xyxyx=zxyxz, xyx=x^2");;
+gap> s := f / r;;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 3 generators and 2 relations with length 18>
+gap> RelationsOfStzPresentation(stz);
+[ [ [ 1, 2, 1, 2, 1 ], [ 3, 1, 2, 1, 3 ] ], [ [ 1, 2, 1 ], [ 1, 1 ] ] ]
+gap> StzSubstituteRelation(stz, 3, 1);
+Error, StzSubstituteRelation: second argument <index> must be no
+greater than the number of relations in first argument
+<stz>
+gap> StzSubstituteRelation(stz, 2, 3);
+Error, StzSubstituteRelation: third argument <side> must be
+either 1 or 2
+gap> StzSubstituteRelation(stz, 2, 1);
+gap> SortedList(RelationsOfStzPresentation(stz));
+[ [ [ 1, 1, 2, 1 ], [ 3, 1, 1, 3 ] ], [ [ 1, 2, 1 ], [ 1, 1 ] ] ]
+
+# Test (internal) function SEMIGROUPS.NewGeneratorName
+gap> SEMIGROUPS.NewGeneratorName([]);
+"a"
+gap> SEMIGROUPS.NewGeneratorName(["a"]);
+"b"
+gap> SEMIGROUPS.NewGeneratorName(["g"]);
+"a"
+gap> SEMIGROUPS.NewGeneratorName(["A"]);
+"B"
+gap> SEMIGROUPS.NewGeneratorName(["R"]);
+"A"
+gap> SEMIGROUPS.NewGeneratorName(["yeet"]);
+"a"
+gap> SEMIGROUPS.NewGeneratorName(["?"]);
+"a"
+gap> SEMIGROUPS.NewGeneratorName(["a", "c", "d", "A", "B", "m4", "m1"]);
+"b"
+gap> SEMIGROUPS.NewGeneratorName(["A", "B", "C", "m1"]);
+"D"
+gap> SEMIGROUPS.NewGeneratorName(["a", "c", "d", "A", "B", "D", "X"]);
+"C"
+gap> SEMIGROUPS.NewGeneratorName(["s1", "s3", "m4", "m6", "m2"]);
+"m7"
+gap> SEMIGROUPS.NewGeneratorName(["gar", "bage"]);
+"s1"
+
+# Test StzSimplifyPresentation
+# We do not require any specific steps to be carried, so suppress output
+# (setting InfoLevel low enough) and only require that the final reduction
+# is below a certain bar, and cannot be reduced further.
+gap> prevFpSemigroupInfoLevel := InfoLevel(InfoFpSemigroup);;
+gap> SetInfoLevel(InfoFpSemigroup, 1);;
+gap> f := FreeSemigroup("a", "b", "c", "d");;
+gap> r := ParseRelations([f.1, f.2, f.3, f.4],
+>         "a^5=a,a^25=cb,(cb)^3=c,a=a^5,cb=cb,(cb)^12=b^12,d=a^10");;
+gap> s := f / r;;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 4 generators and 7 relations with length 101>
+gap> StzSimplifyPresentation(stz);
+gap> l := Length(stz);;
+gap> l < 30;  # first version of the algorithm was able to achieve this
+true
+gap> StzSimplifyOnce(stz);
+false
+gap> l = Length(stz);
+true
+gap> SetInfoLevel(InfoFpSemigroup, prevFpSemigroupInfoLevel);;
+
+# Test StzSimplifyPresentation, 2
+gap> prevFpSemigroupInfoLevel := InfoLevel(InfoFpSemigroup);;
+gap> SetInfoLevel(InfoFpSemigroup, 1);;
+gap> f := FreeSemigroup("f", "g");;
+gap> s := f / [[f.1 * f.2, f.2 * f.1], [f.1, f.2]];;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 2 generators and 2 relations with length 8>
+gap> StzSimplifyPresentation(stz);
+gap> GeneratorsOfStzPresentation(stz);
+[ "g" ]
+gap> RelationsOfStzPresentation(stz);
+[  ]
+gap> SetInfoLevel(InfoFpSemigroup, prevFpSemigroupInfoLevel);;
+
+# Test SEMIGROUPS.StzFrequentSubwordApply
+gap> prevFpSemigroupInfoLevel := InfoLevel(InfoFpSemigroup);;
+gap> SetInfoLevel(InfoFpSemigroup, 1);;
+gap> f := FreeSemigroup("a", "b", "c");;
+gap> r := ParseRelations([f.1, f.2, f.3], "abbabb=cabb, ababb=c");;
+gap> s := f / r;;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 3 generators and 2 relations with length 19>
+gap> SEMIGROUPS.StzFrequentSubwordApply(stz, rec(word := [1, 2, 2]));
+gap> SortedList(RelationsOfStzPresentation(stz));
+[ [ [ 1, 2, 2 ], [ 4 ] ], [ [ 1, 2, 4 ], [ 3 ] ], [ [ 4, 4 ], [ 3, 4 ] ] ]
+gap> SetInfoLevel(InfoFpSemigroup, prevFpSemigroupInfoLevel);;
+
+# Test SEMIGROUPS.StzTrivialRelationApply
+#  and SEMIGROUPS.StzDuplicateRelsApply
+#  and SEMIGROUPS.StzGensRedundantApply
+gap> prevFpSemigroupInfoLevel := InfoLevel(InfoFpSemigroup);;
+gap> SetInfoLevel(InfoFpSemigroup, 1);;
+gap> f := FreeSemigroup("x", "y", "z");;
+gap> r := ParseRelations([f.1, f.2, f.3], "xy=yx, yx=xy, x=x, y=xz");;
+gap> s := f / r;;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 3 generators and 4 relations with length 16>
+gap> SEMIGROUPS.StzTrivialRelationApply(stz, rec(argument := 3));
+gap> SortedList(RelationsOfStzPresentation(stz));
+[ [ [ 1, 2 ], [ 2, 1 ] ], [ [ 2 ], [ 1, 3 ] ], [ [ 2, 1 ], [ 1, 2 ] ] ]
+gap> SEMIGROUPS.StzDuplicateRelsApply(stz, rec(argument := 2));
+gap> SortedList(RelationsOfStzPresentation(stz));
+[ [ [ 1, 2 ], [ 2, 1 ] ], [ [ 2 ], [ 1, 3 ] ] ]
+gap> SEMIGROUPS.StzGensRedundantApply(stz, rec(argument := 2, infoRel := 2));
+gap> SortedList(RelationsOfStzPresentation(stz));
+[ [ [ 1, 1, 2 ], [ 1, 2, 1 ] ] ]
+gap> SetInfoLevel(InfoFpSemigroup, prevFpSemigroupInfoLevel);;
+
+# Test SEMIGROUPS.StzRelsSubApply
+gap> prevFpSemigroupInfoLevel := InfoLevel(InfoFpSemigroup);;
+gap> SetInfoLevel(InfoFpSemigroup, 1);;
+gap> f := FreeSemigroup("a", "b", "c", "d", "e");;
+gap> r := ParseRelations(GeneratorsOfSemigroup(f),
+>         "abc=ca, acb=d, e=ca, ed=abc, ee=e");;
+gap> s := f / r;;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 5 generators and 5 relations with length 25>
+gap> SEMIGROUPS.StzRelsSubApply(stz, rec(argument := 4));
+gap> SortedList(RelationsOfStzPresentation(stz)) =
+>    [[[1, 3, 2], [4]],
+>     [[5], [3, 1]],
+>     [[5, 4], [1, 2, 3]],
+>     [[5, 4], [3, 1]],
+>     [[5, 5], [5]]];
+true
+gap> SetInfoLevel(InfoFpSemigroup, prevFpSemigroupInfoLevel);;
+
+# Test StzSimplifyOnce on 1 argument
+gap> prevFpSemigroupInfoLevel := InfoLevel(InfoFpSemigroup);;
+gap> SetInfoLevel(InfoFpSemigroup, 0);;
+gap> f := FreeSemigroup("a", "b", "c");
+<free semigroup on the generators [ a, b, c ]>
+gap> s := f / [[f.1 ^ 4, f.1], [f.1, f.1 ^ 44], [f.1 ^ 8, f.2 * f.3]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 3 generators and 3 relations with length 63>
+gap> len := Length(stz);
+63
+gap> StzSimplifyOnce(stz);
+true
+gap> Length(stz) < len;
+true
+gap> s := f / [[f.1, f.1 ^ 2]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 3 generators and 1 relation with length 6>
+gap> len := Length(stz);
+6
+gap> StzSimplifyOnce(stz);
+false
+gap> len = Length(stz);
+true
+gap> s := f / [[f.1, f.2 ^ 5]];
+<fp semigroup on the generators [ a, b, c ]>
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 3 generators and 1 relation with length 9>
+gap> len := Length(stz);
+9
+gap> StzSimplifyOnce(stz);
+true
+gap> Length(stz) < len;
+true
+gap> len := Length(stz);
+2
+gap> StzSimplifyOnce(stz);
+false
+gap> len = Length(stz);
+true
+gap> SetInfoLevel(InfoFpSemigroup, prevFpSemigroupInfoLevel);;
+
+# Test TietzeIsomorphism
+gap> prevFpSemigroupInfoLevel := InfoLevel(InfoFpSemigroup);;
+gap> SetInfoLevel(InfoFpSemigroup, 1);;
+gap> f := FreeSemigroup("a", "b", "c");;
+gap> r := ParseRelations([f.1, f.2, f.3], "ab=c, ababa=aba, c^2=bc");;
+gap> s := f / r;;
+gap> stz := StzPresentation(s);
+<fp semigroup presentation with 3 generators and 3 relations with length 18>
+gap> StzPrintGenerators(stz);
+#I  1.  a  6 occurrences
+#I  2.  b  5 occurrences
+#I  3.  c  4 occurrences
+gap> StzPrintRelations(stz);
+#I  1. a*b = c
+#I  2. (a*b)^2*a = a*b*a
+#I  3. c^2 = b*c
+gap> StzRemoveGenerator(stz, "c");
+gap> StzPrintRelations(stz);
+#I  1. (a*b)^2*a = a*b*a
+#I  2. (a*b)^2 = b*a*b
+gap> StzAddGenerator(stz, s.3 * s.1, "d");
+gap> StzPrintRelations(stz);
+#I  1. (a*b)^2*a = a*b*a
+#I  2. (a*b)^2 = b*a*b
+#I  3. a*b*a = d
+gap> StzSubstituteRelation(stz, 3, 1);
+gap> StzPrintRelations(stz);
+#I  1. d*b*a = d
+#I  2. d*b = b*a*b
+#I  3. a*b*a = d
+gap> map := TietzeIsomorphism(stz);;
+gap> s = Source(map);
+true
+gap> t := Range(map);;
+gap> s.1 ^ map = t.1;
+true
+gap> s.2 ^ map = t.2;
+true
+gap> s.3 ^ map = t.1 * t.2;
+true
+gap> RespectsMultiplication(map);
+true
+gap> (s.1 * s.2) ^ map = s.3 ^ map;
+true
+gap> (s.1 * s.2 * s.1 * s.2 * s.1) ^ map = (s.1 * s.2 * s.1) ^ map;
+true
+gap> (s.3 ^ 2) ^ map = (s.2 * s.3) ^ map;
+true
+gap> inv := InverseGeneralMapping(map);;
+gap> t.1 ^ inv = s.1;
+true
+gap> t.2 ^ inv = s.2;
+true
+gap> t.3 ^ inv = s.1 * s.2 * s.1;
+true
+gap> RespectsMultiplication(inv);
+true
+gap> GeneratorsOfSemigroup(t);
+[ a, b, d ]
+gap> SetInfoLevel(InfoFpSemigroup, prevFpSemigroupInfoLevel);;
+
+# Test SimplifiedFpSemigroup
+gap> prevFpSemigroupInfoLevel := InfoLevel(InfoFpSemigroup);;
+gap> SetInfoLevel(InfoFpSemigroup, 1);;
+gap> s := AsSemigroup(IsFpSemigroup, FullTransformationSemigroup(3));;
+gap> t := SimplifiedFpSemigroup(s);;
+gap> s := AsSemigroup(IsTransformationSemigroup, s);;
+gap> t := AsSemigroup(IsTransformationSemigroup, t);;
+gap> IsomorphismSemigroups(s, t) <> fail;
+true
+gap> SetInfoLevel(InfoFpSemigroup, prevFpSemigroupInfoLevel);;
+
+# UnbindVariables
+gap> Unbind(a);
+gap> Unbind(b);
+gap> Unbind(bad);
+gap> Unbind(c);
+gap> Unbind(d);
+gap> Unbind(e);
+gap> Unbind(elm);
+gap> Unbind(f);
+gap> Unbind(f1);
+gap> Unbind(f2);
+gap> Unbind(inv);
+gap> Unbind(l);
+gap> Unbind(len);
+gap> Unbind(map);
+gap> Unbind(prevFpSemigroupInfoLevel);
+gap> Unbind(r);
+gap> Unbind(rels);
+gap> Unbind(s);
+gap> Unbind(s1);
+gap> Unbind(s2);
+gap> Unbind(s3);
+gap> Unbind(stz);
+gap> Unbind(stz1);
+gap> Unbind(stz2);
+gap> Unbind(stz3);
+gap> Unbind(t);
+
+#
+gap> SEMIGROUPS.StopTest();
+gap> STOP_TEST("Semigroups package: standard/tietze.tst");

--- a/tst/standard/tietze.tst
+++ b/tst/standard/tietze.tst
@@ -29,7 +29,7 @@ gap> GeneratorsOfStzPresentation(stz);
 [ "a", "b", "c" ]
 gap> RelationsOfStzPresentation(stz);
 [ [ [ 1, 1, 2, 1, 1, 2 ], [ 1, 1, 2 ] ], [ [ 3 ], [ 1, 1, 2 ] ] ]
-gap> s = UnreducedSemigroupOfStzPresentation(stz);
+gap> s = UnreducedFpSemigroup(stz);
 true
 gap> Length(stz);
 16

--- a/tst/standard/tietze.tst
+++ b/tst/standard/tietze.tst
@@ -713,7 +713,7 @@ gap> len = Length(stz);
 true
 gap> SetInfoLevel(InfoFpSemigroup, prevFpSemigroupInfoLevel);;
 
-# Test TietzeIsomorphism
+# Test StzIsomorphism
 gap> prevFpSemigroupInfoLevel := InfoLevel(InfoFpSemigroup);;
 gap> SetInfoLevel(InfoFpSemigroup, 1);;
 gap> f := FreeSemigroup("a", "b", "c");;
@@ -743,7 +743,7 @@ gap> StzPrintRelations(stz);
 #I  1. d*b*a = d
 #I  2. d*b = b*a*b
 #I  3. a*b*a = d
-gap> map := TietzeIsomorphism(stz);;
+gap> map := StzIsomorphism(stz);;
 gap> s = Source(map);
 true
 gap> t := Range(map);;


### PR DESCRIPTION
Authors: Ben Spiers (@bspiers) and Tom Conti-Leslie (@tomcontileslie)
**Ready for review**

This PR creates methods for a "semigroup Tietze" object which contains the generators and relations of an fp semigroup. Tietze transformations can be manually applied to the object to change the presentation, giving an fp semigroup isomorphic to the original. The idea is to also have a "SimplifyPresentation" operation which will intelligently apply transformations in order to reduce the overall length of the presentation.

Once transformations have been applied to the Tietze object to taste, it can be converted back into an fp semigroup and a mapping object can be produced which provides an isomorphism between the original fp semigroup and the modified version.

### Still needs doing:
- [x] Implement SimplifyPresentation
- [x] Change SEMIGROUPS.StzReplaceSubwordRel to be non-recursive
- [x] Implement a ViewPresentation method to print relations of stz object
- [x] Make sure we're happy with function names, etc
- [x] Format tietze.gd and tietze.gi correctly
- [x] Write documentation
- [x] Write tests
- [x] Remove argument checks from SEMIGROUPS.TietzeTransformation1... etc, but create wrapper functions for users that do check arguments (e.g. called TietzeRemoveGenerator, TietzeAddGenerator, etc, and potentially NC versions)
- [x] Implement something like StzPrintGeneratorImages (the Tz version in the GAP distribution is really nice)
- [x] Check that everything works if the stz object is StzPresentation(FreeSemigroup(2) / [ ]) (currently the relation list is assumed to be non-empty in some places; add this case to the test file)