### PR TITLE
Make compilation of manuals more robust

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -314,7 +314,7 @@ Dependencies := rec(
                           ["digraphs", ">=1.2.0"],
                           ["genss", ">=1.6.5"],
                           ["images", ">=1.3.0"]],
-  SuggestedOtherPackages := [["gapdoc", ">=1.5.1"]],
+  SuggestedOtherPackages := [["GAPDoc", ">=1.6.3"]],
 
   ExternalConditions := []),
 

--- a/ci/docker-install-deps.sh
+++ b/ci/docker-install-deps.sh
@@ -49,6 +49,10 @@ PKGS=( "digraphs" "genss" "io" "orb" "images" "datastructures")
 if [ "$SUITE"  == "coverage" ]; then
   PKGS+=( "profiling" )
 fi
+# We now need a newer GAPDoc than the one included in the Docker container for GAP 4.10.2
+if [ "$GAP_VERSION" == "4.10.2" ]; then
+  PKGS+=( "GAPDoc" )
+fi
 
 for PKG in "${PKGS[@]}"; do
   cd $GAP_HOME/pkg
@@ -65,7 +69,13 @@ for PKG in "${PKGS[@]}"; do
     exit 1
   fi
 
-  URL="https://github.com/gap-packages/$PKG/releases/download/v$VERSION/$PKG-$VERSION.tar.gz"
+  # This can be removed when there is no GAPDoc special case for GAP 4.10.2
+  if [ "$PKG" == "GAPDoc" ]; then
+    URL="http://www.math.rwth-aachen.de/~Frank.Luebeck/GAPDoc/GAPDoc-$VERSION.tar.gz"
+  else
+    URL="https://github.com/gap-packages/$PKG/releases/download/v$VERSION/$PKG-$VERSION.tar.gz"
+  fi
+
   echo -e "\nDownloading $PKG-$VERSION ($PACKAGES version), from URL:\n$URL"
   $CURL "$URL" -o $PKG-$VERSION.tar.gz
   tar xf $PKG-$VERSION.tar.gz && rm $PKG-$VERSION.tar.gz

--- a/ci/docker-test.sh
+++ b/ci/docker-test.sh
@@ -49,7 +49,7 @@ else
   echo "Test(\"load-workspace.tst\"); SemigroupsTestInstall(); quit; quit; quit;" | $GAPSH -L test-output.w -A -x 80 -m 768m -o $MEM -T 2>&1 | tee -a $TESTLOG
 
   echo -e "\nRunning Semigroups package standard tests and manual examples..."
-  echo "LoadPackage(\"semigroups\"); SemigroupsTestStandard(); SEMIGROUPS.TestManualExamples();" |
+  echo "LoadPackage(\"semigroups\"); SemigroupsMakeDoc(); SemigroupsTestStandard(); SEMIGROUPS.TestManualExamples();" |
     $GAPSH -A -x 80 -m 768m -o $MEM -T 2>&1 | tee -a $TESTLOG
 
   # Run GAP tests, but only in 64-bit, since they're far too slow in 32-bit

--- a/gap/tools/utils.gd
+++ b/gap/tools/utils.gd
@@ -8,6 +8,7 @@
 #############################################################################
 ##
 
+DeclareGlobalFunction("SemigroupsMakeDoc");
 DeclareGlobalFunction("SemigroupsTestInstall");
 DeclareGlobalFunction("SemigroupsTestStandard");
 DeclareGlobalFunction("SemigroupsTestExtreme");

--- a/gap/tools/utils.gi
+++ b/gap/tools/utils.gi
@@ -233,6 +233,12 @@ end);
 # 2. Documentation - internal stuff
 ################################################################################
 
+InstallGlobalFunction(SemigroupsMakeDoc,
+function()
+  # Compile the documentation of the currently-loaded version of Semigroups
+  SEMIGROUPS_MakeDoc(DirectoriesPackageLibrary("Semigroups", ""));
+end);
+
 SEMIGROUPS.ManualExamples := function()
   return ExtractExamples(DirectoriesPackageLibrary("semigroups", "doc"),
                          "main.xml", SEMIGROUPS_DocXMLFiles, "Single");

--- a/makedoc.g
+++ b/makedoc.g
@@ -6,7 +6,20 @@
 ##      gap makedoc.g
 ##
 
-if not IsBoundGlobal("SemigroupsMakeDoc") then
-  Read(Filename(DirectoriesPackageLibrary("semigroups", "gap"), "doc.g"));
+if not IsDirectoryPath("gap")
+    or not "doc.g" in DirectoryContents("gap") then
+  Print("Error: GAP must be run from the package directory ",
+        "when reading makedoc.g\n");
+  FORCE_QUIT_GAP(1);
 fi;
-SemigroupsMakeDoc(true);
+if IsBoundGlobal("SEMIGROUPS_DocXMLFiles") then
+  MakeReadWriteGlobal("SEMIGROUPS_DocXMLFiles");
+  UnbindGlobal("SEMIGROUPS_DocXMLFiles");
+fi;
+if IsBoundGlobal("SEMIGROUPS_MakeDoc") then
+  MakeReadWriteGlobal("SEMIGROUPS_MakeDoc");
+  UnbindGlobal("SEMIGROUPS_MakeDoc");
+fi;
+Read("gap/doc.g");
+SEMIGROUPS_MakeDoc(DirectoryCurrent());
+FORCE_QUIT_GAP();


### PR DESCRIPTION
This resolves the issues I mentioned in #767, with the same solution that I have used for Digraphs.

The reason I've had to touch `PackageInfo.g` and `ci/docker-install-deps.sh` is to make sure that the CI uses GAPDoc at least v1.6.3. This version of GAPDoc adds the option `nopdf` to `MakeGAPDocDoc`.

If you call `MakeGAPDocDoc` without the `nopdf` option, and if `pdflatex` is not available, then `MakeGAPDocDoc` fails to create a `manual.six` file. Thus running `GAPDocManualLabFromSixFile` in this situation will fail. Moreover, the Docker containers used in the CI do not have `pdflatex` available.

I think the reason why this wasn't failing previously is because we weren't compiling the manuals in the Azure Pipelines tests. I have added compilation of the manuals to the tests in this PR. If I revert that change, I can also remove the changes to `PackageInfo.g` and `ci/docker-install-deps.sh`.

I'm happy to discuss any other aspects of this PR too.