### PR TITLE
Add colours to the `prerequisites.sh` script

### DIFF
--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -2,6 +2,15 @@
 
 set -e
 
+notice_it() {
+    printf '\033[32m%s\033[0m\n' "$*"
+}
+
+error() {
+    printf '\033[31mERROR: %s\033[0m\n' "$*"
+    exit 1
+}
+
 SEMI_DIR=`dirname "$0"`
 LIBS_DIR="$SEMI_DIR/libsemigroups"
 
@@ -9,36 +18,33 @@ LIBS_DIR="$SEMI_DIR/libsemigroups"
 if [ -f "$SEMI_DIR/.LIBSEMIGROUPS_VERSION" ]; then
   VERS=`tr -d '\n' < $SEMI_DIR/.LIBSEMIGROUPS_VERSION`
 else
-  echo "Error, cannot find $SEMI_DIR/.LIBSEMIGROUPS_VERSION"
-  exit 1
+  error "Error, cannot find $SEMI_DIR/.LIBSEMIGROUPS_VERSION"
 fi
 
-echo "libsemigroups v$VERS is required by this version of Semigroups"
+notice_it "libsemigroups v$VERS is required by this version of Semigroups"
 
 if [ -d "$LIBS_DIR" ] && [ "$(ls -A $LIBS_DIR)" ]; then
-  echo "The libsemigroups directory exists and is non-empty"
+  notice_it "The libsemigroups directory exists and is non-empty"
   if [ -f "$LIBS_DIR/.VERSION" ]; then
-    echo "The file libsemigroups/.VERSION is present"
+    notice_it "The file libsemigroups/.VERSION is present"
     INSTALLED=`tr -d '\n' < "$LIBS_DIR/.VERSION"`
   elif [ -f "$LIBS_DIR/etc/version-number.sh" ]; then
-    echo "Getting version number via etc/version-number.sh in libsemigroups"
+    notice_it "Getting version number via etc/version-number.sh in libsemigroups"
     cd "$LIBS_DIR"
     INSTALLED=`etc/version-number.sh`
     cd "$SEMI_DIR"
   else
-    echo "Error, it is not possible to determine the libsemigroups version"
-    exit 2
+    error "Error, it is not possible to determine the libsemigroups version"
   fi
-  echo "The installed version of libsemigroups is v$INSTALLED"
+  notice_it "The installed version of libsemigroups is v$INSTALLED"
   LEAST=`echo -e "$VERS\n$INSTALLED" | sort -V | head -n1`
   if [[ "$VERS" != "$LEAST" ]]; then
-    echo "Error, the installed version of libsemigroups is too old"
-    exit 3
+    error "Error, the installed version of libsemigroups is too old"
   fi
   exit 0
 fi
 
 # Download libsemigroups
-echo  "Downloading libsemigroups v$VERS into $LIBS_DIR..."
+notice_it "Downloading libsemigroups v$VERS into $LIBS_DIR..."
 curl -L -O "https://github.com/libsemigroups/libsemigroups/releases/download/v$VERS/libsemigroups-$VERS.tar.gz"
 tar -xzf "libsemigroups-$VERS.tar.gz" && rm -f "libsemigroups-$VERS.tar.gz" && mv "libsemigroups-$VERS" "$LIBS_DIR"


### PR DESCRIPTION
I noticed that the `.release` script basically contains a duplicate of the `prerequisites.sh` script. As a first step to allowing `.release` to just call `prerequisites.sh` directly, I'm copying across the colours that are used in `.release`.