### PR TITLE
Run `SemigroupsTestInstall` and `TestManualExamples` in the GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           LDFLAGS: "-pthread"
         with:
           GAP_PKGS_TO_CLONE: "${{ matrix.pkgs-to-clone }}"
-          GAP_PKGS_TO_BUILD: "digraphs genss io orb images datastructures profiling"
+          GAP_PKGS_TO_BUILD: "digraphs io orb datastructures profiling"
           GAPBRANCH: ${{ matrix.gap-branch }}
           ABI: ${{ matrix.ABI }}
       - name: "Build Semigroups"
@@ -60,6 +60,10 @@ jobs:
       - name: "Run tst/teststandard.g"
         uses: gap-actions/run-pkg-tests@v2
         with:
+          # This is the test file that is specified in our PackageInfo.g file.
+          # This Action is *supposed* to use that file by default, but this is
+          # not yet implemented, and instead the default is tst/testall.g.
+          # Therefore we temporarily have to specify tst/teststandard.g here.
           GAP_TESTFILE: "tst/teststandard.g"
       - uses: gap-actions/process-coverage@v2
       - uses: codecov/codecov-action@v1

--- a/tst/teststandard.g
+++ b/tst/teststandard.g
@@ -1,14 +1,18 @@
 #############################################################################
 ##
 #W  teststandard.g
-#Y  Copyright (C) 2018                                      Wilf A. Wilson
+#Y  Copyright (C) 2018-21                                   Wilf A. Wilson
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
 #############################################################################
 ##
 LoadPackage("semigroups", false);;
-if SemigroupsTestStandard(rec(suppressStatusMessage := true)) then
+# These "{No} errors detected" lines currently have to be printed in this way
+# to satisfy the automated GAP testing system that runs on Jenkins.
+if SemigroupsTestInstall()
+    and SemigroupsTestStandard(rec(suppressStatusMessage := true))
+    and SEMIGROUPS.TestManualExamples() then
   Print("#I  No errors detected while testing\n\n");
   QUIT_GAP(0);
 else


### PR DESCRIPTION
I hadn't realised that we weren't already doing this.

Also add a comment, don't try to build two packages (genss and images) that can't be built.