### PR TITLE
Copy the matrix argument given to `NewMatrixOverFiniteField`

### DIFF
--- a/gap/elements/ffmat.gi
+++ b/gap/elements/ffmat.gi
@@ -247,7 +247,7 @@ function(filter, field, list)
   fi;
 
   mat := Objectify(PlistMatrixOverFiniteFieldType,
-                   rec(mat := ImmutableMatrix(field, list)));
+                   rec(mat := ImmutableMatrix(field, List(list, ShallowCopy))));
   SetBaseDomain(mat, field);
 
   return mat;

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -1768,6 +1768,12 @@ gap> EquivalenceRelationLookup(S!.cong);
 Error, Semigroups: EquivalenceRelationLookup: usage,
 <cong> must be over a finite semigroup,
 
+# Issue 788
+gap> S := GLM(2, 2);;
+gap> Matrix(GF(4), One(S));;
+gap> Size(Elements(S));
+16
+
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(B);
 gap> Unbind(D);


### PR DESCRIPTION
`ImmutableMatrix` is a GAP function that can change its argument in place, even if it is given an immutable argument. In particular, `ImmutableMatrix` can change the representation of the matrix that it is given.

For us, this is dangerous since matrices in different representations are considered to be *not* equal in GAP, and they cannot in general be multiplied. Therefore, if a matrix that belongs to a semigroup has its representation changed in-place, then multiplication and equality testing no longer necessarily work correctly in that semigroup. This is what led to the issue in #788, where a semigroup of size 16 had 17 elements, because it had two copies of its identity in different representations.

An even safer version would be to change the line to:
```
  mat := Objectify(PlistMatrixOverFiniteFieldType,
                   rec(mat := MakeImmutable(List(list, ShallowCopy))));
```
i.e. to bypass `ImmutableMatrix` entirely.