### PR TITLE
Avoid using SIZEOF_VOID_P

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -67,11 +67,6 @@ case $host_os in
          * ) CYGWIN=no;;
 esac
 AM_CONDITIONAL([SYS_IS_CYGWIN], [test "$CYGWIN" = "yes"])
-if test "$CYGWIN" = "yes"; then
-  AC_DEFINE(SYS_IS_CYGWIN32, 1, are we on CYGWIN?)
-else
-  AC_DEFINE(SYS_IS_CYGWIN32, 0, are we on CYGWIN?)
-fi
 
 dnl ## Check for libsemigroups
 AX_CHECK_LIBSEMIGROUPS

--- a/src/pkg.cc
+++ b/src/pkg.cc
@@ -38,12 +38,6 @@
 
 using libsemigroups::Congruence;
 
-#if !defined(SIZEOF_VOID_P)
-#error Something is wrong with this GAP installation: SIZEOF_VOID_P not defined
-#elif SIZEOF_VOID_P == 4
-#define SYSTEM_IS_32_BIT
-#endif
-
 Obj SEMIGROUPS;
 
 Obj TheTypeTSemiObj;
@@ -179,7 +173,7 @@ void TSemiObjLoadFunc(Obj o) {
       en_semi_t s_type = static_cast<en_semi_t>(LoadUInt4());
       ADDR_OBJ(o)[1]   = reinterpret_cast<Obj>(s_type);
       if (s_type != UNKNOWN) {
-        SEMIGROUPS_ASSERT(SIZE_OBJ(o) == 6 * SIZEOF_VOID_P);
+        SEMIGROUPS_ASSERT(SIZE_OBJ(o) == 6 * sizeof(void *));
         ADDR_OBJ(o)[2] = LoadSubObj();                        // semigroup Obj
         ADDR_OBJ(o)[3] = reinterpret_cast<Obj>(LoadUInt4());  // degree
         ADDR_OBJ(o)[4] = static_cast<Obj>(nullptr);           // Converter*


### PR DESCRIPTION
This allows future GAP versions to drop it (although 4.12 definitely will support it). As far as I could tell, `SYSTEM_IS_32_BIT` is not used anywhere, so I just removed it. Likewise, `SYS_IS_CYGWIN32` was unused, so I also removed it while at it.