### PR TITLE
stable 3.4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ dnl ##
 AC_PREREQ([2.68])
 AC_INIT([semigroups], m4_esyscmd([tr -d '\n' < .VERSION]))
 AC_CONFIG_SRCDIR([src/pkg.cc])
-AC_CONFIG_HEADER([src/_pkgconfig.h:cnf/pkgconfig.h.in])
+AC_CONFIG_HEADERS([src/_pkgconfig.h:cnf/pkgconfig.h.in])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([cnf])
 

--- a/m4/ax_check_libsemigroup.m4
+++ b/m4/ax_check_libsemigroup.m4
@@ -6,7 +6,7 @@ dnl otherwise use the included version
 dnl
 AC_DEFUN([AX_CHECK_LIBSEMIGROUPS], [
   AC_ARG_WITH([external-libsemigroups],
-	      [AC_HELP_STRING([--with-external-libsemigroups],
+	      [AS_HELP_STRING([--with-external-libsemigroups],
 			      [use the external libsemigroups])])
   REQUI_LIBSEMIGROUPS_VERSION="$(cat .LIBSEMIGROUPS_VERSION)"
   need_included_libsemigroups=yes


### PR DESCRIPTION
- prerequisites.sh: do not create libsemigroups/.VERSION
- Only declare DirectProductOp/SmallGeneratingSet when required
- isomorph.tst: suppress Digraphs output
- GitHub Actions: set env var LDFLAGS="-pthreads"
- Make compilation of manuals more robust
- Update the .release script
- Add new GitHub Actions job to compile/upload manual
- GitHub Actions: consolidate linting jobs into one file
- Update GitHub Actions CI
- Add macOS and 32-bit Ubuntu GitHub Actions jobs
- CI: force cpplint-1.5.4 (not 1.5.5)
- Add colours to the prerequisites.sh script
- Update CHANGELOG
- Update the .release script
- Fix warnings from cpplint-1.5.5
- ci: revert to latest version of cpplint
- Update .github/workflows/lint.yml
- GitHub Actions: run testinstall and man. examples
- Copy the matrix arg in NewMatrixOverFiniteField
- mh/autoconf-warnings
