### PR TITLE
Stop using obsolete autoconf macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ dnl ##
 AC_PREREQ([2.68])
 AC_INIT([semigroups], m4_esyscmd([tr -d '\n' < .VERSION]))
 AC_CONFIG_SRCDIR([src/pkg.cc])
-AC_CONFIG_HEADER([src/_pkgconfig.h:cnf/pkgconfig.h.in])
+AC_CONFIG_HEADERS([src/_pkgconfig.h:cnf/pkgconfig.h.in])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([cnf])
 

--- a/m4/ax_check_libsemigroup.m4
+++ b/m4/ax_check_libsemigroup.m4
@@ -6,7 +6,7 @@ dnl otherwise use the included version
 dnl
 AC_DEFUN([AX_CHECK_LIBSEMIGROUPS], [
   AC_ARG_WITH([external-libsemigroups],
-	      [AC_HELP_STRING([--with-external-libsemigroups],
+	      [AS_HELP_STRING([--with-external-libsemigroups],
 			      [use the external libsemigroups])])
   REQUI_LIBSEMIGROUPS_VERSION="$(cat .LIBSEMIGROUPS_VERSION)"
   need_included_libsemigroups=yes

--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -294,7 +294,7 @@ if test "x$ax_pthread_clang" = "xyes"; then
              # step
              ax_pthread_save_ac_link="$ac_link"
              ax_pthread_sed='s/conftest\.\$ac_ext/conftest.$ac_objext/g'
-             ax_pthread_link_step=`$as_echo "$ac_link" | sed "$ax_pthread_sed"`
+             ax_pthread_link_step=`AS_ECHO(["$ac_link"]) | sed "$ax_pthread_sed"`
              ax_pthread_2step_ac_link="($ac_compile) && (echo ==== >&5) && ($ax_pthread_link_step)"
              ax_pthread_save_CFLAGS="$CFLAGS"
              for ax_pthread_try in '' -Qunused-arguments -Wno-unused-command-line-argument unknown; do


### PR DESCRIPTION
This stops newer autoconf versions from complaining about them