### PR TITLE
Avoid using `SIZEOF_VOID_P`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -67,11 +67,6 @@ case $host_os in
          * ) CYGWIN=no;;
 esac
 AM_CONDITIONAL([SYS_IS_CYGWIN], [test "$CYGWIN" = "yes"])
-if test "$CYGWIN" = "yes"; then
-  AC_DEFINE(SYS_IS_CYGWIN32, 1, are we on CYGWIN?)
-else
-  AC_DEFINE(SYS_IS_CYGWIN32, 0, are we on CYGWIN?)
-fi
 
 dnl ## Check for libsemigroups
 AX_CHECK_LIBSEMIGROUPS

--- a/src/pkg.cpp
+++ b/src/pkg.cpp
@@ -124,12 +124,6 @@ GAPBIND14_MODULE(libsemigroups, m) {
 ////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////
 
-#if !defined(SIZEOF_VOID_P)
-#error Something is wrong with this GAP installation: SIZEOF_VOID_P not defined
-#elif SIZEOF_VOID_P == 4
-#define SYSTEM_IS_32_BIT
-#endif
-
 Obj SEMIGROUPS;
 
 Obj TheTypeTBlocksObj;


### PR DESCRIPTION
[This was added to `stable-3.4` in #790 but didn't make its way into 4.0.0].

From @fingolfin's commit:

> This allows future GAP versions to drop it (although 4.12 definitely will support it). As far as I could tell, `SYS_IS_CYGWIN32` was unused, so I removed it while at it.