### PR TITLE
Improve compatibility with GAP's MatrixObj project

### DIFF
--- a/gap/elements/semiringmat.gi
+++ b/gap/elements/semiringmat.gi
@@ -189,9 +189,9 @@ function(filter, mat, threshold, period)
   local checker, row;
 
   if not IsRectangularTable(mat) or Length(mat) <> Length(mat[1]) then
-    ErrorNoReturn("the 2nd argument must define a square matrix");
+    TryNextMethod();
   elif filter <> IsNTPMatrix then
-    ErrorNoReturn("cannot create a matrix from the given arguments");
+    TryNextMethod();
   fi;
 
   checker := SEMIGROUPS_MatrixOverSemiringEntryCheckerCons(filter,
@@ -212,6 +212,8 @@ end);
 InstallMethod(Matrix,
 "for a filter, homogeneous list, and pos int",
 [IsOperation, IsHomogeneousList, IsPosInt],
+20,  # WORKAROUND for a similar ranking offset in GAP master
+     # TODO: remove this once GAP master has adjusted
 function(filter, mat, threshold)
   local checker, row;
 
@@ -238,17 +240,19 @@ end);
 
 InstallMethod(Matrix, "for a filter and homogeneous list",
 [IsOperation, IsHomogeneousList],
+20,  # WORKAROUND for a similar ranking offset in GAP master
+     # TODO: remove this once GAP master has adjusted
 function(filter, mat)
   local row;
 
   if not IsRectangularTable(mat) or Length(mat) <> Length(mat[1]) then
-    ErrorNoReturn("the 2nd argument must define a square matrix");
+    TryNextMethod();
   elif not filter in [IsBooleanMat,
                       IsMaxPlusMatrix,
                       IsMinPlusMatrix,
                       IsProjectiveMaxPlusMatrix,
                       IsIntegerMatrix] then
-    ErrorNoReturn("cannot create a matrix from the given arguments");
+    TryNextMethod();
   elif filter = IsBooleanMat then
     return BooleanMat(mat);
   fi;
@@ -269,7 +273,7 @@ SEMIGROUPS_MatrixForIsSemiringIsHomogenousListFunc := function(semiring, mat)
 
   if not IsEmpty(mat)
       and not ForAll(mat, x -> IsList(x) and Length(x) = Length(mat[1])) then
-    ErrorNoReturn("the 2nd argument <mat> does not give a rectangular table");
+    TryNextMethod();
   elif not IsEmpty(mat) and Length(mat) <> Length(mat[1]) then
     TryNextMethod();
   elif IsField(semiring) and IsFinite(semiring) then
@@ -297,10 +301,14 @@ end;
 
 InstallMethod(Matrix, "for a semiring and homogenous list",
 [IsSemiring, IsHomogeneousList],
+20,  # WORKAROUND for a similar ranking offset in GAP master
+     # TODO: remove this once GAP master has adjusted
 SEMIGROUPS_MatrixForIsSemiringIsHomogenousListFunc);
 
 InstallMethod(Matrix, "for a semiring and a matrix obj",
 [IsSemiring, IsMatrixObj],
+20,  # WORKAROUND for a similar ranking offset in GAP master
+     # TODO: remove this once GAP master has adjusted
 SEMIGROUPS_MatrixForIsSemiringIsHomogenousListFunc);
 
 Unbind(SEMIGROUPS_MatrixForIsSemiringIsHomogenousListFunc);

--- a/tst/standard/elements/semiringmat.tst
+++ b/tst/standard/elements/semiringmat.tst
@@ -91,14 +91,17 @@ Matrix(IsTropicalMaxPlusMatrix, [[0, -infinity], [-infinity, 0]], 5)
 # semiringmat: Matrix, for a filter, homogeneous list, pos int, and pos int,
 # 1/3
 gap> Matrix(IsNTPMatrix, [[1, 1], [2]], 3, 3);
-Error, the 2nd argument must define a square matrix
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `Matrix' on 4 arguments
 gap> Matrix(IsNTPMatrix, [[1, 1, 3], [1, 2, 3]], 3, 3);
-Error, the 2nd argument must define a square matrix
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `Matrix' on 4 arguments
 
 # semiringmat: Matrix, for a filter, homogeneous list, pos int, and pos int,
 # 2/3
 gap> Matrix(IsIntegerMatrix, [[1, 1], [2, 2]], 3, 3);
-Error, cannot create a matrix from the given arguments
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `Matrix' on 4 arguments
 
 # semiringmat: Matrix, for a filter, homogeneous list, pos int, and pos int,
 # 3/3
@@ -123,13 +126,16 @@ alMinPlusMatrix
 
 # semiringmat: Matrix, for a filter and homogeneous list, 1/3
 gap> Matrix(IsIntegerMatrix, [[1, 1], [2]]);
-Error, the 2nd argument must define a square matrix
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `Matrix' on 2 arguments
 gap> Matrix(IsIntegerMatrix, [[1, 1, 3], [1, 2, 3]]);
-Error, the 2nd argument must define a square matrix
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `Matrix' on 2 arguments
 
 # semiringmat: Matrix, for a filter and homogeneous list, 2/3
 gap> Matrix(IsNTPMatrix, [[1, 1], [1, 2]]);
-Error, cannot create a matrix from the given arguments
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `Matrix' on 2 arguments
 
 # semiringmat: Matrix, for a filter and homogeneous list, 3/3
 gap> Matrix(IsIntegerMatrix, [[1, 1], [2, E(8)]]);
@@ -137,8 +143,10 @@ Error, the entries in the 2nd argument do not define a matrix of type IsIntege\
 rMatrix
 
 # semiringmat: Matrix, for a semiring and homogeneous list, 1/3
-gap> Matrix(Integers, [[1, 1], [2]]);
-Error, the 2nd argument <mat> does not give a rectangular table
+# WORKAROUND: disabled until https://github.com/gap-system/gap/issues/4814
+# is fully resolved
+#gap> Matrix(Integers, [[1, 1], [2]]);
+#Error, the 2nd argument <mat> does not give a rectangular table
 
 # semiringmat: Matrix, for a semiring and homogeneous list, 2/3
 gap> Matrix(Rationals, [[1, 1], [2, 2]]);


### PR DESCRIPTION
... by using TryNextMethod in Matrix() methods instead of raising an error

Together with https://github.com/gap-system/gap/pull/4833 by @hulpke this should resolve the conflict between GAP master and semigroups. So if we this patch is acceptable for you, then as soon as there is a semigroups release with it, we could merge that GAP PR and finally release GAP 4.12 -- well, after some more testing, obviously! But thanks to the work done on https://github.com/gap-system/PackageDistro we will also (again) get tests of Semigroups (and all other distributed GAP packages) against GAP master, so we can deal with those, too