### PR TITLE
Remove spurious dependency on libgmp

### DIFF
--- a/gapbind14/include/gapbind14/gap_include.hpp
+++ b/gapbind14/include/gapbind14/gap_include.hpp
@@ -25,8 +25,6 @@
 #ifndef INCLUDE_GAPBIND14_GAP_INCLUDE_HPP_
 #define INCLUDE_GAPBIND14_GAP_INCLUDE_HPP_
 
-#include <gmp.h>
-
 extern "C" {
 #include "compiled.h"
 }


### PR DESCRIPTION
There is no reason to include gmp.h here. This makes compiling Semigroups a tad easier for e.g. people who have GMP installed via Homebrew on an M1 mac (e.g. me :-) ) where this is not found without adding the right compiler flags manually to CPPFLAGS