### PR TITLE
Use ccache to speed up CI builds (and don't use `-march=native` by default)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
       - name: "Install dependencies"
         if: ${{ runner.os == 'macOS' }}
         run: brew install automake
+      # Setup ccache, to speed up repeated compilation of the same binaries
+      # (i.e., GAP and the packages)
+      - name: "Setup ccache"
+        uses: Chocobo1/setup-ccache-action@v1
+        with:
+          update_packager_index: false
       - name: "Install GAP and clone/compile necessary packages"
         uses: gap-actions/setup-gap@v2
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         uses: gap-actions/build-pkg@v1
         with:
           ABI: ${{ matrix.ABI }}
+          CONFIGFLAGS: --disable-hpcombi
       - name: "Run tst/teststandard.g"
         uses: gap-actions/run-pkg-tests@v2
         with:

--- a/configure.ac
+++ b/configure.ac
@@ -82,17 +82,6 @@ AC_MSG_RESULT([$enable_debug])
 
 AM_CONDITIONAL([KERNEL_DEBUG], [test "x$enable_debug" = xyes])
 
-AC_ARG_WITH([march-native],
-            [AS_HELP_STRING([--without-march-native], 
-                            [do not use compile flag -march=native even if available])]
-           )
-
-AS_IF([test "x$with_march_native" == "xno" ],
-      [AC_MSG_NOTICE([the compile flag -march=native will not be used even if available])])
-
-AS_IF([test "x$with_march_native" != "xno"],
-      [AX_CHECK_COMPILE_FLAG(-march=native, AX_APPEND_FLAG(-march=native))])
-
 # Check if HPCombi is enable, and available
 AX_CHECK_HPCOMBI()
 

--- a/m4/ax_check_hpcombi.m4
+++ b/m4/ax_check_hpcombi.m4
@@ -6,11 +6,11 @@ dnl to handle the other checks as to whether or not HPCombi can be used.
 AC_DEFUN([AX_CHECK_HPCOMBI], [
   m4_define([ax_hpcombi_cxxflags_variable],[HPCOMBI_CXXFLAGS])
 
-  dnl # Check if the flags required for HPCombi are supported 
-  AX_CHECK_COMPILE_FLAG(-march=native, 
-                        AX_APPEND_FLAG(-march=native,
+  dnl # Check if the flags required for HPCombi are supported
+  AX_CHECK_COMPILE_FLAG(-march=avx,
+                        AX_APPEND_FLAG(-march=avx,
                                        [ax_hpcombi_cxxflags_variable]),
-                        [AC_MSG_WARN([flag -march=native not supported])
+                        [AC_MSG_WARN([flag -march=avx not supported])
                          enable_hpcombi=no])
 
   AX_CHECK_COMPILE_FLAG(-flax-vector-conversions, 

--- a/m4/ax_check_hpcombi.m4
+++ b/m4/ax_check_hpcombi.m4
@@ -3,7 +3,8 @@ dnl The basic idea is that we only check here for the things that we need to
 dnl set if HPCombi is enable/disabled, and we leave it up to libsemigroups itself 
 dnl to handle the other checks as to whether or not HPCombi can be used.
 
-AC_DEFUN([AX_CHECK_HPCOMBI], [
+AC_DEFUN([AX_CHECK_HPCOMBI],
+ [AS_IF([test "x$enable_hpcombi" != xno], [
   m4_define([ax_hpcombi_cxxflags_variable],[HPCOMBI_CXXFLAGS])
 
   dnl # Check if the flags required for HPCombi are supported
@@ -31,6 +32,7 @@ AC_DEFUN([AX_CHECK_HPCOMBI], [
                      [hpcombi_constexpr_fun_args=no]
                    )
   AC_MSG_RESULT([$hpcombi_constexpr_fun_args])
+ ])
 
   AM_CONDITIONAL([HPCOMBI_CONSTEXPR_FUN_ARGS], 
                  [test "x$hpcombi_constexpr_fun_args" = xyes])


### PR DESCRIPTION
I noticed that the GitHub Actions CI jobs spend ~50% of their time (e.g. 6 minutes out of 12) compiling C/C++ code. This patch attempts to reduce that by combining the GH Actions caching feature with https://ccache.dev to reduce the compiler overhead to just a few seconds for most builds -- only builds were the C++ sources actually changed would take longer.

However this feature does not mesh well with `-march=native`, which anyway causes other problems e.g. for distro packagers. I've thus also removed this from the default FLAGS. If you think this goes to far, one could also try to modify `.github/workflows/ci.yml` to build w/o `-march=native`.


Note that the performance benefit (if any) of course only shows up once the caches are primed.