### PR TITLE
Fix matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         os:
           - ubuntu
         gap-branch:
+          - master
           - stable-4.11
         ABI:
           - 64
@@ -31,7 +32,7 @@ jobs:
             os: ubuntu
             ABI: 64
           # macOS job
-          - gap-branch: stable-4.11
+          - gap-branch: master
             # to ensure datastructures>= v0.2.6
             pkgs-to-clone: "datastructures"
             os: macos

--- a/gap/elements/semiringmat.gi
+++ b/gap/elements/semiringmat.gi
@@ -212,8 +212,6 @@ end);
 InstallMethod(Matrix,
 "for a filter, homogeneous list, and pos int",
 [IsOperation, IsHomogeneousList, IsPosInt],
-20,  # WORKAROUND for a similar ranking offset in GAP master
-     # TODO: remove this once GAP master has adjusted
 function(filter, mat, threshold)
   local checker, row;
 
@@ -240,8 +238,6 @@ end);
 
 InstallMethod(Matrix, "for a filter and homogeneous list",
 [IsOperation, IsHomogeneousList],
-20,  # WORKAROUND for a similar ranking offset in GAP master
-     # TODO: remove this once GAP master has adjusted
 function(filter, mat)
   local row;
 
@@ -301,14 +297,10 @@ end;
 
 InstallMethod(Matrix, "for a semiring and homogenous list",
 [IsSemiring, IsHomogeneousList],
-20,  # WORKAROUND for a similar ranking offset in GAP master
-     # TODO: remove this once GAP master has adjusted
 SEMIGROUPS_MatrixForIsSemiringIsHomogenousListFunc);
 
 InstallMethod(Matrix, "for a semiring and a matrix obj",
 [IsSemiring, IsMatrixObj],
-20,  # WORKAROUND for a similar ranking offset in GAP master
-     # TODO: remove this once GAP master has adjusted
 SEMIGROUPS_MatrixForIsSemiringIsHomogenousListFunc);
 
 Unbind(SEMIGROUPS_MatrixForIsSemiringIsHomogenousListFunc);


### PR DESCRIPTION
This PR reenables testing against GAP master, and removes the upranking of methods in `elements/semiringmat.gi` introduced in c03fe2f5. Related to the discussion:

https://github.com/gap-system/gap/issues/4878