### PR TITLE
conglatt: fix ordering issue

### DIFF
--- a/doc/conglatt.xml
+++ b/doc/conglatt.xml
@@ -193,13 +193,13 @@ gap> CongruencesOfPoset(latt);
 [ <right semigroup congruence over <regular transformation monoid 
      of size 3, degree 2 with 2 generators> with 0 generating pairs>, 
   <right semigroup congruence over <regular transformation monoid 
-     of size 3, degree 2 with 2 generators> with 1 generating pairs>, 
+     of size 3, degree 2 with 2 generators> with 2 generating pairs>, 
   <right semigroup congruence over <regular transformation monoid 
      of size 3, degree 2 with 2 generators> with 1 generating pairs>, 
   <right semigroup congruence over <regular transformation monoid 
      of size 3, degree 2 with 2 generators> with 1 generating pairs>, 
   <right semigroup congruence over <regular transformation monoid 
-     of size 3, degree 2 with 2 generators> with 2 generating pairs> ]
+     of size 3, degree 2 with 2 generators> with 1 generating pairs> ]
 ]]></Example>
     </Description>
   </ManSection>

--- a/gap/congruences/conglatt.gi
+++ b/gap/congruences/conglatt.gi
@@ -300,7 +300,8 @@ function(gen_congs, WrappedXCongruence)
   poset := DigraphReflexiveTransitiveClosure(PartialOrderOfDClasses(S));
   Info(InfoSemigroups, 1, StringFormatted("Found {} congruences in total!",
        Size(S)));
-  all_congs := List(AsList(S), x -> x![1]);
+  all_congs := List(DClasses(S), x -> Representative(x)![1]);
+
   SetCongruencesOfPoset(poset, all_congs);
   SetDigraphVertexLabels(poset, all_congs);
   SetUnderlyingSemigroupOfCongruencePoset(poset, U);

--- a/tst/standard/congruences/conglatt.tst
+++ b/tst/standard/congruences/conglatt.tst
@@ -353,17 +353,17 @@ gap> Print(l, "\n");
 PosetOfCongruences( 
 [ RightSemigroupCongruence( InverseMonoid( 
     [ PartialPerm( [ 1, 2 ], [ 2, 1 ] ), PartialPerm( [ 1 ], [ 1 ] ) ] ), 
-    [ [ PartialPerm( [ 1 ], [ 1 ] ), PartialPerm( [ 2 ], [ 1 ] ) ] ] ), 
-  RightSemigroupCongruence( InverseMonoid( 
-    [ PartialPerm( [ 1, 2 ], [ 2, 1 ] ), PartialPerm( [ 1 ], [ 1 ] ) ] ), 
-    [ [ PartialPerm( [ 1 ], [ 1 ] ), PartialPerm( [ 1, 2 ], [ 1, 2 ] ) ] ] ), 
+    [ [ PartialPerm( [ 1 ], [ 1 ] ), PartialPerm( [ 2 ], [ 1 ] ) ], 
+      [ PartialPerm( [ 1 ], [ 1 ] ), PartialPerm( [ 1, 2 ], [ 1, 2 ] ) ] ] ), 
   RightSemigroupCongruence( InverseMonoid( 
     [ PartialPerm( [ 1, 2 ], [ 2, 1 ] ), PartialPerm( [ 1 ], [ 1 ] ) ] ), 
     [ [ PartialPerm( [ 1, 2 ], [ 1, 2 ] ), PartialPerm( [ 1, 2 ], [ 2, 1 ] ) 
          ] ] ), RightSemigroupCongruence( InverseMonoid( 
     [ PartialPerm( [ 1, 2 ], [ 2, 1 ] ), PartialPerm( [ 1 ], [ 1 ] ) ] ), 
-    [ [ PartialPerm( [ 1 ], [ 1 ] ), PartialPerm( [ 2 ], [ 1 ] ) ], 
-      [ PartialPerm( [ 1 ], [ 1 ] ), PartialPerm( [ 1, 2 ], [ 1, 2 ] ) ] ] ) 
+    [ [ PartialPerm( [ 1 ], [ 1 ] ), PartialPerm( [ 2 ], [ 1 ] ) ] ] ), 
+  RightSemigroupCongruence( InverseMonoid( 
+    [ PartialPerm( [ 1, 2 ], [ 2, 1 ] ), PartialPerm( [ 1 ], [ 1 ] ) ] ), 
+    [ [ PartialPerm( [ 1 ], [ 1 ] ), PartialPerm( [ 1, 2 ], [ 1, 2 ] ) ] ] ) 
  ] )
 gap> MinimalCongruences(poset);
 [ <2-sided semigroup congruence over <symmetric inverse monoid of degree 2> wi\
@@ -405,6 +405,16 @@ gap> IsIsomorphicDigraph(l, DigraphByInNeighbours(
 > [[1], [1, 2], [1, 3], [1, 4], [1, 2, 3, 4, 5, 6],
 > [1, 2, 3, 4, 6]]));
 true
+
+# Test for correct ordering of congruences and lattice nodes
+gap> S := InverseSemigroup(PartialPerm([1, 3], [2, 4]),
+>                          PartialPerm([1], [1]));;
+gap> D := DigraphReflexiveTransitiveReduction(LatticeOfRightCongruences(S));
+<immutable digraph with 22 vertices, 49 edges>
+gap> x := DigraphSinks(D)[1];
+2
+gap> NrEquivalenceClasses(RightCongruencesOfSemigroup(S)[x]);
+1
 
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(S);


### PR DESCRIPTION
This PR fixes an issue relating to the ordering of congruences in `CongruencesOfSemigroup` and in the nodes of the associated `LatticeOfCongruences`, before this change (and after v4.0.0) they didn't agree:

~~~
gap> S := InverseSemigroup(PartialPerm([1, 3], [2, 4]),
>                          PartialPerm([1], [1]));;
gap> D := DigraphReflexiveTransitiveReduction(LatticeOfRightCongruences(S));
<immutable digraph with 22 vertices, 49 edges>
gap> S := InverseSemigroup(PartialPerm([1, 3], [2, 4]),
>                          PartialPerm([1], [1]));;
gap> D := DigraphReflexiveTransitiveReduction(LatticeOfRightCongruences(S));
<immutable digraph with 22 vertices, 49 edges>
gap> x := DigraphSinks(D)[1];
2
gap> NrEquivalenceClasses(RightCongruencesOfSemigroup(S)[x]);
7
~~~
when the correct value should be 1 (for the universal congruence).