### PR TITLE
semipperm: resolve issue 817

### DIFF
--- a/doc/attrinv.xml
+++ b/doc/attrinv.xml
@@ -458,7 +458,7 @@ gap> T := Range(IsomorphismPartialPermSemigroup(S));
  generators>
 gap> SmallerDegreePartialPermRepresentation(T);
 MappingByFunction( <inverse partial perm monoid of size 6721, 
- rank 6721 with 3 generators>, <inverse partial perm semigroup of 
+ rank 6721 with 3 generators>, <inverse partial perm monoid of 
  rank 30 with 3 generators>
  , function( x ) ... end, function( x ) ... end )]]></Example>
 <#/GAPDoc>

--- a/gap/semigroups/semipperm.gi
+++ b/gap/semigroups/semipperm.gi
@@ -242,7 +242,7 @@ function(S)
   sigmainv, enum, orbits, cosets, stabpp, psi, rho, rhoinv, stab, nrcosets, j,
   reps, gen, offset, rep, box, subbox, T, map, inv, d, k, i, m;
 
-  oldgens := Generators(S);
+  oldgens := GeneratorsOfSemigroup(S);
   newgens := List(oldgens, x -> []);
   D := JoinIrreducibleDClasses(S);
 
@@ -330,8 +330,8 @@ function(S)
       od;
     od;
   od;
-
-  T := InverseSemigroup(List(newgens, x -> PartialPermNC(x)));
+  Apply(newgens, PartialPermNC);
+  T := InverseSemigroup(newgens);
 
   # Return identity mapping if nothing has been accomplished; else the result.
   if NrMovedPoints(T) > NrMovedPoints(S)
@@ -340,8 +340,8 @@ function(S)
     return IdentityMapping(S);
   fi;
 
-  map := x -> EvaluateWord(GeneratorsOfSemigroup(T), Factorization(S, x));
-  inv := x -> EvaluateWord(GeneratorsOfSemigroup(S), Factorization(T, x));
+  map := x -> EvaluateWord(newgens, Factorization(S, x));
+  inv := x -> EvaluateWord(oldgens, Factorization(T, x));
 
   return MagmaIsomorphismByFunctionsNC(S, T, map, inv);
 end);

--- a/tst/standard/semigroups/semipperm.tst
+++ b/tst/standard/semigroups/semipperm.tst
@@ -2086,7 +2086,7 @@ gap> S := Semigroup(S, rec(acting := false));
 <partial perm monoid of rank 25 with 3 generators>
 gap> SmallerDegreePartialPermRepresentation(S);
 MappingByFunction( <inverse partial perm monoid of size 25, rank 25 with 3 
- generators>, <inverse partial perm semigroup of rank 6 with 3 generators>
+ generators>, <inverse partial perm monoid of rank 6 with 3 generators>
  , function( x ) ... end, function( x ) ... end )
 
 #  GeneratorsOfGroup
@@ -2140,13 +2140,33 @@ gap> S := UniformBlockBijectionMonoid(4);
 <inverse block bijection monoid of degree 4 with 3 generators>
 gap> map := SmallerDegreePartialPermRepresentation(S);
 CompositionMapping( MappingByFunction( <inverse partial perm monoid 
- of size 131, rank 131 with 3 generators>, <inverse partial perm semigroup of 
+ of size 131, rank 131 with 3 generators>, <inverse partial perm monoid of 
  rank 10 with 3 generators>, function( x ) ... end, function( x ) ... end ),
  MappingByFunction( <inverse block bijection monoid of size 131, degree 4 
  with 3 generators>, <inverse partial perm monoid of size 131, rank 131 with 
  3 generators>, function( x ) ... end ) )
 gap> S.1 ^ map in Range(map);
 true
+
+# Issue 817
+gap> S := DualSymmetricInverseMonoid(4);
+<inverse block bijection monoid of degree 4 with 3 generators>
+gap> C := SemigroupCongruence(S,
+> [Bipartition([[1, 2, 3, 4, -1, -2, -3, -4]]),
+>  Bipartition([[1, -1], [2, -2], [3, -3], [4, -4]])]);
+<2-sided semigroup congruence over <inverse block bijection monoid 
+ of size 339, degree 4 with 3 generators> with 1 generating pairs>
+gap> map := SmallerDegreePartialPermRepresentation(Source(C));
+CompositionMapping( MappingByFunction( <inverse partial perm monoid 
+ of size 339, rank 339 with 3 generators>, <inverse partial perm monoid of 
+ rank 14 with 3 generators>, function( x ) ... end, function( x ) ... end ),
+ MappingByFunction( <inverse block bijection monoid of size 339, degree 4 
+ with 3 generators>, <inverse partial perm monoid of size 339, rank 339 with 
+ 3 generators>, function( x ) ... end ) )
+gap> List(GeneratingPairsOfSemigroupCongruence(C), x -> OnTuples(x, map));
+[ [ <empty partial perm>, 
+      <identity partial perm on 
+        [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 ]> ] ]
 
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(F);


### PR DESCRIPTION
The issue seems to have been caused by there being mismatch in the
generators used in `SmallerDegreePartialPermRepresentation`, so that
`Factorization` used too large indices