### PR TITLE
Fix gapbind14/demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@
 .libs
 /libsemigroups/
 Makefile
-Makefile.in
+/Makefile.in
 Transitions*
 _*.xml
 _AutoDocMainFile.xml
@@ -51,7 +51,7 @@ bin
 cnf
 config.log
 config.status
-configure
+/configure
 doc/*.css
 doc/*.js
 doc/main.aux

--- a/gapbind14/demo/.gitignore
+++ b/gapbind14/demo/.gitignore
@@ -1,0 +1,1 @@
+src/gapbind14.cc

--- a/gapbind14/demo/Makefile.gappkg
+++ b/gapbind14/demo/Makefile.gappkg
@@ -44,17 +44,25 @@ include $(GAPPATH)/sysinfo.gap
 ifndef GAP_KERNEL_MAJOR_VERSION
   KEXT_CFLAGS += -I$(GAP_LIB_DIR)/src
   KEXT_CXXFLAGS += -I$(GAP_LIB_DIR)/src
-  KEXT_CXXFLAGS += -I$(GAP_LIB_DIR)/pkg/semigroups/gapbind14/include
 endif
-KEXT_CXXFLAGS += -I../include
-KEXT_CXXFLAGS += -std=gnu++14
+
+# honor used supplied flags
+KEXT_CFLAGS += $(CPPFLAGS)
+KEXT_CFLAGS += $(CFLAGS)
+KEXT_CXXFLAGS += $(CPPFLAGS)
+KEXT_CXXFLAGS += $(CXXFLAGS)
+KEXT_LDFLAGS += $(LDFLAGS)
 
 # various derived settings
 KEXT_BINARCHDIR = bin/$(GAParch)
 KEXT_SO = $(KEXT_BINARCHDIR)/$(KEXT_NAME).so
 
+# the following settings are provided by sysinfo.gap in GAP >= 4.12;
+# for compatibility with older GAP version (at least 4.9, 4.10, 4.11)
+# we try to "guess" suitable values here
 GAP ?= $(GAPPATH)/gap
 GAC ?= $(GAPPATH)/gac
+GAP_OBJEXT ?= lo
 
 # override KEXT_RECONF if your package needs a different invocation
 # for reconfiguring (e.g. `./config.status --recheck` for autoconf)
@@ -70,14 +78,13 @@ all: $(KEXT_SO)
 
 ########################################################################
 # Object files
-# For each file FOO.c in SOURCES, add gen/FOO.lo to KEXT_OBJS; similar
-# for .cc files
+# For each file FOO.c in SOURCES, add gen/FOO.$(GAP_OBJEXT) to KEXT_OBJS
+# and similar for .cc files
 ########################################################################
-KEXT_OBJS = $(patsubst %.s,gen/%.lo, \
-            $(patsubst %.cc,gen/%.lo, \
-            $(patsubst %.cpp,gen/%.lo, \
-            $(patsubst %.c,gen/%.lo, \
-                $(KEXT_SOURCES)))))
+KEXT_OBJS = $(patsubst %.s,gen/%.$(GAP_OBJEXT), \
+            $(patsubst %.cc,gen/%.$(GAP_OBJEXT), \
+            $(patsubst %.c,gen/%.$(GAP_OBJEXT), \
+                $(KEXT_SOURCES))))
 
 ########################################################################
 # Quiet rules.
@@ -87,7 +94,7 @@ KEXT_OBJS = $(patsubst %.s,gen/%.lo, \
 ########################################################################
 ifneq ($(findstring $(MAKEFLAGS),s),s)
 ifndef V
-QUIET_GAC     = @echo "   GAC     $< => $@";
+QUIET_GAC     = @echo "   GAC     $< => $@";>/dev/null # keep the trailing space!
 endif
 endif
 
@@ -97,7 +104,7 @@ endif
 ########################################################################
 
 # List of all (potential) dependency files, derived from KEXT_OBJS
-KEXT_DEPFILES = $(patsubst %.lo,%.d,$(KEXT_OBJS))
+KEXT_DEPFILES = $(patsubst %.$(GAP_OBJEXT),%.d,$(KEXT_OBJS))
 
 # Include the dependency tracking files
 -include $(KEXT_DEPFILES)
@@ -114,30 +121,26 @@ KEXT_DEPFLAGS = -MQ "$@" -MMD -MP -MF $(@D)/$(*F).d
 
 # build rule for C code
 # The dependency on Makefile ensures that re-running configure recompiles everything
-gen/%.lo: %.c Makefile
+gen/%.$(GAP_OBJEXT): %.c Makefile
 	@mkdir -p $(@D)
-	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CFLAGS)" -p "$(CFLAGS)" -c $< -o $@
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CFLAGS)" -c $< -o $@
 
 # build rule for C++ code
 # The dependency on Makefile ensures that re-running configure recompiles everything
-gen/%.lo: %.cc Makefile
+gen/%.$(GAP_OBJEXT): %.cc Makefile
 	@mkdir -p $(@D)
-	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CXXFLAGS)" -p "$(CXXFLAGS)" -c $< -o $@
-
-gen/%.lo: %.cpp Makefile
-	@mkdir -p $(@D)
-	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CXXFLAGS)" -p "$(CXXFLAGS)" -c $< -o $@
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CXXFLAGS)" -c $< -o $@
 
 # build rule for assembler code
 # The dependency on Makefile ensures that re-running configure recompiles everything
-gen/%.lo: %.s Makefile
+gen/%.$(GAP_OBJEXT): %.s Makefile
 	@mkdir -p $(@D)
-	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CFLAGS)" -p "$(CFLAGS)" -c $< -o $@
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CFLAGS)" -c $< -o $@
 
 # build rule for linking all object files together into a kernel extension
 $(KEXT_SO): $(KEXT_OBJS)
 	@mkdir -p $(@D)
-	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -P "$(KEXT_LDFLAGS)" -P "$(LDFLAGS)" $(KEXT_OBJS) -o $@
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -P "$(KEXT_LDFLAGS)" $(KEXT_OBJS) -o $@
 
 # hook into `make clean`
 clean: clean-kext
@@ -145,7 +148,7 @@ clean-kext:
 	rm -rf $(KEXT_BINARCHDIR) gen
 
 # hook into `make distclean`
-distclean: clean-kext
+distclean: distclean-kext
 distclean-kext:
 	rm -rf bin gen Makefile
 	(cd doc && ./clean)

--- a/gapbind14/demo/Makefile.in
+++ b/gapbind14/demo/Makefile.in
@@ -1,0 +1,19 @@
+#
+# Makefile rules for the orb package
+#
+KEXT_NAME = gapbind_demo
+KEXT_SOURCES = src/gapbind_demo.c src/gapbind14.cc
+
+KEXT_CXXFLAGS = -I../include -std=gnu++14
+KEXT_LDFLAGS = -lstdc++
+
+# ifndef GAP_KERNEL_MAJOR_VERSION
+#   KEXT_CXXFLAGS += -I$(GAP_LIB_DIR)/pkg/semigroups/gapbind14/include
+# endif
+
+# include shared GAP package build system
+GAPPATH = @GAPPATH@
+include Makefile.gappkg
+
+src/gapbind14.cc: ../src/gapbind14.cpp
+	cp $< $@

--- a/gapbind14/demo/configure
+++ b/gapbind14/demo/configure
@@ -1,0 +1,34 @@
+#!/bin/sh
+# usage: configure gappath
+# this script creates a `Makefile' from `Makefile.in'
+
+set -e
+
+GAPPATH=../..
+while test "$#" -ge 1 ; do
+  option="$1" ; shift
+  case "$option" in
+    --with-gaproot=*) GAPPATH=${option#--with-gaproot=}; ;;
+    -*)               echo "ERROR: unsupported argument $option" ; exit 1;;
+    *)                GAPPATH="$option" ;;
+  esac
+done
+
+if test ! -r "$GAPPATH/sysinfo.gap" ; then
+    echo
+    echo "No file $GAPPATH/sysinfo.gap found."
+    echo
+    echo "Usage: ./configure [GAPPATH]"
+    echo "       where GAPPATH is a path to your GAP installation"
+    echo "       (The default for GAPPATH is \"../..\")"
+    echo
+    echo "Either your GAPPATH is incorrect or the GAP it is pointing to"
+    echo "is not properly compiled (do \"./configure && make\" there first)."
+    echo
+    echo "Aborting... No Makefile is generated."
+    echo
+    exit 1
+fi
+
+echo "Using settings from $GAPPATH/sysinfo.gap"
+sed -e "s;@GAPPATH@;$GAPPATH;g" Makefile.in > Makefile


### PR DESCRIPTION
Update `.gitignore` to allow adding the missing `Makefile.in` & `configure`, then update `Makefile.gappkg` to the latest version.

Also remove the added support for `.cpp` from `Makefile.gappkg`, for two reasons:
1. using an identical copy of the original `Makefile.gappkg` makes future updates easier (of course it is perfectly acceptable to submit a PR to GAP to add support for the `.cpp` extension into the master copy of `Makefile.gappkg`!)
2. referencing a relative path like `../src/gapbind14.cpp` in `KEXT_SOURCES` messed up the code which attempts to adapt paths so that all object files end up inside the `gen` directory. It is easier and safer to just copy the source file into the local `src` directory; and if one does that anyway, one may as well rename it on the fly

Of course I am guessing here as to what your `Makefile.in` and `Makefile.gappkg` were saying (I am guessing you had them but they were accidentally not checked in due to the `.gitignore` rule).

I note that the use of a relative path involving `..` messes up the logic for generating the location of the `.o` files inside `gen`, so we end up with `gapbind14/demo/src/gapbind14.o`. This could be fixed by instead