### PR TITLE
Add a workaround for macOS code signing issues.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -78,6 +78,7 @@ bin/include/libsemigroups/libsemigroups.hpp:
 
 all-local: semigroups.la
 	$(mkdir_p) $(top_srcdir)/$(BINARCHDIR)
+	rm -f $(GAPINSTALLLIB)  # workaround for macOS code signing
 if SYS_IS_CYGWIN
 	cp .libs/semigroups.dll $(GAPINSTALLLIB)
 if WITH_INCLUDED_LIBSEMIGROUPS


### PR DESCRIPTION
Copying new builds of loadable modules, shared libraries or executable
over an existing older copy confuses macOS' code signing system, leading
to segfaults when trying to load the updated copy. As a workaround,
delete the old copy before copying the new file into place.
