### PR TITLE
homomorph: fix issue in SemigroupIsoByImages

### DIFF
--- a/gap/attributes/homomorph.gi
+++ b/gap/attributes/homomorph.gi
@@ -154,8 +154,11 @@ InstallMethod(SemigroupIsomorphismByImages, "for two semigroup and two lists",
 [IsSemigroup, IsSemigroup, IsList, IsList],
 function(S, T, gens, imgs)
   local hom;
+  # TODO(Homomorph): we could check for other isomorphism invariants here, like
+  # we require that gens, and imgs are duplicate free for example, and that S
+  # and T have the same size etc
   hom := SemigroupHomomorphismByImages(S, T, gens, imgs);
-  if IsBijective(hom) then
+  if hom <> fail and IsBijective(hom) then
     return hom;
   fi;
   return fail;

--- a/tst/standard/attributes/homomorph.tst
+++ b/tst/standard/attributes/homomorph.tst
@@ -157,6 +157,12 @@ PartialPerm( [ ], [ ] ) ] ), [ IdentityTransformation ], [ PartialPerm( [ ], [\
  ] ) ] )
 gap> EvalString(String(hom)) = hom;
 true
+gap> S := TrivialSemigroup();
+<trivial transformation group of degree 0 with 1 generator>
+gap> T := FullTransformationSemigroup(2);
+<full transformation monoid of degree 2>
+gap> SemigroupIsomorphismByImages(S, T, [S.1, S.1], [T.1, T.2]);
+fail
 
 # homomorph: SemigroupHomomorphismByImages, for infinite semigroup(s)
 gap> S := FreeSemigroup(1);;


### PR DESCRIPTION
An unhelpful error was given by `SemigroupIsomorphismByImages` when it should have returned `fail`. This PR fixes this issue.