### PR TITLE
Resolve Issue #868

### DIFF
--- a/gap/attributes/attr.gi
+++ b/gap/attributes/attr.gi
@@ -526,8 +526,9 @@ function(S)
   return DClasses(S){DigraphSources(D)};
 end);
 
-InstallMethod(MaximalDClasses, "for a finite monoid as semigroup",
-[IsFinite and IsMonoidAsSemigroup],
+InstallMethod(MaximalDClasses,
+"for a finite monoid as semigroup with mult. neutral elt",
+[IsFinite and IsMonoidAsSemigroup and HasMultiplicativeNeutralElement],
 S -> [DClass(S, MultiplicativeNeutralElement(S))]);
 
 InstallMethod(MaximalLClasses,

--- a/tst/standard/attributes/attr.tst
+++ b/tst/standard/attributes/attr.tst
@@ -2113,6 +2113,17 @@ gap> MaximalLClasses(S);
 gap> MaximalRClasses(S);
 [ <Green's R-class: PBR([ [ -1 ] ], [ [ 1 ] ])> ]
 
+# Issue 868 - IsMonoidAsSemigroup assumed HasMultiplicativeNeutralElement
+gap> S := SemigroupByMultiplicationTable(
+> [[1, 1, 1, 1, 5, 6],
+>  [1, 1, 1, 2, 5, 6],
+>  [3, 3, 3, 3, 5, 6],
+>  [1, 2, 3, 4, 5, 6],
+>  [5, 5, 5, 5, 5, 5],
+>  [6, 6, 6, 6, 6, 6]]);;
+gap> S := AsMonoid(IsFpMonoid, S);
+<fp monoid with 5 generators and 25 relations of length 80>
+
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(D);
 gap> Unbind(G);


### PR DESCRIPTION
The issue was that the method for `MaximalDClasses` for `IsMonoidAsSemigroup` assumed that the argument knew its `MultiplicativeNeutralElement`, which isn't the case for monoids/semigroups defined by a multiplication table. 