### PR TITLE
m4/find_gap.m4: update

### DIFF
--- a/m4/find_gap.m4
+++ b/m4/find_gap.m4
@@ -55,6 +55,7 @@ AC_DEFUN([FIND_GAP],
   if test "x$GAParch" != "x"; then
     GAPARCH=$GAParch
   fi
+  AC_MSG_RESULT($GAPARCH)
 
   if test "x$GAPARCH" = "xUnknown" ; then
     echo ""
@@ -88,7 +89,6 @@ AC_DEFUN([FIND_GAP],
   AC_SUBST(GAP_CPPFLAGS)
   AC_SUBST(GAP_CFLAGS)
   AC_SUBST(GAP_LDFLAGS)
-  AC_SUBST(GAP_LIBS)
 
   AC_LANG_POP([C])
 ])


### PR DESCRIPTION
Stop referencing unused GAP_LIBS, and balance 'checking for GAP architecture' message: The conclusion to the check was not printed and hence no trailing newline printed. So whatever configure message came next ended up starting on the wrong line.