### PR TITLE
Adds method for `IsSelfDualSemigroup` and related functionality

### DIFF
--- a/gap/attributes/properties.gd
+++ b/gap/attributes/properties.gd
@@ -43,6 +43,10 @@ DeclareOperation("IsFullInverseSubsemigroup",
 DeclareOperation("IsNormalInverseSubsemigroup",
                  [IsInverseSemigroup, IsInverseSemigroup]);
 
+if not IsBoundGlobal("IsSelfDualSemigroup") then
+  DeclareProperty("IsSelfDualSemigroup", IsSemigroup);
+fi;
+
 DeclareSynonymAttr("IsRectangularGroup",
                    IsOrthodoxSemigroup and IsSimpleSemigroup);
 

--- a/gap/attributes/properties.gi
+++ b/gap/attributes/properties.gi
@@ -1645,3 +1645,17 @@ function(S, T)
   od;
   return true;
 end);
+
+InstallMethod(IsSelfDualSemigroup,
+"for a finite semigroup with CanUseFroidurePin",
+[IsSemigroup and CanUseFroidurePin],
+function(S)
+  local T, map;
+  T := AsSemigroup(IsFpSemigroup, S);
+  map := AntiIsomorphismDualFpSemigroup(T);
+  return SemigroupIsomorphismByImages(T,
+                                      Range(map),
+                                      GeneratorsOfSemigroup(T),
+                                      List(GeneratorsOfSemigroup(T),
+                                           x -> x ^ map)) <> fail;
+end);

--- a/gap/attributes/semifp.gd
+++ b/gap/attributes/semifp.gd
@@ -1,0 +1,12 @@
+#############################################################################
+##
+##  attributes/semifp.gd
+##  Copyright (C) 2022                                      James Mitchell
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+
+DeclareAttribute("AntiIsomorphismDualFpSemigroup", IsFpSemigroup);
+DeclareAttribute("AntiIsomorphismDualFpMonoid", IsFpMonoid);

--- a/gap/attributes/semifp.gi
+++ b/gap/attributes/semifp.gi
@@ -42,3 +42,43 @@ function(S)
   return Set(Filtered(PartsOfPartitionDS(uf), x -> not decomposable[x[1]]),
              x -> GeneratorsOfSemigroup(S)[x[1]]);
 end);
+
+InstallMethod(AntiIsomorphismDualFpSemigroup, "for an fp semigroup",
+[IsFpSemigroup],
+function(S)
+  local F, R, T, map, inv;
+  F := FreeSemigroupOfFpSemigroup(S);
+  R := List(RelationsOfFpSemigroup(S), x -> List(x, Reversed));
+  T := F / R;
+  map := function(x)
+    local word;
+    word := Reversed(UnderlyingElement(x));
+    return ElementOfFpSemigroup(FamilyObj(Representative(T)), word);
+  end;
+  inv := function(x)
+    local word;
+    word := Reversed(UnderlyingElement(x));
+    return ElementOfFpSemigroup(FamilyObj(Representative(S)), word);
+  end;
+  return MappingByFunction(S, T, map, inv);
+end);
+
+InstallMethod(AntiIsomorphismDualFpMonoid, "for an fp monoid",
+[IsFpMonoid],
+function(S)
+  local F, R, T, map, inv;
+  F := FreeMonoidOfFpMonoid(S);
+  R := List(RelationsOfFpMonoid(S), x -> List(x, Reversed));
+  T := F / R;
+  map := function(x)
+    local word;
+    word := Reversed(UnderlyingElement(x));
+    return ElementOfFpMonoid(FamilyObj(Representative(T)), word);
+  end;
+  inv := function(x)
+    local word;
+    word := Reversed(UnderlyingElement(x));
+    return ElementOfFpMonoid(FamilyObj(Representative(S)), word);
+  end;
+  return MappingByFunction(S, T, map, inv);
+end);

--- a/gap/semigroups/semifp.gd
+++ b/gap/semigroups/semifp.gd
@@ -16,5 +16,8 @@ DeclareAttribute("UnderlyingCongruence", IsFpMonoid);
 DeclareAttribute("Length", IsFpSemigroup);
 DeclareAttribute("Length", IsFpMonoid);
 
+DeclareOperation("ReversedOp", [IsElementOfFpSemigroup]);
+DeclareOperation("ReversedOp", [IsElementOfFpMonoid]);
+
 DeclareGlobalFunction("FreeMonoidAndAssignGeneratorVars");
 DeclareGlobalFunction("FreeSemigroupAndAssignGeneratorVars");

--- a/gap/semigroups/semifp.gi
+++ b/gap/semigroups/semifp.gi
@@ -1329,3 +1329,19 @@ function(S)
   return Length(GeneratorsOfMonoid(S))
     + Sum(RelationsOfFpMonoid(S), x -> Length(x[1]) + Length(x[2]));
 end);
+
+InstallMethod(ReversedOp, "for an element of an fp semigroup",
+[IsElementOfFpSemigroup],
+function(word)
+  local rev;
+  rev := Reversed(UnderlyingElement(word));
+  return ElementOfFpSemigroup(FamilyObj(word), rev);
+end);
+
+InstallMethod(ReversedOp, "for an element of an fp monoid",
+[IsElementOfFpMonoid],
+function(word)
+  local rev;
+  rev := Reversed(UnderlyingElement(word));
+  return ElementOfFpMonoid(FamilyObj(word), rev);
+end);

--- a/init.g
+++ b/init.g
@@ -114,6 +114,7 @@ ReadPackage("semigroups", "gap/attributes/isorms.gd");
 ReadPackage("semigroups", "gap/attributes/maximal.gd");
 ReadPackage("semigroups", "gap/attributes/properties.gd");
 ReadPackage("semigroups", "gap/attributes/homomorph.gd");
+ReadPackage("semigroups", "gap/attributes/semifp.gd");
 ReadPackage("semigroups", "gap/attributes/translat.gd");
 ReadPackage("semigroups", "gap/attributes/rms-translat.gd");
 


### PR DESCRIPTION
This PR adds a method for `IsSelfDualSemigroup`, `AntiIsomorphismDualFpSemigroup`, and a method for `ReversedOp` for fp semigroup and fp monoid elements.

This PR is currently missing documentation and tests. 