### PR TITLE
Fix closure semigroup for non-libsemigroups types

### DIFF
--- a/gap/semigroups/semigrp.gi
+++ b/gap/semigroups/semigrp.gi
@@ -520,7 +520,7 @@ InstallMethod(ClosureSemigroupOrMonoidNC,
 "for a function, semigroup, finite list, and record",
 [IsFunction, IsSemigroup, IsList and IsFinite, IsRecord],
 function(Constructor, S, coll, opts)
-  local n;
+  local n, T, x;
 
   # opts must be copied and processed before calling this function
   # coll must be copied before calling this function
@@ -538,7 +538,14 @@ function(Constructor, S, coll, opts)
     Sort(coll, IsGreensDGreaterThanFunc(Semigroup(coll)));
   fi;
 
-  return Constructor(S, coll, opts);
+  T := Constructor(S, opts);
+
+  for x in coll do
+    if not x in T then
+      T := Constructor(T, x, opts);
+    fi;
+  od;
+  return T;
 end);
 
 #############################################################################

--- a/tst/standard/semigroups/semigrp.tst
+++ b/tst/standard/semigroups/semigrp.tst
@@ -1098,6 +1098,12 @@ gap> S := GraphInverseSemigroup(CycleDigraph(2));
 gap> S < S;
 false
 
+# Issue 565 - no ClosureSemigroup method for non-libsemigroups types
+gap> S := FreeBand(3);
+<free band on the generators [ x1, x2, x3 ]>
+gap> Size(GeneratorsOfSemigroup(Semigroup(AsList(S), rec(small := true)))) < Size(S);
+true
+
 #
 gap> SEMIGROUPS.StopTest();
 gap> STOP_TEST("Semigroups package: standard/semigroups/semigrp.tst");

--- a/tst/standard/semigroups/semiquo.tst
+++ b/tst/standard/semigroups/semiquo.tst
@@ -176,8 +176,7 @@ gap> SmallSemigroupGeneratingSet(S / cong);
 [ <2-sided congruence class of <identity partial perm on [ 1, 2, 3, 4 ]>>, 
   <2-sided congruence class of (1,3)(2,4)(21,23)(22,24)(25,27)(26,28)(33,35)
     (34,36)>, <2-sided congruence class of (1,2)(3,4)(5,6)(7,8)(11,12)(13,14)
-    (19,20)(29,30)>, <2-sided congruence class of [11,10][12,9][13,16][14,15]
-    [19,18][20,17][29,32][30,31](1,4)(2,3)(5,8)(6,7)> ]
+    (19,20)(29,30)> ]
 gap> GeneratorsSmallest(S / cong);
 [ <2-sided congruence class of <identity partial perm on [ 1, 2, 3, 4 ]>>, 
   <2-sided congruence class of (1,2)(3,4)(5,6)(7,8)(11,12)(13,14)(19,20)

--- a/tst/standard/semigroups/semitrans.tst
+++ b/tst/standard/semigroups/semitrans.tst
@@ -2747,7 +2747,7 @@ gap> IsomorphismTransformationSemigroup(F / R);
 Error, the argument (a semigroup) is not finite
 gap> IsomorphismTransformationSemigroup(MinimalIdeal(FreeBand(2)));
 <simple semigroup ideal of size 4, with 1 generator> -> 
-<transformation semigroup of size 4, degree 5 with 4 generators>
+<transformation semigroup of size 4, degree 5 with 3 generators>
 
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(B);


### PR DESCRIPTION
This issue was a missing method for ClosureSemigroup for non-libsemigroups types. This resolves issue #865 