### PR TITLE
Fix faulty usage of 0-simple RZMS translations code

### DIFF
--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -1380,7 +1380,7 @@ function(H)
   S := UnderlyingSemigroup(H);
   if SEMIGROUPS.HasEasyBitranslationsGenerators(H) then
     TryNextMethod();
-  elif IsReesZeroMatrixSemigroup(S) then
+  elif IsReesZeroMatrixSemigroup(S) and IsZeroSimpleSemigroup(S) then
     return SEMIGROUPS.BitranslationsRZMS(H);
   elif SEMIGROUPS.IsNormalRMSOverGroup(S) then
     return SEMIGROUPS.BitranslationsNormalRMS(H);

--- a/gap/attributes/translat.gi
+++ b/gap/attributes/translat.gi
@@ -1440,7 +1440,7 @@ function(S)
   H := TranslationalHull(S);
   if SEMIGROUPS.HasEasyBitranslationsGenerators(H) then
     return Size(H);  # this is probably more efficient
-  elif IsReesZeroMatrixSemigroup(S) then
+  elif IsReesZeroMatrixSemigroup(S) and IsZeroSimpleSemigroup(S) then
     out := SEMIGROUPS.BitranslationsRZMS(H, "nr_only");
   elif SEMIGROUPS.IsNormalRMSOverGroup(S) then
     out := SEMIGROUPS.BitranslationsNormalRMS(H, "nr_only");

--- a/tst/standard/attributes/translat.tst
+++ b/tst/standard/attributes/translat.tst
@@ -775,6 +775,20 @@ gap> for h in H do
 > HTAdd(ht, h, true);
 > od;
 
+# Translational Hull of RZMS which is not completely 0-simple
+gap> G := Range(IsomorphismPermGroup(SmallGroup(16, 2)));;   
+gap> mat := [[G.1, 0, 0], [G.1 * G.2, 0, G.2]];;             
+gap> S := ReesZeroMatrixSemigroup(G, mat);;
+gap> Size(TranslationalHull(S));
+14977
+
+# Translational Hull of RZMS which is not completely 0-simple
+gap> G := Range(IsomorphismPermGroup(SmallGroup(16, 2)));;   
+gap> mat := [[G.1, 0, 0], [G.1 * G.2, 0, G.2]];;             
+gap> S := ReesZeroMatrixSemigroup(G, mat);;
+gap> NrBitranslations(S);
+14977
+
 # SEMIGROUPS_UnbindVariables
 gap> Unbind(a);
 gap> Unbind(b);


### PR DESCRIPTION
Previously the code for computing bitranslations of a RZMS could be incorrectly be triggered by a RZMS defined with a non-regular sandwich matrix.