### PR TITLE
Remove invalid MutableCopyMat invocation

### DIFF
--- a/gap/main/setup.gi
+++ b/gap/main/setup.gi
@@ -1238,7 +1238,7 @@ function(S, mat)
   bd  := BaseDomain(mat);
   n   := NrRows(mat);
   mat := List([1 .. n],
-              i -> Concatenation(MutableCopyMat(mat[i]), [Zero(bd)]));
+              i -> Concatenation(mat[i], [Zero(bd)]));
   Add(mat, ZeroMatrix(bd, 1, n + 1)[1]);
   mat[n + 1, n + 1] := One(bd);
   return Matrix(bd, mat);


### PR DESCRIPTION
Applying to it a matrix row (= vector) is invalid. It also is not necessary in this case.