### PR TITLE
Ci config options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - "master"
+      - "main"
       - "stable-*.*"
   schedule:
     # Every day at 3:15 AM UTC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,16 @@ jobs:
        CHERE_INVOKING: 1
      steps:
        - uses: actions/checkout@v2
-       - uses: gap-actions/setup-cygwin@v1
-       - uses: gap-actions/setup-gap@cygwin-v2
+       - name: "Setup cygwin"
+         uses: gap-actions/setup-cygwin@v1
+       - name: "Setup GAP for cygwin"
+         uses: gap-actions/setup-gap@cygwin-v2
          with:
            GAP_PKGS_TO_BUILD: "digraphs io orb datastructures profiling"
-       - uses: gap-actions/build-pkg@cygwin-v1
+       - name: "Build Semigroups"
+         uses: gap-actions/build-pkg@cygwin-v1
+         with:
+           CONFIGFLAGS: --disable-fmt # to try and speed up compilation
        - uses: gap-actions/run-pkg-tests@cygwin-v2
          with:
            GAP_TESTFILE: "tst/teststandard.g"

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,15 +1,22 @@
 name: clang-format
-on: [push, pull_request]
-concurrency:
-  group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}
-  cancel-in-progress: true
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - "main"
+      - "stable-*.*"
+  schedule:
+    # Every day at 3:10 AM UTC
+    - cron: '10 3 * * *'
+
 jobs:
   formatting-check:
     name: Formatting check
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Run clang-format style check for C/C++/Protobuf programs.
+    - name: "Run clang-format style checks on src/*.[hc]pp . . ."
       uses: jidicula/clang-format-action@v4.10.1
       with:
         clang-format-version: '15'

--- a/.github/workflows/config-options.yml
+++ b/.github/workflows/config-options.yml
@@ -42,6 +42,7 @@ jobs:
       ABI: 64
       PKG_CONFIG_PATH: "/home/runner/micromamba-root/envs/libsemigroups/lib/pkgconfig:/home/runner/micromamba-root/envs/libsemigroups/share/pkgconfig/"
       LD_LIBRARY_PATH: "/home/runner/micromamba-root/envs/libsemigroups/lib"
+      DO_NOT_DOWNLOAD_LIBSEMIGROUPS: 1 # prevents prerequisites.sh
     defaults:
       run:
         shell: bash -l {0}
@@ -50,14 +51,14 @@ jobs:
       - name: "Install conda environment from environment.yml . . ."
         uses: mamba-org/provision-with-micromamba@main
       - name: "Python version . . ."
-        run: |
-          micromamba activate libsemigroups
+        run:  micromamba activate libsemigroups
       - name: "Setup ccache"
         uses: Chocobo1/setup-ccache-action@v1
         with:
           update_packager_index: false
           override_cache_key: ${{ runner.os }}-$GAPBRANCH-$ABI-${{ github.ref }}
           override_cache_key_fallback: ${{ runner.os }}-$GAPBRANCH-$ABI
+      - run: mkdir libsemigroups
       - name: "Install GAP and clone/compile necessary packages"
         uses: gap-actions/setup-gap@v2
         env:

--- a/.github/workflows/config-options.yml
+++ b/.github/workflows/config-options.yml
@@ -8,7 +8,6 @@ on:
       - "stable-*.*"
 jobs:
   enable-debug:
-    name: "stable-4.12 / ubuntu / 64-bit"
     runs-on: "ubuntu-latest"
     env:
       GAPBRANCH: "stable-4.12"
@@ -33,5 +32,43 @@ jobs:
         uses: gap-actions/build-pkg@v1
         with:
           CONFIGFLAGS: --disable-hpcombi --enable-debug
+      - name: "Run Semigroups package's tst/teststandard.g"
+        uses: gap-actions/run-pkg-tests@v2
+
+  with-external-libsemigroups:
+    runs-on: "ubuntu-latest"
+    env:
+      GAPBRANCH: "stable-4.12"
+      ABI: 64
+      PKG_CONFIG_PATH: "/home/runner/micromamba-root/envs/libsemigroups/lib/pkgconfig:/home/runner/micromamba-root/envs/libsemigroups/share/pkgconfig/"
+      LD_LIBRARY_PATH: "/home/runner/micromamba-root/envs/libsemigroups/lib"
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Install conda environment from environment.yml . . ."
+        uses: mamba-org/provision-with-micromamba@main
+      - name: "Python version . . ."
+        run: |
+          micromamba activate libsemigroups
+      - name: "Setup ccache"
+        uses: Chocobo1/setup-ccache-action@v1
+        with:
+          update_packager_index: false
+          override_cache_key: ${{ runner.os }}-$GAPBRANCH-$ABI-${{ github.ref }}
+          override_cache_key_fallback: ${{ runner.os }}-$GAPBRANCH-$ABI
+      - name: "Install GAP and clone/compile necessary packages"
+        uses: gap-actions/setup-gap@v2
+        env:
+          # We don't understand why this is necessary. Hopefully it can be
+          # removed in the fullness of time.
+          LDFLAGS: "-pthread"
+        with:
+          GAP_PKGS_TO_BUILD: "digraphs io orb datastructures profiling"
+      - name: "Build Semigroups"
+        uses: gap-actions/build-pkg@v1
+        with: # we use --with-external-fmt since this is available from conda
+          CONFIGFLAGS: --disable-hpcombi --with-external-libsemigroups --enable-fmt --with-external-fmt
       - name: "Run Semigroups package's tst/teststandard.g"
         uses: gap-actions/run-pkg-tests@v2

--- a/.github/workflows/config-options.yml
+++ b/.github/workflows/config-options.yml
@@ -1,0 +1,37 @@
+name: "Configuration options"
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - "main"
+      - "stable-*.*"
+jobs:
+  enable-debug:
+    name: "stable-4.12 / ubuntu / 64-bit"
+    runs-on: "ubuntu-latest"
+    env:
+      GAPBRANCH: "stable-4.12"
+      ABI: 64
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Setup ccache"
+        uses: Chocobo1/setup-ccache-action@v1
+        with:
+          update_packager_index: false
+          override_cache_key: ${{ runner.os }}-$GAPBRANCH-$ABI-${{ github.ref }}
+          override_cache_key_fallback: ${{ runner.os }}-$GAPBRANCH-$ABI
+      - name: "Install GAP and clone/compile necessary packages"
+        uses: gap-actions/setup-gap@v2
+        env:
+          # We don't understand why this is necessary. Hopefully it can be
+          # removed in the fullness of time.
+          LDFLAGS: "-pthread"
+        with:
+          GAP_PKGS_TO_BUILD: "digraphs io orb datastructures profiling"
+      - name: "Build Semigroups"
+        uses: gap-actions/build-pkg@v1
+        with:
+          CONFIGFLAGS: --disable-hpcombi --enable-debug
+      - name: "Run Semigroups package's tst/teststandard.g"
+        uses: gap-actions/run-pkg-tests@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - "master"
+      - "main"
       - "stable-*.*"
   schedule:
     # Every day at 3:10 AM UTC

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - "master"
+      - "main"
       - "stable-*.*"
   schedule:
     # Every day at 3:33 AM UTC

--- a/doc/io.xml
+++ b/doc/io.xml
@@ -163,7 +163,7 @@ gap> ReadGenerators(file, 13);
       list of multiplication tables.<P/>
 
       If the optional second argument <A>nr</A> is present, then
-      <C>ReadMultiplicationTable</C> returns the mutiplication table stored in
+      <C>ReadMultiplicationTable</C> returns the multiplication table stored in
       the <A>nr</A>th line of <A>filename</A>.
       <!-- The next example is a log not an example because for some reason it
       fails in the cygwin CI job -->

--- a/doc/isomorph.xml
+++ b/doc/isomorph.xml
@@ -127,7 +127,7 @@ gap> CanonicalMultiplicationTable(S);
     <Description>
       This function returns the lex-least multiplication table of a semigroup
       isomorphic to the semigroup <A>S</A>. <C>SmallestMultiplicationTable</C>
-      returns the lex-least multiplication of any semigroup isomoprhic to
+      returns the lex-least multiplication of any semigroup isomorphic to
       <A>S</A>.
 
       Due to the high complexity of computing the smallest multiplication table

--- a/doc/semieunit.xml
+++ b/doc/semieunit.xml
@@ -50,7 +50,7 @@
 
     must return <K>true</K>. Herein if we say that a vertex <C>A</C> of <A>X</A>
     is 'in' <A>Y</A> then we mean there is a vertex of <A>Y</A> whose label is
-    <C>A</C>. Alerternatively the user may choose to give the argument
+    <C>A</C>. Alternatively the user may choose to give the argument
     <A>Y</A> as the vertices of <A>X</A> on which <A>Y</A> is the induced
     subdigraph. <P/>
     

--- a/doc/semiex.xml
+++ b/doc/semiex.xml
@@ -167,7 +167,7 @@ gap> Size(T);
     <Description>
       If <A>n</A> is a non-negative integer, then this operation returns the
       Brauer monoid of degree <A>n</A>. The <E>Brauer monoid</E> is the
-      submonoid of the partition monoid consisiting of those bipartitions where
+      submonoid of the partition monoid consisting of those bipartitions where
       the size of every block is 2. <P/>
 
       <C>PartialBrauerMonoid</C> returns the partial Brauer monoid, which is the

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,7 @@
+name: libsemigroups
+
+channels:
+  - conda-forge
+
+dependencies:
+  - libsemigroups

--- a/m4/ax_check_libsemigroup.m4
+++ b/m4/ax_check_libsemigroup.m4
@@ -50,6 +50,9 @@ AC_DEFUN([AX_CHECK_LIBSEMIGROUPS], [
 	AC_SUBST(LIBSEMIGROUPS_CFLAGS, ['-I./bin/include -I./bin/include/libsemigroups'])
 	AC_SUBST(LIBSEMIGROUPS_LIBS, ['bin/lib/libsemigroups.la'])
         AC_CONFIG_SUBDIRS([libsemigroups])
+  else 
+        LIBSEMIGROUPS_VERSION="$(pkg-config --modversion libsemigroups)"
+	AC_MSG_NOTICE([using external libsemigroups $LIBSEMIGROUPS_VERSION])
   fi
 
   AM_CONDITIONAL([WITH_INCLUDED_LIBSEMIGROUPS], [test "$need_included_libsemigroups" = yes])

--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -23,6 +23,18 @@ fi
 
 notice_it "libsemigroups v$VERS is required by this version of Semigroups"
 
+if [ -f "config.log" ] ; then
+  if grep -q "\.\/configure.*\-\-with\-external\-libsemigroups" config.log ; then
+    notice_it "Configuration flag \"--with-external-libsemigroups\" found in config.log"
+    notice_it "Not downloading libsemigroups, no further prerequisites required"
+    exit 0
+  fi
+elif [[ ! -z "${DO_NOT_DOWNLOAD_LIBSEMIGROUPS}" ]]; then
+  notice_it "Environment variable DO_NOT_DOWNLOAD_LIBSEMIGROUPS is defined"
+  notice_it "Not downloading libsemigroups, no further prerequisites required"
+  exit 0
+fi
+
 if [ -d "$LIBS_DIR" ] && [ "$(ls -A $LIBS_DIR)" ]; then
   notice_it "The libsemigroups directory exists and is non-empty"
   if [ -f "$LIBS_DIR/.VERSION" ]; then

--- a/src/to_gap.hpp
+++ b/src/to_gap.hpp
@@ -97,6 +97,7 @@ namespace gapbind14 {
         }
         AssPlist(result, i + 1, row);
       }
+      SEMIGROUPS_ASSERT(LEN_PLIST(result) == n + extra_capacity);
       if (gap_t != nullptr) {
         RetypeBag(result, T_POSOBJ);
         SET_TYPE_POSOBJ(result, gap_t);
@@ -248,7 +249,6 @@ namespace gapbind14 {
             return (y == NEGATIVE_INFINITY ? to_gap<NegativeInfinity>()(y)
                                            : to_gap<scalar_type>()(y));
           });
-      SEMIGROUPS_ASSERT(LEN_PLIST(result) == x.number_of_rows() + 1);
       SET_ELM_PLIST(result,
                     x.number_of_rows() + 1,
                     to_gap<scalar_type>()(matrix_threshold(x)));
@@ -273,7 +273,6 @@ namespace gapbind14 {
             return (y == POSITIVE_INFINITY ? to_gap<PositiveInfinity>()(y)
                                            : to_gap<scalar_type>()(y));
           });
-      SEMIGROUPS_ASSERT(LEN_PLIST(result) == x.number_of_rows() + 1);
       SET_ELM_PLIST(result,
                     x.number_of_rows() + 1,
                     to_gap<scalar_type>()(matrix_threshold(x)));
@@ -314,7 +313,6 @@ namespace gapbind14 {
       using libsemigroups::matrix_threshold;
 
       auto result = detail::make_matrix(x, NTPMatrixType, 2);
-      SEMIGROUPS_ASSERT(LEN_PLIST(result) == x.number_of_rows() + 2);
       SET_ELM_PLIST(result,
                     x.number_of_rows() + 1,
                     to_gap<scalar_type>()(matrix_threshold(x)));


### PR DESCRIPTION
TODO:

- [x] fix the debug build (seems there's actually a bug in Semigroups there, not the setup)
- [x] if using external `libsemigroups` is there a way of not running `autogen.sh` in the vendored `libsemigroups`?
- [x] adjust `prerequisites.sh` to not download `libsemigroups` if using `--with-external-libsemigroups`
- [x] add a message indicating that we are using external `libsemigroups` to `AX_CHECK_LIBSEMIGROUPS`
- [x] report the version of `libsemigroups` being used if `--with-external-libsemigroups` is used.