### PR TITLE
Update libsemigroups URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1506,7 +1506,7 @@ added the functions `CitrusDefaultMem`, `CitrusHiMem`,
 [Semigroups]: https://gap-packages.github.io/Semigroups
 [Smallsemi]: https://gap-packages.github.io/smallsemi
 [io]: https://gap-packages.github.io/io
-[libsemigroups]: https://libsemigroups.github.io/libsemigroups
+[libsemigroups]: https://libsemigroups.github.io/
 [orb package]: https://gap-packages.github.io/orb
 [orb]: https://gap-packages.github.io/orb
 [Bitbucket issue tracker]: https://bitbucket.org/james-d-mitchell/semigroups/issues

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Both [orb][] and [Semigroups][] perform better when [orb][] is compiled, so comp
 Enjoy!
 
 [Semigroups]: https://semigroups.github.io/Semigroups
-[libsemigroups]: https://libsemigroups.github.io/libsemigroups
+[libsemigroups]: https://libsemigroups.github.io/
 [pkg-config]: https://www.freedesktop.org/wiki/Software/pkg-config/
 [orb]: https://gap-packages.github.io/orb
 [Digraphs]: https://digraphs.github.io/Digraphs

--- a/doc/z-chap02.xml
+++ b/doc/z-chap02.xml
@@ -69,7 +69,7 @@
         from version 3.0.0, it is necessary to compile the &SEMIGROUPS; package.
         &SEMIGROUPS; uses the
         <URL Text="libsemigroups">
-          https://libsemigroups.github.io/libsemigroups/
+          https://libsemigroups.github.io/
         </URL>
         C++ library, which requires a compiler implementing the C++14 standard.
         Inside the <F>pkg/semigroups-&VERSION;</F> directory, in your terminal


### PR DESCRIPTION
The old URL gives a 404