### PR TITLE
greens: fix RhoOrbStabChain(DClass)

### DIFF
--- a/gap/greens/acting.gi
+++ b/gap/greens/acting.gi
@@ -456,7 +456,7 @@ end);
 
 InstallMethod(RhoOrbStabChain, "for a D-class of an acting semigroup",
 [IsGreensDClass and IsActingSemigroupGreensClass],
-D -> RhoOrbStabChain(GreensLClassOfElementNC(D, Representative(D))));
+D -> RhoOrbStabChain(GreensLClassOfElementNC(D, D!.rep)));
 
 # same method for regular, not required for inverse, same for ideals
 

--- a/tst/standard/greens/acting.tst
+++ b/tst/standard/greens/acting.tst
@@ -11,7 +11,7 @@
 #@local BruteForceInverseCheck, BruteForceIsoCheck, CheckLeftGreensMultiplier1
 #@local CheckLeftGreensMultiplier2, CheckRightGreensMultiplier1
 #@local CheckRightGreensMultiplier2, D, DD, DDD, H, L, L3, LL, R, RR, RRR, S, T
-#@local a, acting, b, d, en, h, inv, it, iter, map, mults, nr, r, x, y
+#@local a, acting, b, c, d, e, en, h, inv, it, iter, map, mults, nr, r, x, y
 gap> START_TEST("Semigroups package: standard/greens/acting.tst");
 gap> LoadPackage("semigroups", false);;
 
@@ -2010,6 +2010,22 @@ gap> D := DClasses(T)[4];;
 gap> d := Representative(D);;
 gap> mults := List(HClassReps(LClass(T, d)), h -> LeftGreensMultiplierNC(T, d, h));;
 gap> Length(Set(mults, m -> RClass(T, m * d))) = Length(RClasses(D));
+true
+
+# Fix issue #931 (bug in RhoOrbStabChain(DClass) using the wrong representative
+gap> S := Monoid(Transformation([3, 2, 3, 3, 5, 5]), 
+>                Transformation([5, 4, 4, 5, 1, 4]), 
+>                Transformation([1, 1, 5, 3, 3]), 
+>                Transformation([4, 5, 6, 4, 1, 4]), 
+>                Transformation([5, 1, 2, 1, 6, 5]));
+<transformation monoid of degree 6 with 5 generators>
+gap> e := Transformation([1, 6, 6, 1, 5, 6]);
+Transformation( [ 1, 6, 6, 1, 5, 6 ] )
+gap> c := Transformation([6, 1, 1, 6, 5, 1]);
+Transformation( [ 6, 1, 1, 6, 5, 1 ] )
+gap> c in DClass(S, e);
+true
+gap> c in HClass(S, e);
 true
 
 #


### PR DESCRIPTION
This PR resolves issue #931, it seems that the method for `RhoOrbStabChain` for a $\mathscr{D}$-class used the wrong representative, which resulted in a false negative for membership testing in the $\mathscr{D}$-class.