### PR TITLE
Add `UniformRandomPartialPerm`

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -384,7 +384,7 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">=4.12.1",
-  NeededOtherPackages := [["datastructures", ">=0.2.5"],
+  NeededOtherPackages := [["datastructures", ">=0.3.0"],
                           ["digraphs", ">=1.6.2"],
                           ["genss", ">=1.6.5"],
                           ["images", ">=1.3.1"],

--- a/doc/semipperm.xml
+++ b/doc/semipperm.xml
@@ -93,3 +93,32 @@ gap> CyclesOfPartialPerm(x);
   </Description>
 </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="UniformRandomPartialPerm">
+<ManSection>
+  <Oper Name="UniformRandomPartialPerm" Arg = "n"/>
+  <Returns>
+    A partial perm of degree <A>n</A> chosen uniformly at random among all
+    partial permutations of that degree.
+  </Returns>
+  <Description>
+    This function returns a partial perm of degree <A>n</A> chosen uniformly at
+    random among all partial permutations of that degree. This function differs
+    from <Ref Oper="RandomPartialPerm" BookName="ref"/> in that the returned
+    partial perm is chosen <E>uniformly</E> at random, whereas <Ref
+        Oper="RandomPartialPerm" BookName="ref"/> does not use a uniform
+    distribution. <P/>
+
+    The downside to <C>UniformRandomPartialPerm</C> is that it can use a
+    significant amount of memory, and is rather slower than <Ref
+        Oper="RandomPartialPerm" BookName="ref"/>. 
+
+    <Log><![CDATA[
+gap> UniformRandomPartialPerm(1000);
+<partial perm on 971 pts with degree 1000, codegree 1000>]]>
+    </Log>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+

--- a/doc/z-chap11.xml
+++ b/doc/z-chap11.xml
@@ -230,13 +230,14 @@
   <Section>
 
     <Heading>
-      Attributes of partial perm semigroups
+      Attributes of partial perms and partial perm semigroups
     </Heading>
 
     <#Include Label = "ComponentRepsOfPartialPermSemigroup">
     <#Include Label = "ComponentsOfPartialPermSemigroup">
     <#Include Label = "CyclesOfPartialPerm">
     <#Include Label = "CyclesOfPartialPermSemigroup">
+    <#Include Label = "UniformRandomPartialPerm">
 
   </Section>
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
 
 dependencies:
-  - libsemigroups
+  - libsemigroups==2.7.3

--- a/gap/elements/pperm.gd
+++ b/gap/elements/pperm.gd
@@ -9,3 +9,4 @@
 ##
 
 DeclareAttribute("CyclesOfPartialPerm", IsPartialPerm);
+DeclareOperation("UniformRandomPartialPerm", [IsPosInt]);

--- a/gap/elements/pperm.gi
+++ b/gap/elements/pperm.gi
@@ -12,3 +12,70 @@ InstallMethod(IndexPeriodOfSemigroupElement, "for a partial perm",
 
 InstallMethod(CyclesOfPartialPerm, "for a partial perm", [IsPartialPerm],
 f -> DigraphAllSimpleCircuits(AsDigraph(f)));
+
+DeclareGlobalVariable("_RANDOM_PPERM_CACHED_VALUES");
+MakeReadWriteGlobal("_RANDOM_PPERM_CACHED_VALUES");
+_RANDOM_PPERM_CACHED_VALUES := WeakPointerObj([]);
+
+InstallMethod(UniformRandomPartialPerm, "for a positive integer", [IsPosInt],
+function(n)
+  local cache, num_bijections, r, im, unused_vals, num_undefined,
+  num_each_defined, pos, i, j;
+
+  cache := Immutable(_RANDOM_PPERM_CACHED_VALUES);
+
+  if not IsBound(cache[n + 1]) then
+    # TODO check that all the values in cache are bound
+    cache := [];
+    cache[1] := [1];
+    for i in [2 .. n + 1] do
+      cache[i] := [1];
+      for j in [2 .. i] do
+        cache[i][j] := cache[i][j - 1] + (i - 1) * cache[i - 1][j - 1];
+      od;
+    od;
+  fi;
+
+  # The number of partial perms from a set of size i to a set of size j.
+  # num_bijections := function(i, j)
+  #   local tmp;
+  #   if j < i then
+  #     tmp := i;
+  #     i := j;
+  #     j := tmp;
+  #   fi;
+  #   return Sum([0 .. i], r -> Binomial(i, r) * Binomial(j, r) * Factorial(r));
+  # end;
+
+  num_bijections := function(i, j)
+    local tmp;
+    if j > i then
+      tmp := i;
+      i := j;
+      j := tmp;
+    fi;
+    return cache[i + 1][j + 1];
+  end;
+
+  # Rank so far
+  r := 0;
+  im := [];
+
+  unused_vals := HashSet([1 .. n]);
+
+  for i in [1 .. n] do
+    num_undefined := num_bijections(n - i, n - r);
+    num_each_defined := num_bijections(n - i, n - r - 1);
+    pos := Random(1, num_undefined + (n - r) * num_each_defined);
+    if pos <= num_undefined then
+      im[i] := 0;  # undefined
+    else
+      pos := pos - num_undefined;
+      im[i] := Set(unused_vals)[QuoInt(pos - 1, num_each_defined) + 1];
+      RemoveSet(unused_vals, im[i]);
+      r := r + 1;
+    fi;
+  od;
+  _RANDOM_PPERM_CACHED_VALUES := WeakPointerObj(cache);
+  return PartialPermNC(im);
+end);

--- a/gap/elements/pperm.gi
+++ b/gap/elements/pperm.gi
@@ -25,7 +25,6 @@ function(n)
   cache := Immutable(_RANDOM_PPERM_CACHED_VALUES);
 
   if not IsBound(cache[n + 1]) then
-    # TODO check that all the values in cache are bound
     cache := [];
     cache[1] := [1];
     for i in [2 .. n + 1] do
@@ -36,17 +35,7 @@ function(n)
     od;
   fi;
 
-  # The number of partial perms from a set of size i to a set of size j.
-  # num_bijections := function(i, j)
-  #   local tmp;
-  #   if j < i then
-  #     tmp := i;
-  #     i := j;
-  #     j := tmp;
-  #   fi;
-  #   return Sum([0 .. i], r -> Binomial(i, r) * Binomial(j, r) * Factorial(r));
-  # end;
-
+  # number of bijections from set of size i into a set of size j.
   num_bijections := function(i, j)
     local tmp;
     if j > i then

--- a/gap/semigroups/semipperm.gi
+++ b/gap/semigroups/semipperm.gi
@@ -24,19 +24,25 @@ InstallMethod(SEMIGROUPS_ProcessRandomArgsCons,
 {filt, params} -> SEMIGROUPS_ProcessRandomArgsCons(IsSemigroup, params));
 
 InstallMethod(RandomSemigroupCons, "for IsPartialPermSemigroup and a list",
-[IsPartialPermSemigroup, IsList], {filt, params} ->
-Semigroup(List([1 .. params[1]], i -> RandomPartialPerm(params[2]))));
+[IsPartialPermSemigroup, IsList],
+function(_, params)
+  return Semigroup(List([1 .. params[1]],
+                        i -> UniformRandomPartialPerm(params[2])));
+end);
 
 InstallMethod(RandomMonoidCons, "for IsPartialPermMonoid and a list",
-[IsPartialPermMonoid, IsList], {filt, params} ->
-Monoid(List([1 .. params[1]], i -> RandomPartialPerm(params[2]))));
+[IsPartialPermMonoid, IsList],
+function(_, params)
+  return Monoid(List([1 .. params[1]],
+                     i -> UniformRandomPartialPerm(params[2])));
+end);
 
 InstallMethod(RandomInverseSemigroupCons,
 "for IsPartialPermSemigroup and a list",
 [IsPartialPermSemigroup, IsList],
 function(_, params)
   return InverseSemigroup(List([1 .. params[1]],
-                               i -> RandomPartialPerm(params[2])));
+                               i -> UniformRandomPartialPerm(params[2])));
 end);
 
 InstallMethod(RandomInverseMonoidCons,
@@ -44,7 +50,7 @@ InstallMethod(RandomInverseMonoidCons,
 [IsPartialPermMonoid, IsList],
 function(_, params)
   return InverseMonoid(List([1 .. params[1]],
-                            i -> RandomPartialPerm(params[2])));
+                            i -> UniformRandomPartialPerm(params[2])));
 end);
 
 #############################################################################


### PR DESCRIPTION
This PR adds an operation `UniformRandomPartialPerm` that returns a partial perm acting on `n` points  uniformly at random. On the down side this is slower than `RandomPartialPerm` but on the up side the distribution is uniform. 

This requires documentation and test.

Joint work with @le27 and Alex Levine.