### PR TITLE
Fix a typo that breaks HPCombi support

### DIFF
--- a/src/to_cpp.hpp
+++ b/src/to_cpp.hpp
@@ -508,7 +508,7 @@ namespace gapbind14 {
 #ifdef LIBSEMIGROUPS_HPCOMBI_ENABLED
     template <>
     struct Undef<HPCombi::PPerm16> {
-      static constexpr UInt2 value = OxFF;
+      static constexpr UInt2 value = 0xFF;
     };
 #endif
 


### PR DESCRIPTION
Issue and fix reported in https://github.com/semigroups/Semigroups/pull/937#issuecomment-1616628364 by @dimpase -- this changes is also part of #937 but it makes sense to merge it right away.