### PR TITLE
typo (ERNEL<-KERNEL) in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,7 @@ AC_ARG_ENABLE([debug],
     )
 AC_MSG_CHECKING([whether to enable debug mode])
 AC_MSG_RESULT([$enable_debug])
-ERNEL_DEBUG=$enable_debug
+KERNEL_DEBUG=$enable_debug
 AC_SUBST(KERNEL_DEBUG)
 
 # Check if HPCombi is enable, and available


### PR DESCRIPTION
typo mentioned in #942 etc