### PR TITLE
use install-sh etc from GAP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@
 /gen/
 /gh-pages/
 /libsemigroups/
-/src/pkgconfig.h.in
+/src/pkgconfig.h.in*
 /src/semigroups-config.hpp
+/config/

--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,14 @@ AC_INIT([semigroups], [GAP package])
 AC_CONFIG_SRCDIR([src/pkg.cpp])
 AC_CONFIG_HEADERS([gen/pkgconfig.h:src/pkgconfig.h.in])
 AC_CONFIG_MACRO_DIR([m4])
+dnl ##
+dnl ## Locate the GAP root dir
+dnl ##
+FIND_GAP
+cd config
+ln -s ${GAPROOT}/cnf/* .
+cd ..
+AC_CONFIG_AUX_DIR([config])
 
 AX_PREFIX_CONFIG_H([src/semigroups-config.hpp],[semigroups],[gen/pkgconfig.h])
 
@@ -28,10 +36,6 @@ AC_LANG([C++])
 
 AX_CXX_COMPILE_STDCXX_14(,[mandatory])
 
-dnl ##
-dnl ## Locate the GAP root dir
-dnl ##
-FIND_GAP
 
 dnl ##
 dnl ## Check for pthread, this seems to be required to compile with GCC


### PR DESCRIPTION
To fix the problem mentioned in https://github.com/semigroups/Semigroups/pull/937#issuecomment-1616590034, which is present on other platforms, e.g. on Debian linux:
```
$ ./configure            
...
configure: error: cannot find install-sh, install.sh, or shtool in "." "./.." "./../.."
```

This works as follows:

1) autogen.sh takes the parameter from AC_CONFIG_AUX_DIR and creates the corresnding directiry, named config/

2) ./configure finds GAP location and populates config/ with links to the contents of GAP's cnf/ directory

Note that we set `config/` to be ignored in .gitignore