### PR TITLE
Work around autoconf 2.69 bugs

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -6,3 +6,20 @@
 # Requires GNU autoconf, GNU automake and GNU libtool.
 #
 autoreconf -vif `dirname "$0"`
+
+# autoconf 2.69 has a bug where autoreconf does not copy config.guess
+# and config.sub even though configure.ac needs them, unless automake is
+# being used. We work around this by forcing a call to automake if one
+# or both of config.sub and config.guess are missing.
+if ! test -x config.guess -a -x config.sub ; then
+  automake -acf 2> /dev/null || :
+fi
+
+# There is a second bug in autoconf 2.69 where the generated configure
+# script complains about install-sh not being there (even though it does
+# not actually need it). As a workaround, we just provide an empty file
+# instead. Since newer autoconf versions such as 2.71 are not affected
+# by the bug, we add a test to limit when this workaround is applied
+if fgrep -q ac_aux_dir/install-sh configure ; then
+  touch install-sh
+fi


### PR DESCRIPTION
Resolves #943. Alternative to #946 and hence closes #946

That issue only affects people working with the git version of Semigroups (because the release tarballs bundle the required files). So it is OK if we play a bit dirty, in this case, by invoking automake and touching install-sh. 

See also the comments inside the changes for further details.

Alternatives considered:
- just require autoconf >= 2.71 and otherwise refuse to run: excludes people who can't easily get a newer autoconf; plus there is no good clean way to check the autoconf version in a script other than to parse the output of `autoconf --version` which is not meant to be human readable
- include bundled copies of those files -- simple (we use it for GAP) but those files need to be regularly updated, and you'll get complaints about why they are missing ;-)
- copy from GAP or `SOMEPREFIX/share/automake*/config.sub` some other location: a bit fragile (none of those places may have a copy; and it is not even necessarily clear what SOMEPREFIX should be).

Granted, this approach also has drawbacks, e.g. it relies on `automake` really installing these files even though it complains ("error: no proper invocation of AM_INIT_AUTOMAKE was found"); also the "fgrep" is a bit of a hack (but the consequences are easy to control: false positive will result in a harmlos "touch", false negative at worst in the user reporting yet another version of autotools affected by the bug).

In the end, any of those solutions could have been made to work "good enough" for regular devs, I just hope this particular one will work for most "regular users who for some reason want to use a git version of Semigroups" (whoever they may be ... 😁 )

CC @dimpase 