### PR TITLE
some changes of PreImages... to NC versions

### DIFF
--- a/gap/attributes/factor.gi
+++ b/gap/attributes/factor.gi
@@ -224,7 +224,7 @@ function(o, m, p)
       word := [k, -k];
     else
       epi := EpimorphismFromFreeGroup(G);
-      word := LetterRepAssocWord(PreImagesRepresentative(epi, p));
+      word := LetterRepAssocWord(PreImagesRepresentativeNC(epi, p));
     fi;
   fi;
 

--- a/gap/attributes/isorms.gi
+++ b/gap/attributes/isorms.gi
@@ -1106,14 +1106,14 @@ function(map)
   return IsOne(map[1]) and IsOne(map[2]) and ForAll(map[3], IsOne);
 end);
 
-InstallMethod(PreImagesRepresentative,
+InstallMethod(PreImagesRepresentativeNC,
 "for an RMS element under a mapping by a triple",
 FamRangeEqFamElm, [IsRMSIsoByTriple, IsReesMatrixSemigroupElement],
 function(map, x)
   return ImagesRepresentative(InverseGeneralMapping(map), x);
 end);
 
-InstallMethod(PreImagesRepresentative,
+InstallMethod(PreImagesRepresentativeNC,
 "for an RZMS element under a mapping by a triple",
 FamRangeEqFamElm, [IsRZMSIsoByTriple, IsReesZeroMatrixSemigroupElement],
 function(map, x)

--- a/init.g
+++ b/init.g
@@ -43,17 +43,17 @@ BindGlobal("LIBSEMIGROUPS_VERSION",
                                           "/.LIBSEMIGROUPS_VERSION"))));
 
 # added when addressing issue #949
-if not IsBound( PreImagesNC ) then
-    BindGlobal( "PreImagesNC", PreImages );
+if not IsBound(PreImagesNC) then
+    BindGlobal("PreImagesNC", PreImages);
 fi;
-if not IsBound( PreImagesElmNC ) then
-    BindGlobal( "PreImagesElmNC", PreImagesElm );
+if not IsBound(PreImagesElmNC) then
+    BindGlobal("PreImagesElmNC", PreImagesElm);
 fi;
-if not IsBound( PreImagesSetNC ) then
-    BindGlobal( "PreImagesSetNC", PreImagesSet );
+if not IsBound(PreImagesSetNC) then
+    BindGlobal("PreImagesSetNC", PreImagesSet);
 fi;
-if not IsBound( PreImagesRepresentativeNC ) then
-    BindGlobal( "PreImagesRepresentativeNC", PreImagesRepresentative );
+if not IsBound(PreImagesRepresentativeNC) then
+    BindGlobal("PreImagesRepresentativeNC", PreImagesRepresentative);
 fi;
 
 ReadPackage("semigroups", "gap/options.g");

--- a/init.g
+++ b/init.g
@@ -43,18 +43,18 @@ BindGlobal("LIBSEMIGROUPS_VERSION",
                                           "/.LIBSEMIGROUPS_VERSION"))));
 
 # added when addressing issue #949
-if not IsBound( PreImagesNC ) then 
-    BindGlobal( "PreImagesNC", PreImages ); 
-fi; 
-if not IsBound( PreImagesElmNC ) then 
-    BindGlobal( "PreImagesElmNC", PreImagesElm ); 
-fi; 
-if not IsBound( PreImagesSetNC ) then 
-    BindGlobal( "PreImagesSetNC", PreImagesSet ); 
-fi; 
-if not IsBound( PreImagesRepresentativeNC ) then 
-    BindGlobal( "PreImagesRepresentativeNC", PreImagesRepresentative ); 
-fi; 
+if not IsBound( PreImagesNC ) then
+    BindGlobal( "PreImagesNC", PreImages );
+fi;
+if not IsBound( PreImagesElmNC ) then
+    BindGlobal( "PreImagesElmNC", PreImagesElm );
+fi;
+if not IsBound( PreImagesSetNC ) then
+    BindGlobal( "PreImagesSetNC", PreImagesSet );
+fi;
+if not IsBound( PreImagesRepresentativeNC ) then
+    BindGlobal( "PreImagesRepresentativeNC", PreImagesRepresentative );
+fi;
 
 ReadPackage("semigroups", "gap/options.g");
 

--- a/init.g
+++ b/init.g
@@ -42,6 +42,20 @@ BindGlobal("LIBSEMIGROUPS_VERSION",
            Chomp(StringFile(Concatenation(SEMIGROUPS.PackageDir,
                                           "/.LIBSEMIGROUPS_VERSION"))));
 
+# added when addressing issue #949
+if not IsBound( PreImagesNC ) then 
+    BindGlobal( "PreImagesNC", PreImages ); 
+fi; 
+if not IsBound( PreImagesElmNC ) then 
+    BindGlobal( "PreImagesElmNC", PreImagesElm ); 
+fi; 
+if not IsBound( PreImagesSetNC ) then 
+    BindGlobal( "PreImagesSetNC", PreImagesSet ); 
+fi; 
+if not IsBound( PreImagesRepresentativeNC ) then 
+    BindGlobal( "PreImagesRepresentativeNC", PreImagesRepresentative ); 
+fi; 
+
 ReadPackage("semigroups", "gap/options.g");
 
 ReadPackage("semigroups", "gap/elements/semiringmat.gd");


### PR DESCRIPTION
This PR deals with Semigroiups issue #949 which arises from GAP PR #5073. 
Declarations of the NC versions have been made in init.g 
The two methods in gap/attributes/homomorph.gi test the input so remain non-NC. 
A call in gap/attributes.factor.gi:227 has been changes to PreImagesRepresentativeNC. 
In gap/attributes/isorms.gi:329,519 calls to PreImagesRepresentative are in tester functions, so remain non-NC. 
In gap/attributes/isorms.gi:1109,1116 Methods for PreImagesRepresentative have been changed to NC. 
No changes have been made to the doc files (isorms.xml, properties.xml, z-chap14.xml).
Tests should test, so no changes made in homomorph.tst or isorms.tst.