### PR TITLE
Set up Dependabot to update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
I've noticed warnings at e.g. https://github.com/semigroups/Semigroups/actions/runs/7628515256 node12 versus nod16 etc. etc. due to the use of the outdated `codecov/codecov-action@v2`. Using Dependabot helps avoid this by ensuring GH Actions are always used in their most up-to-date version.