### PR TITLE
Fix bug in `IrredundantGeneratingSubset`

### DIFF
--- a/gap/attributes/attr.gi
+++ b/gap/attributes/attr.gi
@@ -243,7 +243,7 @@ function(coll)
     fi;
 
     if not x in redund and not x in out then
-      if x in Semigroup(Difference(gens, [x])) then
+      if Length(gens) > 1 and x in Semigroup(Difference(gens, [x])) then
         AddSet(redund, x);
         gens := Difference(gens, [x]);
       else

--- a/tst/standard/attributes/attr.tst
+++ b/tst/standard/attributes/attr.tst
@@ -439,6 +439,28 @@ gap> S := Semigroup([Transformation([1, 1]), Transformation([1, 1])]);
 gap> Size(IrredundantGeneratingSubset(S));
 1
 
+# attr: IrredundantGeneratingSubset: for a set containing identity and 
+# a single generator, generators defined separately
+gap> gens := [Transformation([2, 1]), IdentityTransformation];;
+gap> Size(IrredundantGeneratingSubset(gens));
+1
+
+# attr: IrredundantGeneratingSubset: for a set containing identity and 
+# a single generator, generators given directly
+gap> IrredundantGeneratingSubset([Transformation([2, 1]), IdentityTransformation]);;
+
+# attr: IrredundantGeneratingSubset: for a set containing elements
+# of a cyclic semigroup along with a generator, generators defined separately
+gap> gens := [Transformation([1, 1, 3, 1]),
+> Transformation([3, 3, 1, 3])];;
+gap> Size(IrredundantGeneratingSubset(gens));
+1
+
+# attr: IrredundantGeneratingSubset: for a set containing elements
+# of a cyclic semigroup along with a generator, generators given directly
+gap> IrredundantGeneratingSubset([ Transformation( [ 1, 1, 3, 1 ] ),
+> Transformation( [ 3, 3, 1, 3 ] ) ]);;
+
 # attr: IrredundantGeneratingSubset: test info statements
 gap> S := MonogenicSemigroup(IsTransformationSemigroup, 4, 1);;
 gap> S := Semigroup(Elements(S));

--- a/tst/standard/attributes/attr.tst
+++ b/tst/standard/attributes/attr.tst
@@ -458,8 +458,8 @@ gap> Size(IrredundantGeneratingSubset(gens));
 
 # attr: IrredundantGeneratingSubset: for a set containing elements
 # of a cyclic semigroup along with a generator, generators given directly
-gap> IrredundantGeneratingSubset([ Transformation( [ 1, 1, 3, 1 ] ),
-> Transformation( [ 3, 3, 1, 3 ] ) ]);;
+gap> IrredundantGeneratingSubset([Transformation([1, 1, 3, 1]),
+> Transformation([3, 3, 1, 3])]);;
 
 # attr: IrredundantGeneratingSubset: test info statements
 gap> S := MonogenicSemigroup(IsTransformationSemigroup, 4, 1);;


### PR DESCRIPTION
Running `IrredundantGeneratingSubset` with a set of 2 generators of a cyclic semigroup currently causes issues, e.g.
```
gap> IrredundantGeneratingSubset([Transformation([2, 1]), IdentityTransformation]);
Error, Usage: cannot create a semigroup with no generators ...
gap> IrredundantGeneratingSubset([Transformation([ 1, 1, 3, 1 ]), Transformation([3, 3, 1, 3 ])]);
Error, Usage: cannot create a semigroup with no generators ...
```
What seems to happen is that the generating set gets reduced to only have 1 generator, but for some reason the check for irredundancy still gets carried out, meaning that we attempt to generate a semigroup with empty generating set, hence the error.

My fix adds a condition in the if statement that causes the error. Not sure this addresses the underlying issue with the stopping logic of the function, but it does fix the error for the two examples above, happy for any further suggestions for fixes.