### PR TITLE
ci: install libtool for macosx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: "Install dependencies (macOS only!)"
         if: ${{ runner.os == 'macOS' }}
-        run: brew install automake
+        run: brew install automake libtool
       # Setup ccache, to speed up repeated compilation of the same binaries
       # (i.e., GAP and the packages)
       - name: "Setup ccache"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         gap-branch:
           - master
           - stable-4.12
+          - stable-4.13
         ABI:
           - 64
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
           - stable-4.13
         ABI:
           - 64
+        exclude:
+          # We exclude this combination for the reasons discussed at:
+          # https://github.com/semigroups/Semigroups/pull/1015
+          # https://github.com/gap-system/gap/issues/5640
+          - os: macos
+            gap-branch: stable-4.12
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Install libtool via brew in the macosx ci job.