### PR TITLE
Fix bug in gen pairs

### DIFF
--- a/gap/congruences/conginv.gi
+++ b/gap/congruences/conginv.gi
@@ -584,5 +584,6 @@ function(C)
       od;
     od;
   od;
-  return pairs;
+  return GeneratingPairsOfSemigroupCongruence(CC);
 end);
+


### PR DESCRIPTION
The bug is that `pairs` can be unassigned if the congruence is trivial.