### PR TITLE
Use GAP kernel helper IS_STRING_REP to test for strings

### DIFF
--- a/gapbind14/include/gapbind14/to_cpp.hpp
+++ b/gapbind14/include/gapbind14/to_cpp.hpp
@@ -86,7 +86,7 @@ namespace gapbind14 {
     static gap_tnum_type constexpr gap_type = T_STRING;
 
     std::string operator()(Obj o) const {
-      if (TNUM_OBJ(o) != T_STRING) {
+      if (!IS_STRING_REP(o)) {
         throw std::runtime_error(std::string("expected string, found ")
                                  + TNAM_OBJ(o));
       }

--- a/src/to_cpp.hpp
+++ b/src/to_cpp.hpp
@@ -388,7 +388,7 @@ namespace gapbind14 {
     static gap_tnum_type constexpr gap_type = T_STRING;
 
     cpp_type operator()(Obj o) const {
-      if (TNUM_OBJ(o) != T_STRING && TNUM_OBJ(o) != T_STRING + IMMUTABLE) {
+      if (!IS_STRING_REP(o)) {
         ErrorQuit("expected string but got %s!", (Int) TNAM_OBJ(o), 0L);
       }
       std::string stype = std::string(CSTR_STRING(o));
@@ -409,7 +409,7 @@ namespace gapbind14 {
     using cpp_type = libsemigroups::Congruence::options::runners;
 
     cpp_type operator()(Obj o) const {
-      if (TNUM_OBJ(o) != T_STRING && TNUM_OBJ(o) != T_STRING + IMMUTABLE) {
+      if (!IS_STRING_REP(o)) {
         ErrorQuit("expected string but got %s!", (Int) TNAM_OBJ(o), 0L);
       }
       std::string stype = std::string(CSTR_STRING(o));


### PR DESCRIPTION
There are actually six TNUMs indicating strings.

I don't know which branch you want this to land in. I based this branch
on tag v5.4.0 so you should be able to re-target this PR if it should
go into `stable-5.4` instead of `main`.