### PR TITLE
Add Cartan matrix computation for monoids

### DIFF
--- a/doc/bibliography.xml
+++ b/doc/bibliography.xml
@@ -621,3 +621,16 @@
   <url>http://dx.doi.org/10.1016/0021-8693(77)90383-0</url>
 </article></entry>
 </file>
+
+<entry id="Balthazar2025aa"><article>
+  <author>
+    <name><first>Balthazar</first><last>Charles</last></name>
+  </author>
+  <title>Computing character tables and Cartan matrices of finite monoids with fixed point counting</title>
+  <journal>Journal of Symbolic Computation</journal>
+  <year>2025</year>
+  <volume>127</volume>
+  <pages>1--29</pages>
+  <issn>0747-7171</issn>
+  <url>https://doi.org/10.1016/j.jsc.2024.102371</url>
+</article></entry>

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -17,58 +17,58 @@
          Label = "for a semigroup"/>
     <Returns>A complete list of generalized conjugacy classes.</Returns>
     <Description>
-      <Ref Attr="GeneralizedConjugacyClasses" Label = "for a semigroup"/> 
-      returns a list of the generalized 
-      conjugacy classes of the semigroup <A>S</A>. Let <M>R</M> be a 
+      <Ref Attr="GeneralizedConjugacyClasses" Label = "for a semigroup"/>
+      returns a list of the generalized
+      conjugacy classes of the semigroup <A>S</A>. Let <M>R</M> be a
       relation on <A>S</A> such that it is the union of the set
-      <M>\{(mn,nm) | m,n \in S \}</M> and the set 
-      <M>\{(m,m^{(w+1)}) | m \in S \}</M> where <M>w</M> is 
+      <M>\{(mn,nm) | m,n \in S \}</M> and the set
+      <M>\{(m,m^{(w+1)}) | m \in S \}</M> where <M>w</M> is
       <Ref Attr="SmallestIdempotentPower"/> of <C>m</C>.
       A generalized conjugacy class is an equivalence class of the smallest
       equivalence relation that contains <M>R</M>.
-      <Ref Attr="GeneralizedConjugacyClassesRepresentatives" Label = "for a semigroup"/> 
-      returns a list of the representatives of the generalized conjugacy classes in the 
-      semigroup <A>S</A>. In a group generalized conjugacy classes coincide 
+      <Ref Attr="GeneralizedConjugacyClassesRepresentatives" Label = "for a semigroup"/>
+      returns a list of the representatives of the generalized conjugacy classes in the
+      semigroup <A>S</A>. In a group generalized conjugacy classes coincide
       with conjugacy classes.<P/>
 
       Note that each generalized conjugacy class as currently implemented
       does not store a list of elements in the conjugacy class, only the representative
       with no way to compute all the elements in the conjugacy class.
-      This means that 
-      <Ref Attr="GeneralizedConjugacyClasses" Label = "for a semigroup"/> as currently 
-      implemented is only as effective as 
+      This means that
+      <Ref Attr="GeneralizedConjugacyClasses" Label = "for a semigroup"/> as currently
+      implemented is only as effective as
       <Ref Attr="GeneralizedConjugacyClassesRepresentatives" Label = "for a semigroup"/>.
 
       <Example><![CDATA[
 gap> S := FullTransformationMonoid(6);;
 gap> GeneralizedConjugacyClassesRepresentatives(S);
-[ IdentityTransformation, Transformation( [ 1, 2, 3, 4, 6, 5 ] ), 
-  Transformation( [ 1, 2, 3, 5, 6, 4 ] ), 
-  Transformation( [ 1, 2, 4, 3, 6, 5 ] ), 
-  Transformation( [ 1, 2, 4, 5, 6, 3 ] ), 
-  Transformation( [ 1, 3, 2, 5, 6, 4 ] ), 
-  Transformation( [ 1, 3, 4, 5, 6, 2 ] ), 
-  Transformation( [ 2, 1, 4, 3, 6, 5 ] ), 
-  Transformation( [ 2, 1, 4, 5, 6, 3 ] ), 
-  Transformation( [ 2, 3, 1, 5, 6, 4 ] ), 
-  Transformation( [ 2, 3, 4, 5, 6, 1 ] ), 
-  Transformation( [ 1, 2, 3, 4, 5, 1 ] ), 
-  Transformation( [ 1, 2, 3, 5, 4, 1 ] ), 
-  Transformation( [ 1, 2, 4, 5, 3, 1 ] ), 
-  Transformation( [ 1, 3, 2, 5, 4, 1 ] ), 
-  Transformation( [ 1, 3, 4, 5, 2, 1 ] ), 
-  Transformation( [ 2, 1, 4, 5, 3, 2 ] ), 
-  Transformation( [ 2, 3, 4, 5, 1, 2 ] ), 
-  Transformation( [ 2, 2, 3, 4, 5, 2 ] ), 
-  Transformation( [ 2, 2, 3, 5, 4, 2 ] ), 
-  Transformation( [ 2, 2, 4, 5, 3, 2 ] ), 
-  Transformation( [ 3, 3, 2, 5, 4, 3 ] ), 
-  Transformation( [ 3, 3, 4, 5, 2, 3 ] ), 
-  Transformation( [ 1, 1, 3, 4, 3, 1 ] ), 
-  Transformation( [ 1, 1, 4, 3, 4, 1 ] ), 
-  Transformation( [ 3, 3, 4, 1, 4, 3 ] ), 
-  Transformation( [ 1, 2, 2, 1, 2, 1 ] ), 
-  Transformation( [ 2, 1, 1, 2, 1, 2 ] ), 
+[ IdentityTransformation, Transformation( [ 1, 2, 3, 4, 6, 5 ] ),
+  Transformation( [ 1, 2, 3, 5, 6, 4 ] ),
+  Transformation( [ 1, 2, 4, 3, 6, 5 ] ),
+  Transformation( [ 1, 2, 4, 5, 6, 3 ] ),
+  Transformation( [ 1, 3, 2, 5, 6, 4 ] ),
+  Transformation( [ 1, 3, 4, 5, 6, 2 ] ),
+  Transformation( [ 2, 1, 4, 3, 6, 5 ] ),
+  Transformation( [ 2, 1, 4, 5, 6, 3 ] ),
+  Transformation( [ 2, 3, 1, 5, 6, 4 ] ),
+  Transformation( [ 2, 3, 4, 5, 6, 1 ] ),
+  Transformation( [ 1, 2, 3, 4, 5, 1 ] ),
+  Transformation( [ 1, 2, 3, 5, 4, 1 ] ),
+  Transformation( [ 1, 2, 4, 5, 3, 1 ] ),
+  Transformation( [ 1, 3, 2, 5, 4, 1 ] ),
+  Transformation( [ 1, 3, 4, 5, 2, 1 ] ),
+  Transformation( [ 2, 1, 4, 5, 3, 2 ] ),
+  Transformation( [ 2, 3, 4, 5, 1, 2 ] ),
+  Transformation( [ 2, 2, 3, 4, 5, 2 ] ),
+  Transformation( [ 2, 2, 3, 5, 4, 2 ] ),
+  Transformation( [ 2, 2, 4, 5, 3, 2 ] ),
+  Transformation( [ 3, 3, 2, 5, 4, 3 ] ),
+  Transformation( [ 3, 3, 4, 5, 2, 3 ] ),
+  Transformation( [ 1, 1, 3, 4, 3, 1 ] ),
+  Transformation( [ 1, 1, 4, 3, 4, 1 ] ),
+  Transformation( [ 3, 3, 4, 1, 4, 3 ] ),
+  Transformation( [ 1, 2, 2, 1, 2, 1 ] ),
+  Transformation( [ 2, 1, 1, 2, 1, 2 ] ),
   Transformation( [ 1, 1, 1, 1, 1, 1 ] ) ]
 ]]></Example>
     </Description>
@@ -81,21 +81,21 @@ gap> GeneralizedConjugacyClassesRepresentatives(S);
          Label = "for a D-classs"/>
     <Returns>A matrix of non-negative integers.</Returns>
     <Description>
-      <Ref Attr="DClassBicharacter" Label="for a D-classs"/> returns a matrix whose 
-      <C>i</C>th row and <C>j</C>th column entry is the size of the set 
-      <M>\{m \in D | hmk = m \}</M> where <C>h</C> is an element in the <C>i</C>th 
-      generalized conjugacy class of the <Ref Attr="Parent" BookName = "ref"/> monoid of <A>D</A> 
-      and <C>k</C> is an element in the <C>j</C>th generalized conjugacy class of the 
-      <Ref Attr="Parent" BookName = "ref"/> monoid of <A>D</A>. The order of the generalized conjugacy classes of the 
-      <Ref Attr="Parent" BookName = "ref"/> monoid of <A>D</A> is determined by the list returned by the attribute 
-      <Ref Attr="GeneralizedConjugacyClasses" Label="for a semigroup"/> of the <Ref Attr="Parent" BookName = "ref"/> 
+      <Ref Attr="DClassBicharacter" Label="for a D-classs"/> returns a matrix whose
+      <C>i</C>th row and <C>j</C>th column entry is the size of the set
+      <M>\{m \in D | hmk = m \}</M> where <C>h</C> is an element in the <C>i</C>th
+      generalized conjugacy class of the <Ref Attr="Parent" BookName = "ref"/> monoid of <A>D</A>
+      and <C>k</C> is an element in the <C>j</C>th generalized conjugacy class of the
+      <Ref Attr="Parent" BookName = "ref"/> monoid of <A>D</A>. The order of the generalized conjugacy classes of the
+      <Ref Attr="Parent" BookName = "ref"/> monoid of <A>D</A> is determined by the list returned by the attribute
+      <Ref Attr="GeneralizedConjugacyClasses" Label="for a semigroup"/> of the <Ref Attr="Parent" BookName = "ref"/>
       monoid of <A>D</A>.
 
       <Example><![CDATA[
 gap> S := FullTransformationMonoid(3);;
 gap> D := DClasses(S)[1];;
 gap> DClassBicharacter(D);
-[ [ 6, 0, 0, 0, 0, 0 ], [ 0, 2, 0, 0, 0, 0 ], [ 0, 0, 3, 0, 0, 0 ], 
+[ [ 6, 0, 0, 0, 0, 0 ], [ 0, 2, 0, 0, 0, 0 ], [ 0, 0, 3, 0, 0, 0 ],
   [ 0, 0, 0, 0, 0, 0 ], [ 0, 0, 0, 0, 0, 0 ], [ 0, 0, 0, 0, 0, 0 ] ]]]>
   </Example>
     </Description>
@@ -108,20 +108,20 @@ gap> DClassBicharacter(D);
          Label = "for a semigroup"/>
     <Returns>A matrix of non-negative integers.</Returns>
     <Description>
-      <Ref Attr="RegularRepresentationBicharacter" Label="for a semigroup"/> 
-      returns a matrix whose <C>i</C>th row 
-      and <C>j</C>th column entry is the size of the set 
-      <M>\{m \in <A>S</A> | hmk = m \}</M> where <M>h</M> is an element in the 
-      <C>i</C>th generalized conjugacy class of <A>S</A> and <M>k</M> is an element 
-      in the <C>j</C>th generalized conjugacy class of <A>S</A>. The order of the 
-      generalized conjugacy classes of <A>S</A> is determined by the list returned 
-      by the attribute 
+      <Ref Attr="RegularRepresentationBicharacter" Label="for a semigroup"/>
+      returns a matrix whose <C>i</C>th row
+      and <C>j</C>th column entry is the size of the set
+      <M>\{m \in <A>S</A> | hmk = m \}</M> where <M>h</M> is an element in the
+      <C>i</C>th generalized conjugacy class of <A>S</A> and <M>k</M> is an element
+      in the <C>j</C>th generalized conjugacy class of <A>S</A>. The order of the
+      generalized conjugacy classes of <A>S</A> is determined by the list returned
+      by the attribute
       <Ref Attr="GeneralizedConjugacyClasses" Label="for a semigroup"/> of <A>S</A>.
 
       <Example><![CDATA[
 gap> S := FullTransformationMonoid(3);;
 gap> RegularRepresentationBicharacter(S);
-[ [ 27, 1, 0, 8, 0, 1 ], [ 9, 3, 0, 4, 0, 1 ], [ 3, 1, 3, 2, 0, 1 ], 
+[ [ 27, 1, 0, 8, 0, 1 ], [ 9, 3, 0, 4, 0, 1 ], [ 3, 1, 3, 2, 0, 1 ],
   [ 9, 1, 0, 4, 0, 1 ], [ 3, 3, 0, 2, 2, 1 ], [ 3, 1, 0, 2, 0, 1 ] ]]]>
   </Example>
     </Description>
@@ -134,19 +134,19 @@ gap> RegularRepresentationBicharacter(S);
          Label = "for a group H-class"/>
     <Returns>A matrix of non-negative integers.</Returns>
     <Description>
-      <Ref Attr="RClassBicharacterOfGroupHClass" Label="for a group H-class"/> 
-      returns a matrix whose <C>i</C>th row 
-      and <C>j</C>th column entry is the size of the set 
-      <M>\{m \in R | hmk = m \}</M> where <C>R</C> is the <Ref Meth="RClassOfHClass"/> of 
-      <A>H</A>. Furthermore, <M>h</M> is an element in the <C>i</C>th generalized 
-      conjugacy class of <A>H</A> as a group and <M>k</M> is an element in the 
-      <C>j</C>th generalized conjugacy class of the <Ref Attr="Parent" BookName = "ref"/> semigroup of <A>H</A>. The order 
-      of the generalized conjugacy classes of the <Ref Attr="Parent" BookName = "ref"/> semigroup of <A>H</A> is determined 
-      by the list returned by the attribute 
-      <Ref Attr="GeneralizedConjugacyClasses" Label="for a semigroup"/> of 
-      the <Ref Attr="Parent" BookName = "ref"/> semigroup of <A>H</A>. The order of the generalized conjugacy classes of 
-      <A>H</A> is determined by the list returned by the attribute 
-      <Ref Attr = "ConjugacyClasses" BookName = "ref"/> of <Ref Attr = "OrdinaryCharacterTable" BookName = "ref"/> of 
+      <Ref Attr="RClassBicharacterOfGroupHClass" Label="for a group H-class"/>
+      returns a matrix whose <C>i</C>th row
+      and <C>j</C>th column entry is the size of the set
+      <M>\{m \in R | hmk = m \}</M> where <C>R</C> is the <Ref Meth="RClassOfHClass"/> of
+      <A>H</A>. Furthermore, <M>h</M> is an element in the <C>i</C>th generalized
+      conjugacy class of <A>H</A> as a group and <M>k</M> is an element in the
+      <C>j</C>th generalized conjugacy class of the <Ref Attr="Parent" BookName = "ref"/> semigroup of <A>H</A>. The order
+      of the generalized conjugacy classes of the <Ref Attr="Parent" BookName = "ref"/> semigroup of <A>H</A> is determined
+      by the list returned by the attribute
+      <Ref Attr="GeneralizedConjugacyClasses" Label="for a semigroup"/> of
+      the <Ref Attr="Parent" BookName = "ref"/> semigroup of <A>H</A>. The order of the generalized conjugacy classes of
+      <A>H</A> is determined by the list returned by the attribute
+      <Ref Attr = "ConjugacyClasses" BookName = "ref"/> of <Ref Attr = "OrdinaryCharacterTable" BookName = "ref"/> of
       <Ref Attr = "Range" BookName = "ref"/> of <Ref Attr="IsomorphismPermGroup"/> of <A>H</A>.
 
       <Example><![CDATA[
@@ -166,19 +166,19 @@ gap> RClassBicharacterOfGroupHClass(H);
          Label = "for a semigroup"/>
     <Returns>A matrix.</Returns>
     <Description>
-      <Ref Attr="BlockDiagonalMatrixOfCharacterTables" Label="for a semigroup"/> 
-      returns a block diagonal matrix which has a mmatrix block for each 
-      regular &D;-class of <A>S</A>. The block matrices along the diagonal are 
-      character tables of some group &H;-classes in each regular &D;-class of 
-      <A>S</A>. The character tables are determined by 
-      <Ref Attr = "OrdinaryCharacterTable" BookName = "ref"/> of 
+      <Ref Attr="BlockDiagonalMatrixOfCharacterTables" Label="for a semigroup"/>
+      returns a block diagonal matrix which has a mmatrix block for each
+      regular &D;-class of <A>S</A>. The block matrices along the diagonal are
+      character tables of some group &H;-classes in each regular &D;-class of
+      <A>S</A>. The character tables are determined by
+      <Ref Attr = "OrdinaryCharacterTable" BookName = "ref"/> of
       <Ref Attr = "Range" BookName = "ref"/> of <Ref Attr="IsomorphismPermGroup"/>
-      of <Ref Attr="GroupHClass"/> of <Ref Attr="RegularDClasses"/> of <A>S</A>. 
+      of <Ref Attr="GroupHClass"/> of <Ref Attr="RegularDClasses"/> of <A>S</A>.
 
       <Example><![CDATA[
 gap> S := FullTransformationMonoid(3);;
 gap> BlockDiagonalMatrixOfCharacterTables(S);
-[ [ 1, -1, 1, 0, 0, 0 ], [ 2, 0, -1, 0, 0, 0 ], [ 1, 1, 1, 0, 0, 0 ], 
+[ [ 1, -1, 1, 0, 0, 0 ], [ 2, 0, -1, 0, 0, 0 ], [ 1, 1, 1, 0, 0, 0 ],
   [ 0, 0, 0, 1, -1, 0 ], [ 0, 0, 0, 1, 1, 0 ], [ 0, 0, 0, 0, 0, 1 ] ]]]>
   </Example>
     </Description>
@@ -191,9 +191,9 @@ gap> BlockDiagonalMatrixOfCharacterTables(S);
     <Returns>The character table object for <A>M</A> over <A>F</A>.</Returns>
     <Description>
       Called with a finite monoid <A>M</A> and optionally a field <A>F</A>,
-      <Ref Attr="MonoidCharacterTable"/> returns the character table of the 
-      monoid which is defined as the matrix <M>Trace(X(m))</M>, where <M>X</M> 
-      runs over the simple <M>FM</M>-modules and <M>m</M> runs over the 
+      <Ref Attr="MonoidCharacterTable"/> returns the character table of the
+      monoid which is defined as the matrix <M>Trace(X(m))</M>, where <M>X</M>
+      runs over the simple <M>FM</M>-modules and <M>m</M> runs over the
       generalized conjugacy class representatives of <A>M</A>.<P/>
 
       To get the character table of a monoid to display like the example below,
@@ -201,11 +201,11 @@ gap> BlockDiagonalMatrixOfCharacterTables(S);
       <Ref Attr="Irr" Label="for a monoid character table"/>.<P/>
 
       If <A>F</A> is not given, then
-      <Ref Attr="MonoidCharacterTable"/> returns the character table of 
+      <Ref Attr="MonoidCharacterTable"/> returns the character table of
       <M>M</M> over a characteristic zero splitting field of <A>M</A>.<P/>
 
       At the moment, methods are available for the following cases:
-      if <A>F</A> is not given (i.e. it defaults to a splitting field of 
+      if <A>F</A> is not given (i.e. it defaults to a splitting field of
       <A>M</A> over the rationals) and <A>M</A> is a finite monoid.<P/>
 
       For other cases no methods are implemented yet.<P/>
@@ -216,7 +216,7 @@ gap> ct := MonoidCharacterTable(S);;
 gap> Irr(ct);;
 gap> Display(ct);
     c.1 c.2 c.3 c.4 c.5 c.6
-                           
+
 X.1   1  -1   1   .   .   .
 X.2   2   .  -1   .   .   .
 X.3   1   1   1   .   .   .
@@ -234,27 +234,36 @@ X.6   1   1   1   1   1   1
          Label = "for a monoid character table"/>
     <Returns>A list of monoid characters.</Returns>
     <Description>
-      <Ref Attr="Irr" Label="for a monoid character table"/> returns a list of 
-      the characters of the irreducible representations of the <Ref Attr="Parent" BookName = "ref"/> monoid 
+      <Ref Attr="Irr" Label="for a monoid character table"/> returns a list of
+      the characters of the irreducible representations of the <Ref Attr="Parent" BookName = "ref"/> monoid
       of the monoid character table <A>T</A>.
 
       <!-- The following example is a log because the values in the vectors and
       the presentation of the monoid display inconsistently -->
-      <Log><![CDATA[
-gap> M := FullBooleanMatMonoid(2);
-<monoid of 2x2 boolean matrices with 3 generators>
+      <Example><![CDATA[
+gap> M := FullBooleanMatMonoid(2);;
 gap> ct := MonoidCharacterTable(M);;
 gap> Irr(ct);
-[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 1, 1, 1, 1, 1 ] ),
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 1, 2, 3, 1 ] ),
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 1, 2, 0 ] ),
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, -1 ] ),
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ]]]></Log>
+[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat\
+, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true\
+, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], \
+[ false, false ] ]) ] ) ) , [ 1, 1, 1, 1, 1 ] ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat\
+, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true\
+, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], \
+[ false, false ] ]) ] ) ) , [ 0, 1, 2, 3, 1 ] ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat\
+, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true\
+, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], \
+[ false, false ] ]) ] ) ) , [ 0, 0, 1, 2, 0 ] ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat\
+, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true\
+, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], \
+[ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, -1 ] ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat\
+, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true\
+, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], \
+[ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ]]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -265,9 +274,9 @@ at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ]]]></Log
     <Returns>An object.</Returns>
     <Description>
       Called with a finite monoid <A>M</A> and a field <A>F</A>,
-      <Ref Attr="MonoidCartanMatrix"/> returns the Cartan matrix of the monoid 
+      <Ref Attr="MonoidCartanMatrix"/> returns the Cartan matrix of the monoid
       algebra <M>FM</M> which is defined as the matrix
-      <M>dim Hom(P,Q)/dim End(P / rad(FM))</M>, where <M>P</M> and <M>Q</M> 
+      <M>dim Hom(P,Q)/dim End(P / rad(FM))</M>, where <M>P</M> and <M>Q</M>
       run over the right indecomposable projective modules of FM.<P/>
 
       To get the Cartan matrix of a monoid to display like the example below,
@@ -275,12 +284,12 @@ at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ]]]></Log
       <Ref Attr="Pims" Label="for a monoid cartan matrix"/>.<P/>
 
       If <A>M</A> is the only argument then
-      <Ref Attr="MonoidCartanMatrix"/> returns the Cartan matrix of the monoid 
-      algebra <M>FM</M>, where <A>F</A> is a splitting field of <A>M</A> over 
+      <Ref Attr="MonoidCartanMatrix"/> returns the Cartan matrix of the monoid
+      algebra <M>FM</M>, where <A>F</A> is a splitting field of <A>M</A> over
       the rationals.<P/>
 
       At the moment, methods are available for the following cases:
-      if <A>F</A> is not given (i.e. it defaults to a splitting field of <A>M</A> 
+      if <A>F</A> is not given (i.e. it defaults to a splitting field of <A>M</A>
       over the rationals) and <A>M</A> is a finite monoid.<P/>
 
       For other cases no methods are implemented yet.<P/>
@@ -291,7 +300,7 @@ gap> cm := MonoidCartanMatrix(S);;
 gap> Pims(cm);;
 gap> Display(cm);
     X.1 X.2 X.3 X.4 X.5 X.6
-                           
+
 P.1   1   .   .   .   .   .
 P.2   .   1   .   .   .   .
 P.3   1   .   1   1   .   .
@@ -309,32 +318,56 @@ P.6   .   .   .   1   .   1
          Label = "for a monoid cartan matrix"/>
     <Returns>A list of monoid characters.</Returns>
     <Description>
-      <Ref Attr="Pims" Label="for a monoid cartan matrix"/> returns a 
-      list of the characters of the projective indecomposable 
+      <Ref Attr="Pims" Label="for a monoid cartan matrix"/> returns a
+      list of the characters of the projective indecomposable
       modules of the <Ref Attr="Parent" BookName = "ref"/> monoid of the monoid character table <A>T</A>.
 
       <!-- The following example is a log because the values in the vectors and
       the presentation of the monoid display inconsistently -->
-      <Log><![CDATA[
-gap> M := FullBooleanMatMonoid(2);
-<monoid of 2x2 boolean matrices with 3 generators>
+      <Example><![CDATA[
+gap> M := FullBooleanMatMonoid(2);;
 gap> cm := MonoidCartanMatrix(M);;
 gap> Pims(cm);
-[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
-IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 1, 1, 1, 1, 1 ] ) ),
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
-IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 1, 2, 3, 1 ] ) ),
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
-IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 1, 2, 0 ] ) ),
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
-IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, -1 ] ) ),
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
-IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ) ]]]></Log>
+[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat\
+, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true\
+, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], \
+[ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( Monoi\
+dCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ t\
+rue, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true \
+] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , [ 1, 1, 1, 1, 1 ] ) ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat\
+, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true\
+, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], \
+[ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( Monoi\
+dCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ t\
+rue, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true \
+] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , [ 0, 1, 2, 3, 1 ] ) ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat\
+, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true\
+, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], \
+[ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( Monoi\
+dCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ t\
+rue, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true \
+] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , [ 0, 0, 1, 2, 0 ] ) ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat\
+, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true\
+, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], \
+[ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( Monoi\
+dCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ t\
+rue, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true \
+] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , [ 0, 0, 0, 1, -1 ] ) ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat\
+, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true\
+, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], \
+[ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( Monoi\
+dCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ t\
+rue, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true \
+] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , [ 0, 0, 0, 1, 1 ] ) ) ]]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -238,7 +238,7 @@ X.6   1   1   1   1   1   1
       the characters of the irreducible representations of the parent monoid 
       of the monoid character table <A>T</A>.
 
-      <Example><![CDATA[
+      <Log><![CDATA[
 gap> M := FullBooleanMatMonoid(2);
 <monoid of 2x2 boolean matrices with 3 generators>
 gap> ct := MonoidCharacterTable(M);;
@@ -252,7 +252,7 @@ at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 1, 2, 0 ] ),
   MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
 at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, -1 ] ),
   MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ]]]></Example>
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ]]]></Log>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -311,7 +311,7 @@ P.6   .   .   .   1   .   1
       list of the characters of the projective indecomposable 
       modules of the parent monoid of the monoid character table <A>T</A>.
 
-      <Example><![CDATA[
+      <Log><![CDATA[
 gap> M := FullBooleanMatMonoid(2);
 <monoid of 2x2 boolean matrices with 3 generators>
 gap> cm := MonoidCartanMatrix(M);;
@@ -330,7 +330,7 @@ at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCha
 IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, -1 ] ) ),
   MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
 at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
-IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ) ]]]></Example>
+IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ) ]]]></Log>
     </Description>
   </ManSection>
 <#/GAPDoc>

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -87,7 +87,7 @@ gap> GeneralizedConjugacyClassesRepresentatives(S);
       generalized conjugacy class of the parent monoid of <A>D</A> 
       and <C>k</C> is an element in the <C>j</C>th generalized conjugacy class of the 
       parent monoid of <A>D</A>. The order of the generalized conjugacy classes of the 
-      <Ref Attr="ParentAttr"/> of <A>D</A> is determined by the list returned by the attribute 
+      <Ref Attr="ParentAttr" BookName = "ref"/> of <A>D</A> is determined by the list returned by the attribute 
       <Ref Attr="GeneralizedConjugacyClasses" Label="for a semigroup"/> of the parent 
       monoid of <A>D</A>.
 

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -87,7 +87,7 @@ gap> GeneralizedConjugacyClassesRepresentatives(S);
       generalized conjugacy class of the parent monoid of <A>D</A> 
       and <C>k</C> is an element in the <C>j</C>th generalized conjugacy class of the 
       parent monoid of <A>D</A>. The order of the generalized conjugacy classes of the 
-      parent monoid of <A>D</A> is determined by the list returned by the attribute 
+      <Ref Attr="ParentAttr"/> of <A>D</A> is determined by the list returned by the attribute 
       <Ref Attr="GeneralizedConjugacyClasses" Label="for a semigroup"/> of the parent 
       monoid of <A>D</A>.
 

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -1,0 +1,336 @@
+#############################################################################
+##
+#W  cartan.xml
+#Y  Copyright (C) 2024                                   Balthazar Charles
+##                                                             Joseph Ruiz
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+
+<#GAPDoc Label="GeneralizedConjugacyClasses">
+  <ManSection>
+    <Attr Name ="GeneralizedConjugacyClasses" Arg="S"
+         Label = "for a semigroup"/>
+    <Attr Name ="GeneralizedConjugacyClassesRepresentatives" Arg="S"
+         Label = "for a semigroup"/>
+    <Returns>A complete list of generalized conjugacy classes.</Returns>
+    <Description>
+      <Ref Attr="GeneralizedConjugacyClasses" Label = "for a semigroup"/> 
+      returns a list of the generalized 
+      conjugacy classes of the semigroup <A>S</A>. Let <M>R</M> be a 
+      relation on <A>S</A> such that it is the union of the set
+      <M>\{(mn,nm) | m,n \in S \}</M> and the set 
+      <M>\{(m,m^{(w+1)}) | m \in S \}</M> where <M>w</M> is 
+      <Ref Attr="SmallestIdempotentPower"/> of <C>m</C>.
+      A generalized conjugacy class is an equivalence class of the smallest
+      equivalence relation that contains <M>R</M>.
+      <Ref Attr="GeneralizedConjugacyClassesRepresentatives" Label = "for a semigroup"/> 
+      returns a list of the representatives of the generalized conjugacy classes in the 
+      semigroup <A>S</A>. In a group generalized conjugacy classes coincide 
+      with conjugacy classes.<P/>
+
+      Note that each generalized conjugacy class as currently implemented
+      does not store a list of elements in the conjugacy class, only the representative
+      with no way to compute all the elements in the conjugacy class.
+      This means that 
+      <Ref Attr="GeneralizedConjugacyClasses" Label = "for a semigroup"/> as currently 
+      implemented is only as effective as 
+      <Ref Attr="GeneralizedConjugacyClassesRepresentatives" Label = "for a semigroup"/>.
+
+      <Example><![CDATA[
+gap> S := FullTransformationMonoid(6);;
+gap> GeneralizedConjugacyClassesRepresentatives(S);
+[ IdentityTransformation, Transformation( [ 1, 2, 3, 4, 6, 5 ] ), 
+  Transformation( [ 1, 2, 3, 5, 6, 4 ] ), 
+  Transformation( [ 1, 2, 4, 3, 6, 5 ] ), 
+  Transformation( [ 1, 2, 4, 5, 6, 3 ] ), 
+  Transformation( [ 1, 3, 2, 5, 6, 4 ] ), 
+  Transformation( [ 1, 3, 4, 5, 6, 2 ] ), 
+  Transformation( [ 2, 1, 4, 3, 6, 5 ] ), 
+  Transformation( [ 2, 1, 4, 5, 6, 3 ] ), 
+  Transformation( [ 2, 3, 1, 5, 6, 4 ] ), 
+  Transformation( [ 2, 3, 4, 5, 6, 1 ] ), 
+  Transformation( [ 1, 2, 3, 4, 5, 1 ] ), 
+  Transformation( [ 1, 2, 3, 5, 4, 1 ] ), 
+  Transformation( [ 1, 2, 4, 5, 3, 1 ] ), 
+  Transformation( [ 1, 3, 2, 5, 4, 1 ] ), 
+  Transformation( [ 1, 3, 4, 5, 2, 1 ] ), 
+  Transformation( [ 2, 1, 4, 5, 3, 2 ] ), 
+  Transformation( [ 2, 3, 4, 5, 1, 2 ] ), 
+  Transformation( [ 2, 2, 3, 4, 5, 2 ] ), 
+  Transformation( [ 2, 2, 3, 5, 4, 2 ] ), 
+  Transformation( [ 2, 2, 4, 5, 3, 2 ] ), 
+  Transformation( [ 3, 3, 2, 5, 4, 3 ] ), 
+  Transformation( [ 3, 3, 4, 5, 2, 3 ] ), 
+  Transformation( [ 1, 1, 3, 4, 3, 1 ] ), 
+  Transformation( [ 1, 1, 4, 3, 4, 1 ] ), 
+  Transformation( [ 3, 3, 4, 1, 4, 3 ] ), 
+  Transformation( [ 1, 2, 2, 1, 2, 1 ] ), 
+  Transformation( [ 2, 1, 1, 2, 1, 2 ] ), 
+  Transformation( [ 1, 1, 1, 1, 1, 1 ] ) ]
+]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="DClassBicharacter">
+  <ManSection>
+    <Attr Name ="DClassBicharacter" Arg="D"
+         Label = "for a D-classs"/>
+    <Returns>A matrix of non-negative integers.</Returns>
+    <Description>
+      <Ref Attr="DClassBicharacter" Label="for a D-classs"/> returns a matrix whose 
+      <C>i</C>th row and <C>j</C>th column entry is the size of the set 
+      <M>\{m \in D | hmk = m \}</M> where <C>h</C> is an element in the <C>i</C>th 
+      generalized conjugacy class of the parent monoid of <A>D</A> 
+      and <C>k</C> is an element in the <C>j</C>th generalized conjugacy class of the 
+      parent monoid of <A>D</A>. The order of the generalized conjugacy classes of the 
+      parent monoid of <A>D</A> is determined by the list returned by the attribute 
+      <Ref Attr="GeneralizedConjugacyClasses" Label="for a semigroup"/> of the parent 
+      monoid of <A>D</A>.
+
+      <Example><![CDATA[
+gap> S := FullTransformationMonoid(3);;
+gap> D := DClasses(S)[1];;
+gap> DClassBicharacter(D);
+[ [ 6, 0, 0, 0, 0, 0 ], [ 0, 2, 0, 0, 0, 0 ], [ 0, 0, 3, 0, 0, 0 ], 
+  [ 0, 0, 0, 0, 0, 0 ], [ 0, 0, 0, 0, 0, 0 ], [ 0, 0, 0, 0, 0, 0 ] ]]]>
+  </Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="RegularRepresentationBicharacter">
+  <ManSection>
+    <Attr Name ="RegularRepresentationBicharacter" Arg="S"
+         Label = "for a semigroup"/>
+    <Returns>A matrix of non-negative integers.</Returns>
+    <Description>
+      <Ref Attr="RegularRepresentationBicharacter" Label="for a semigroup"/> 
+      returns a matrix whose <C>i</C>th row 
+      and <C>j</C>th column entry is the size of the set 
+      <M>\{m \in <A>S</A> | hmk = m \}</M> where <M>h</M> is an element in the 
+      <C>i</C>th generalized conjugacy class of <A>S</A> and <M>k</M> is an element 
+      in the <C>j</C>th generalized conjugacy class of <A>S</A>. The order of the 
+      generalized conjugacy classes of <A>S</A> is determined by the list returned 
+      by the attribute 
+      <Ref Attr="GeneralizedConjugacyClasses" Label="for a semigroup"/> of <A>S</A>.
+
+      <Example><![CDATA[
+gap> S := FullTransformationMonoid(3);;
+gap> RegularRepresentationBicharacter(S);
+[ [ 27, 1, 0, 8, 0, 1 ], [ 9, 3, 0, 4, 0, 1 ], [ 3, 1, 3, 2, 0, 1 ], 
+  [ 9, 1, 0, 4, 0, 1 ], [ 3, 3, 0, 2, 2, 1 ], [ 3, 1, 0, 2, 0, 1 ] ]]]>
+  </Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="RClassBicharacterOfGroupHClass">
+  <ManSection>
+    <Attr Name ="RClassBicharacterOfGroupHClass" Arg="H"
+         Label = "for a group H-class"/>
+    <Returns>A matrix of non-negative integers.</Returns>
+    <Description>
+      <Ref Attr="RClassBicharacterOfGroupHClass" Label="for a group H-class"/> 
+      returns a matrix whose <C>i</C>th row 
+      and <C>j</C>th column entry is the size of the set 
+      <M>\{m \in R | hmk = m \}</M> where <C>R</C> is the <Ref Meth="RClassOfHClass"/> of 
+      <A>H</A>. Furthermore, <M>h</M> is an element in the <C>i</C>th generalized 
+      conjugacy class of <A>H</A> as a group and <M>k</M> is an element in the 
+      <C>j</C>th generalized conjugacy class of the parent semigroup of <A>H</A>. The order 
+      of the generalized conjugacy classes of the parent semigroup of <A>H</A> is determined 
+      by the list returned by the attribute 
+      <Ref Attr="GeneralizedConjugacyClasses" Label="for a semigroup"/> of 
+      the parent semigroup of <A>H</A>. The order of the generalized conjugacy classes of 
+      <A>H</A> is determined by the list returned by the attribute 
+      <Ref Attr = "ConjugacyClasses" BookName = "ref"/> of <Ref Attr = "OrdinaryCharacterTable" BookName = "ref"/> of 
+      <Ref Attr = "Range" BookName = "ref"/> of <Ref Attr="IsomorphismPermGroup"/> of <A>H</A>.
+
+      <Example><![CDATA[
+gap> S := FullTransformationMonoid(3);;
+gap> D := RegularDClasses(S)[1];;
+gap> H := GroupHClass(D);;
+gap> RClassBicharacterOfGroupHClass(H);
+[ [ 6, 0, 0, 0, 0, 0 ], [ 0, 2, 0, 0, 0, 0 ], [ 0, 0, 3, 0, 0, 0 ] ]]]>
+</Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="BlockDiagonalMatrixOfCharacterTables">
+  <ManSection>
+    <Attr Name ="BlockDiagonalMatrixOfCharacterTables" Arg="S"
+         Label = "for a semigroup"/>
+    <Returns>A matrix.</Returns>
+    <Description>
+      <Ref Attr="BlockDiagonalMatrixOfCharacterTables" Label="for a semigroup"/> 
+      returns a block diagonal matrix whose
+      block matrices along the diagonal are character tables of some group &H;-classes 
+      in each regular &D;-class of <A>S</A>.
+      The character tables are determined by 
+      <Ref Attr = "OrdinaryCharacterTable" BookName = "ref"/> of 
+      <Ref Attr = "Range" BookName = "ref"/> of <Ref Attr="IsomorphismPermGroup"/>
+      of <Ref Attr="GroupHClass"/> of <Ref Attr="RegularDClasses"/> of <A>S</A>. 
+
+      <Example><![CDATA[
+gap> S := FullTransformationMonoid(3);;
+gap> BlockDiagonalMatrixOfCharacterTables(S);
+[ [ 1, -1, 1, 0, 0, 0 ], [ 2, 0, -1, 0, 0, 0 ], [ 1, 1, 1, 0, 0, 0 ], 
+  [ 0, 0, 0, 1, -1, 0 ], [ 0, 0, 0, 1, 1, 0 ], [ 0, 0, 0, 0, 0, 1 ] ]]]>
+  </Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="MonoidCharacterTable">
+  <ManSection>
+    <Attr Name="MonoidCharacterTable" Arg='M[, F]'/>
+    <Returns>The character table object for <A>M</A> over <A>F</A>.</Returns>
+    <Description>
+      Called with a finite monoid <A>M</A> and optionally a field <A>F</A>,
+      <Ref Attr="MonoidCharacterTable"/> returns the character table of the 
+      monoid which is defined as the matrix <M>Trace(X(m))</M>, where <M>X</M> 
+      runs over the simple <M>FM</M>-modules and <M>m</M> runs over the 
+      generalized conjugacy class representatives of <A>M</A>.<P/>
+
+      To get the character table of a monoid to display like the example below,
+      the irreducible characters need to be computed first using
+      <Ref Attr="Irr" Label="for a monoid character table"/>.<P/>
+
+      If <A>F</A> is not given, then
+      <Ref Attr="MonoidCharacterTable"/> returns the character table of 
+      <M>M</M> over a characteristic zero splitting field of <A>M</A>.<P/>
+
+      At the moment, methods are available for the following cases:
+      if <A>F</A> is not given (i.e. it defaults to a splitting field of 
+      <A>M</A> over the rationals) and <A>M</A> is a finite monoid.<P/>
+
+      For other cases no methods are implemented yet.<P/>
+
+      <Example><![CDATA[
+gap> S := FullTransformationMonoid(3);;
+gap> ct := MonoidCharacterTable(S);;
+gap> Irr(ct);;
+gap> Display(ct);
+    c.1 c.2 c.3 c.4 c.5 c.6
+                           
+X.1   1  -1   1   .   .   .
+X.2   2   .  -1   .   .   .
+X.3   1   1   1   .   .   .
+X.4   2   .  -1   1  -1   .
+X.5   3   1   .   1   1   .
+X.6   1   1   1   1   1   1
+]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="Irr">
+  <ManSection>
+    <Attr Name ="Irr" Arg="T"
+         Label = "for a monoid character table"/>
+    <Returns>A list of monoid characters.</Returns>
+    <Description>
+      <Ref Attr="Irr" Label="for a monoid character table"/> returns a list of 
+      the characters of the irreducible representations of the parent monoid 
+      of the monoid character table <A>T</A>.
+
+      <Log><![CDATA[
+gap> M := FullBooleanMatMonoid(2);
+<monoid of 2x2 boolean matrices with 3 generators>
+gap> ct := MonoidCharacterTable(M);;
+gap> Irr(ct);
+[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 1, 1, 1, 1, 1 ] ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 1, 2, 3, 1 ] ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 1, 2, 0 ] ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, -1 ] ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ]]]></Log>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="MonoidCartanMatrix">
+  <ManSection>
+    <Attr Name="MonoidCartanMatrix" Arg='M[, F]'/>
+    <Returns>An object.</Returns>
+    <Description>
+      Called with a finite monoid <A>M</A> and a field <A>F</A>,
+      <Ref Attr="MonoidCartanMatrix"/> returns the Cartan matrix of the monoid 
+      algebra <M>FM</M> which is defined as the matrix
+      <M>dim Hom(P,Q)/dim End(P / rad(FM))</M>, where <M>P</M> and <M>Q</M> 
+      run over the right indecomposable projective modules of FM.<P/>
+
+      To get the Cartan matrix of a monoid to display like the example below,
+      the projective indecomposable modules need to be computed first using
+      <Ref Attr="Pims" Label="for a monoid cartan matrix"/>.<P/>
+
+      If <A>M</A> is the only argument then
+      <Ref Attr="MonoidCartanMatrix"/> returns the Cartan matrix of the monoid 
+      algebra <M>FM</M>, where <A>F</A> is a splitting field of <A>M</A> over 
+      the rationals.<P/>
+
+      At the moment, methods are available for the following cases:
+      if <A>F</A> is not given (i.e. it defaults to a splitting field of <A>M</A> 
+      over the rationals) and <A>M</A> is a finite monoid.<P/>
+
+      For other cases no methods are implemented yet.<P/>
+
+      <Example><![CDATA[
+gap> S := FullTransformationMonoid(3);;
+gap> cm := MonoidCartanMatrix(S);;
+gap> Pims(cm);;
+gap> Display(cm);
+    X.1 X.2 X.3 X.4 X.5 X.6
+                           
+P.1   1   .   .   .   .   .
+P.2   .   1   .   .   .   .
+P.3   1   .   1   1   .   .
+P.4   1   .   .   1   .   .
+P.5   .   .   .   .   1   .
+P.6   .   .   .   1   .   1
+]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="Pims">
+  <ManSection>
+    <Attr Name ="Pims" Arg="T"
+         Label = "for a monoid cartan matrix"/>
+    <Returns>A list of monoid characters.</Returns>
+    <Description>
+      <Ref Attr="Pims" Label="for a monoid cartan matrix"/> returns a 
+      list of the characters of the projective indecomposable 
+      modules of the parent monoid of the monoid character table <A>T</A>.
+
+      <Log><![CDATA[
+gap> M := FullBooleanMatMonoid(2);
+<monoid of 2x2 boolean matrices with 3 generators>
+gap> cm := MonoidCartanMatrix(M);;
+gap> Pims(cm);
+[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
+IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 1, 1, 1, 1, 1 ] ) ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
+IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 1, 2, 3, 1 ] ) ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
+IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 1, 2, 0 ] ) ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
+IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, -1 ] ) ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
+IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ) ]]]></Log>
+    </Description>
+  </ManSection>
+<#/GAPDoc>

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -239,30 +239,16 @@ X.6   1   1   1   1   1   1
       of the monoid character table <A>T</A>.
 
       <Example><![CDATA[
-gap> M := FullBooleanMatMonoid(2);
-<monoid of 2x2 boolean matrices with 3 generators>
+gap> M := FullTransformationMonoid(2);
+<full transformation monoid of degree 2>
 gap> ct := MonoidCharacterTable(M);;
 gap> Irr(ct);
-[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , [ 1, 1, 1, 1, 1 ] ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , [ 0, 1, 2, 3, 1 ] ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , [ 0, 0, 1, 2, 0 ] ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , [ 0, 0, 0, 1, -1 ] ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , [ 0, 0, 0, 1, 1 ] ) ]></Example>
+[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Transformation( [ 2, 1 ] ),\
+ Transformation( [ 1, 1 ] ) ] ) ) , [ 1, -1, 0 ] ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Transformation( [ 2, 1 ] ),\
+ Transformation( [ 1, 1 ] ) ] ) ) , [ 1, 1, 0 ] ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Transformation( [ 2, 1 ] ),\
+ Transformation( [ 1, 1 ] ) ] ) ) , [ 1, 1, 1 ] ) ]]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -322,45 +308,22 @@ P.6   .   .   .   1   .   1
       modules of the parent monoid of the monoid character table <A>T</A>.
 
       <Example><![CDATA[
-gap> M := FullBooleanMatMonoid(2);
-<monoid of 2x2 boolean matrices with 3 generators>
+gap> M := FullTransformationMonoid(2);
+<full transformation monoid of degree 2>
 gap> cm := MonoidCartanMatrix(M);;
 gap> Pims(cm);
-[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
-x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
-[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
-false, false ] ]) ] ) ) , [ 1, 1, 1, 1, 1 ] ) ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
-x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
-[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
-false, false ] ]) ] ) ) , [ 0, 1, 2, 3, 1 ] ) ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
-x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
-[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
-false, false ] ]) ] ) ) , [ 0, 0, 1, 2, 0 ] ) ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
-x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
-[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
-false, false ] ]) ] ) ) , [ 0, 0, 0, 1, -1 ] ) ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
-x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
-[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
-false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ) ]></Example>
+[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Transformation( [ 2, 1 ] ),\
+ Transformation( [ 1, 1 ] ) ] ) ) , Projective Cover Of MonoidCharacter( Monoi\
+dCharacterTable( Monoid( [ Transformation( [ 2, 1 ] ), Transformation( [ 1, 1 \
+] ) ] ) ) , [ 1, -1, 0 ] ) ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Transformation( [ 2, 1 ] ),\
+ Transformation( [ 1, 1 ] ) ] ) ) , Projective Cover Of MonoidCharacter( Monoi\
+dCharacterTable( Monoid( [ Transformation( [ 2, 1 ] ), Transformation( [ 1, 1 \
+] ) ] ) ) , [ 1, 1, 0 ] ) ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Transformation( [ 2, 1 ] ),\
+ Transformation( [ 1, 1 ] ) ] ) ) , Projective Cover Of MonoidCharacter( Monoi\
+dCharacterTable( Monoid( [ Transformation( [ 2, 1 ] ), Transformation( [ 1, 1 \
+] ) ] ) ) , [ 1, 1, 1 ] ) ) ]]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -238,7 +238,7 @@ X.6   1   1   1   1   1   1
       the characters of the irreducible representations of the <Ref Attr="Parent" BookName = "ref"/> monoid 
       of the monoid character table <A>T</A>.
 
-      <!-- The following example is a log becasue the values in the vectors and
+      <!-- The following example is a log because the values in the vectors and
       the presentation of the monoid display inconsistently -->
       <Log><![CDATA[
 gap> M := FullBooleanMatMonoid(2);
@@ -313,7 +313,7 @@ P.6   .   .   .   1   .   1
       list of the characters of the projective indecomposable 
       modules of the <Ref Attr="Parent" BookName = "ref"/> monoid of the monoid character table <A>T</A>.
 
-      <!-- The following example is a log becasue the values in the vectors and
+      <!-- The following example is a log because the values in the vectors and
       the presentation of the monoid display inconsistently -->
       <Log><![CDATA[
 gap> M := FullBooleanMatMonoid(2);

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -167,9 +167,9 @@ gap> RClassBicharacterOfGroupHClass(H);
     <Returns>A matrix.</Returns>
     <Description>
       <Ref Attr="BlockDiagonalMatrixOfCharacterTables" Label="for a semigroup"/>
-      returns a block diagonal matrix which has a mmatrix block for each
-      regular &D;-class of <A>S</A>. The block matrices along the diagonal are
-      character tables of some group &H;-classes in each regular &D;-class of
+      returns a block diagonal matrix which has a matrix block for each
+      regular &D;-class of <A>S</A>. Each diagonal blocks is the
+      character table of one (arbitrary) group &H;-class in each regular &D;-class of
       <A>S</A>. The character tables are determined by
       <Ref Attr = "OrdinaryCharacterTable" BookName = "ref"/> of
       <Ref Attr = "Range" BookName = "ref"/> of <Ref Attr="IsomorphismPermGroup"/>

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -238,7 +238,7 @@ X.6   1   1   1   1   1   1
       the characters of the irreducible representations of the parent monoid 
       of the monoid character table <A>T</A>.
 
-      <Log><![CDATA[
+      <Example><![CDATA[
 gap> M := FullBooleanMatMonoid(2);
 <monoid of 2x2 boolean matrices with 3 generators>
 gap> ct := MonoidCharacterTable(M);;
@@ -252,7 +252,7 @@ at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 1, 2, 0 ] ),
   MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
 at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, -1 ] ),
   MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ]]]></Log>
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ]]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -311,7 +311,7 @@ P.6   .   .   .   1   .   1
       list of the characters of the projective indecomposable 
       modules of the parent monoid of the monoid character table <A>T</A>.
 
-      <Log><![CDATA[
+      <Example><![CDATA[
 gap> M := FullBooleanMatMonoid(2);
 <monoid of 2x2 boolean matrices with 3 generators>
 gap> cm := MonoidCartanMatrix(M);;
@@ -330,7 +330,7 @@ at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCha
 IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, -1 ] ) ),
   MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
 at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
-IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ) ]]]></Log>
+IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ) ]]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -87,7 +87,7 @@ gap> GeneralizedConjugacyClassesRepresentatives(S);
       generalized conjugacy class of the parent monoid of <A>D</A> 
       and <C>k</C> is an element in the <C>j</C>th generalized conjugacy class of the 
       parent monoid of <A>D</A>. The order of the generalized conjugacy classes of the 
-      <Ref Attr="ParentAttr" BookName = "ref"/> of <A>D</A> is determined by the list returned by the attribute 
+      <Ref Attr="Parent" BookName = "ref"/> of <A>D</A> is determined by the list returned by the attribute 
       <Ref Attr="GeneralizedConjugacyClasses" Label="for a semigroup"/> of the parent 
       monoid of <A>D</A>.
 

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -243,16 +243,26 @@ gap> M := FullBooleanMatMonoid(2);
 <monoid of 2x2 boolean matrices with 3 generators>
 gap> ct := MonoidCharacterTable(M);;
 gap> Irr(ct);
-[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 1, 1, 1, 1, 1 ] ),
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 1, 2, 3, 1 ] ),
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 1, 2, 0 ] ),
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, -1 ] ),
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ]]]></Example>
+[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , [ 1, 1, 1, 1, 1 ] ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , [ 0, 1, 2, 3, 1 ] ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , [ 0, 0, 1, 2, 0 ] ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , [ 0, 0, 0, 1, -1 ] ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , [ 0, 0, 0, 1, 1 ] ) ]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -316,21 +326,41 @@ gap> M := FullBooleanMatMonoid(2);
 <monoid of 2x2 boolean matrices with 3 generators>
 gap> cm := MonoidCartanMatrix(M);;
 gap> Pims(cm);
-[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
-IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 1, 1, 1, 1, 1 ] ) ),
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
-IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 1, 2, 3, 1 ] ) ),
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
-IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 1, 2, 0 ] ) ),
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
-IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, -1 ] ) ),
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
-at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
-IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ) ]]]></Example>
+[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
+x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
+[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
+false, false ] ]) ] ) ) , [ 1, 1, 1, 1, 1 ] ) ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
+x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
+[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
+false, false ] ]) ] ) ) , [ 0, 1, 2, 3, 1 ] ) ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
+x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
+[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
+false, false ] ]) ] ) ) , [ 0, 0, 1, 2, 0 ] ) ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
+x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
+[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
+false, false ] ]) ] ) ) , [ 0, 0, 0, 1, -1 ] ) ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
+x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
+[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
+false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ) ]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -238,6 +238,8 @@ X.6   1   1   1   1   1   1
       the characters of the irreducible representations of the parent monoid 
       of the monoid character table <A>T</A>.
 
+      <!-- The following example is a log becasue the values in the vectors and
+      the presentation of the monoid display inconsistently -->
       <Log><![CDATA[
 gap> M := FullBooleanMatMonoid(2);
 <monoid of 2x2 boolean matrices with 3 generators>
@@ -311,6 +313,8 @@ P.6   .   .   .   1   .   1
       list of the characters of the projective indecomposable 
       modules of the parent monoid of the monoid character table <A>T</A>.
 
+      <!-- The following example is a log becasue the values in the vectors and
+      the presentation of the monoid display inconsistently -->
       <Log><![CDATA[
 gap> M := FullBooleanMatMonoid(2);
 <monoid of 2x2 boolean matrices with 3 generators>

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -167,10 +167,10 @@ gap> RClassBicharacterOfGroupHClass(H);
     <Returns>A matrix.</Returns>
     <Description>
       <Ref Attr="BlockDiagonalMatrixOfCharacterTables" Label="for a semigroup"/> 
-      returns a block diagonal matrix whose
-      block matrices along the diagonal are character tables of some group &H;-classes 
-      in each regular &D;-class of <A>S</A>.
-      The character tables are determined by 
+      returns a block diagonal matrix which has a mmatrix block for each 
+      regular &D;-class of <A>S</A>. The block matrices along the diagonal are 
+      character tables of some group &H;-classes in each regular &D;-class of 
+      <A>S</A>. The character tables are determined by 
       <Ref Attr = "OrdinaryCharacterTable" BookName = "ref"/> of 
       <Ref Attr = "Range" BookName = "ref"/> of <Ref Attr="IsomorphismPermGroup"/>
       of <Ref Attr="GroupHClass"/> of <Ref Attr="RegularDClasses"/> of <A>S</A>. 

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -243,26 +243,16 @@ gap> M := FullBooleanMatMonoid(2);
 <monoid of 2x2 boolean matrices with 3 generators>
 gap> ct := MonoidCharacterTable(M);;
 gap> Irr(ct);
-[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , [ 1, 1, 1, 1, 1 ] ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , [ 0, 1, 2, 3, 1 ] ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , [ 0, 0, 1, 2, 0 ] ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , [ 0, 0, 0, 1, -1 ] ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , [ 0, 0, 0, 1, 1 ] ) ]></Example>
+[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 1, 1, 1, 1, 1 ] ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 1, 2, 3, 1 ] ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 1, 2, 0 ] ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, -1 ] ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ]]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -326,41 +316,21 @@ gap> M := FullBooleanMatMonoid(2);
 <monoid of 2x2 boolean matrices with 3 generators>
 gap> cm := MonoidCartanMatrix(M);;
 gap> Pims(cm);
-[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
-x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
-[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
-false, false ] ]) ] ) ) , [ 1, 1, 1, 1, 1 ] ) ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
-x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
-[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
-false, false ] ]) ] ) ) , [ 0, 1, 2, 3, 1 ] ) ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
-x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
-[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
-false, false ] ]) ] ) ) , [ 0, 0, 1, 2, 0 ] ) ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
-x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
-[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
-false, false ] ]) ] ) ) , [ 0, 0, 0, 1, -1 ] ) ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
-lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
-e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
-) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
-x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
-[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
-false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ) ]></Example>
+[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
+IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 1, 1, 1, 1, 1 ] ) ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
+IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 1, 2, 3, 1 ] ) ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
+IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 1, 2, 0 ] ) ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
+IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, -1 ] ) ),
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanM\
+at, [ [ true, false ], [ false, false ] ]) ] ) ) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(\
+IsBooleanMat, [ [ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ) ]]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -84,11 +84,11 @@ gap> GeneralizedConjugacyClassesRepresentatives(S);
       <Ref Attr="DClassBicharacter" Label="for a D-classs"/> returns a matrix whose 
       <C>i</C>th row and <C>j</C>th column entry is the size of the set 
       <M>\{m \in D | hmk = m \}</M> where <C>h</C> is an element in the <C>i</C>th 
-      generalized conjugacy class of the parent monoid of <A>D</A> 
+      generalized conjugacy class of the <Ref Attr="Parent" BookName = "ref"/> monoid of <A>D</A> 
       and <C>k</C> is an element in the <C>j</C>th generalized conjugacy class of the 
-      parent monoid of <A>D</A>. The order of the generalized conjugacy classes of the 
-      <Ref Attr="Parent" BookName = "ref"/> of <A>D</A> is determined by the list returned by the attribute 
-      <Ref Attr="GeneralizedConjugacyClasses" Label="for a semigroup"/> of the parent 
+      <Ref Attr="Parent" BookName = "ref"/> monoid of <A>D</A>. The order of the generalized conjugacy classes of the 
+      <Ref Attr="Parent" BookName = "ref"/> monoid of <A>D</A> is determined by the list returned by the attribute 
+      <Ref Attr="GeneralizedConjugacyClasses" Label="for a semigroup"/> of the <Ref Attr="Parent" BookName = "ref"/> 
       monoid of <A>D</A>.
 
       <Example><![CDATA[
@@ -140,11 +140,11 @@ gap> RegularRepresentationBicharacter(S);
       <M>\{m \in R | hmk = m \}</M> where <C>R</C> is the <Ref Meth="RClassOfHClass"/> of 
       <A>H</A>. Furthermore, <M>h</M> is an element in the <C>i</C>th generalized 
       conjugacy class of <A>H</A> as a group and <M>k</M> is an element in the 
-      <C>j</C>th generalized conjugacy class of the parent semigroup of <A>H</A>. The order 
-      of the generalized conjugacy classes of the parent semigroup of <A>H</A> is determined 
+      <C>j</C>th generalized conjugacy class of the <Ref Attr="Parent" BookName = "ref"/> semigroup of <A>H</A>. The order 
+      of the generalized conjugacy classes of the <Ref Attr="Parent" BookName = "ref"/> semigroup of <A>H</A> is determined 
       by the list returned by the attribute 
       <Ref Attr="GeneralizedConjugacyClasses" Label="for a semigroup"/> of 
-      the parent semigroup of <A>H</A>. The order of the generalized conjugacy classes of 
+      the <Ref Attr="Parent" BookName = "ref"/> semigroup of <A>H</A>. The order of the generalized conjugacy classes of 
       <A>H</A> is determined by the list returned by the attribute 
       <Ref Attr = "ConjugacyClasses" BookName = "ref"/> of <Ref Attr = "OrdinaryCharacterTable" BookName = "ref"/> of 
       <Ref Attr = "Range" BookName = "ref"/> of <Ref Attr="IsomorphismPermGroup"/> of <A>H</A>.
@@ -235,7 +235,7 @@ X.6   1   1   1   1   1   1
     <Returns>A list of monoid characters.</Returns>
     <Description>
       <Ref Attr="Irr" Label="for a monoid character table"/> returns a list of 
-      the characters of the irreducible representations of the parent monoid 
+      the characters of the irreducible representations of the <Ref Attr="Parent" BookName = "ref"/> monoid 
       of the monoid character table <A>T</A>.
 
       <!-- The following example is a log becasue the values in the vectors and
@@ -311,7 +311,7 @@ P.6   .   .   .   1   .   1
     <Description>
       <Ref Attr="Pims" Label="for a monoid cartan matrix"/> returns a 
       list of the characters of the projective indecomposable 
-      modules of the parent monoid of the monoid character table <A>T</A>.
+      modules of the <Ref Attr="Parent" BookName = "ref"/> monoid of the monoid character table <A>T</A>.
 
       <!-- The following example is a log becasue the values in the vectors and
       the presentation of the monoid display inconsistently -->

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -239,16 +239,30 @@ X.6   1   1   1   1   1   1
       of the monoid character table <A>T</A>.
 
       <Example><![CDATA[
-gap> M := FullTransformationMonoid(2);
-<full transformation monoid of degree 2>
+gap> M := FullBooleanMatMonoid(2);
+<monoid of 2x2 boolean matrices with 3 generators>
 gap> ct := MonoidCharacterTable(M);;
 gap> Irr(ct);
-[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Transformation( [ 2, 1 ] ),\
- Transformation( [ 1, 1 ] ) ] ) ) , [ 1, -1, 0 ] ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Transformation( [ 2, 1 ] ),\
- Transformation( [ 1, 1 ] ) ] ) ) , [ 1, 1, 0 ] ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Transformation( [ 2, 1 ] ),\
- Transformation( [ 1, 1 ] ) ] ) ) , [ 1, 1, 1 ] ) ]]]></Example>
+[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , [ 1, 1, 1, 1, 1 ] ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , [ 0, 1, 2, 3, 1 ] ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , [ 0, 0, 1, 2, 0 ] ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , [ 0, 0, 0, 1, -1 ] ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , [ 0, 0, 0, 1, 1 ] ) ]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
@@ -308,22 +322,45 @@ P.6   .   .   .   1   .   1
       modules of the parent monoid of the monoid character table <A>T</A>.
 
       <Example><![CDATA[
-gap> M := FullTransformationMonoid(2);
-<full transformation monoid of degree 2>
+gap> M := FullBooleanMatMonoid(2);
+<monoid of 2x2 boolean matrices with 3 generators>
 gap> cm := MonoidCartanMatrix(M);;
 gap> Pims(cm);
-[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Transformation( [ 2, 1 ] ),\
- Transformation( [ 1, 1 ] ) ] ) ) , Projective Cover Of MonoidCharacter( Monoi\
-dCharacterTable( Monoid( [ Transformation( [ 2, 1 ] ), Transformation( [ 1, 1 \
-] ) ] ) ) , [ 1, -1, 0 ] ) ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Transformation( [ 2, 1 ] ),\
- Transformation( [ 1, 1 ] ) ] ) ) , Projective Cover Of MonoidCharacter( Monoi\
-dCharacterTable( Monoid( [ Transformation( [ 2, 1 ] ), Transformation( [ 1, 1 \
-] ) ] ) ) , [ 1, 1, 0 ] ) ), 
-  MonoidCharacter( MonoidCharacterTable( Monoid( [ Transformation( [ 2, 1 ] ),\
- Transformation( [ 1, 1 ] ) ] ) ) , Projective Cover Of MonoidCharacter( Monoi\
-dCharacterTable( Monoid( [ Transformation( [ 2, 1 ] ), Transformation( [ 1, 1 \
-] ) ] ) ) , [ 1, 1, 1 ] ) ) ]]]></Example>
+[ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
+x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
+[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
+false, false ] ]) ] ) ) , [ 1, 1, 1, 1, 1 ] ) ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
+x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
+[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
+false, false ] ]) ] ) ) , [ 0, 1, 2, 3, 1 ] ) ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
+x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
+[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
+false, false ] ]) ] ) ) , [ 0, 0, 1, 2, 0 ] ) ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
+x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
+[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
+false, false ] ]) ] ) ) , [ 0, 0, 0, 1, -1 ] ) ), 
+  MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat, [ [ fa\
+lse, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ tru\
+e, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ false, false ] ]) ] ) \
+) , Projective Cover Of MonoidCharacter( MonoidCharacterTable( Monoid( [ Matri\
+x(IsBooleanMat, [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ \
+[ true, false ], [ true, true ] ]), Matrix(IsBooleanMat, [ [ true, false ], [ \
+false, false ] ]) ] ) ) , [ 0, 0, 0, 1, 1 ] ) ) ]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>

--- a/doc/z-chap11.xml
+++ b/doc/z-chap11.xml
@@ -305,12 +305,7 @@
     monoid in characteristic zero. The case for computing character tables and
     Cartan matrices for finite monoids over a splitting field of the 
     monoid in characteristic zero originates from <Cite Key="Balthazar2025aa"/> 
-    by Balthazar Charles. 
-    An example of a splitting field for a finite monoid is the cyclotomic field 
-    with gth roots where g is the least common multiple of the exponents of every 
-    maximal subgroup of the finite monoid. In what follows cyclotomic field 
-    with gth roots can be assumed to be what is meant by a splitting field of the 
-    monoid.<P/>
+    by Balthazar Charles.<P/>
 
     <#Include Label="GeneralizedConjugacyClasses">
     <#Include Label="DClassBicharacter">

--- a/doc/z-chap11.xml
+++ b/doc/z-chap11.xml
@@ -293,4 +293,33 @@
   <!--**********************************************************************-->
   <!--**********************************************************************-->
 
+  <Section>
+
+    <Heading>
+      Monoid character table and Cartan matrix
+    </Heading>
+
+    In this section we describe some operations in &SEMIGROUPS; for computing 
+    character tables and Cartan matrices of monoids. These functions
+    are currently implemented for finite monoids over a splitting field of the 
+    monoid in characteristic zero. The case for computing character tables and
+    Cartan matrices for finite monoids over a splitting field of the 
+    monoid in characteristic zero originates from <Cite Key="Balthazar2025aa"/> 
+    by Balthazar Charles.<P/>
+
+    <#Include Label="GeneralizedConjugacyClasses">
+    <#Include Label="DClassBicharacter">
+    <#Include Label="RegularRepresentationBicharacter">
+    <#Include Label="RClassBicharacterOfGroupHClass">
+    <#Include Label="BlockDiagonalMatrixOfCharacterTables">
+    <#Include Label="MonoidCharacterTable">
+    <#Include Label="Irr">
+    <#Include Label="MonoidCartanMatrix">
+    <#Include Label="Pims">
+
+  </Section>
+
+  <!--**********************************************************************-->
+  <!--**********************************************************************-->
+
 </Chapter>

--- a/doc/z-chap11.xml
+++ b/doc/z-chap11.xml
@@ -307,9 +307,9 @@
     monoid in characteristic zero originates from <Cite Key="Balthazar2025aa"/> 
     by Balthazar Charles. 
     An example of a splitting field for a finite monoid is the cyclotomic field 
-    with gth roots where g is the least common multiple of the exponents of every 
+    with <M>g</M>th roots where <M>g</M> is the least common multiple of the exponents of every 
     maximal subgroup of the finite monoid. In what follows cyclotomic field 
-    with gth roots can be assumed to be what is meant by a splitting field of the 
+    with <M>g</M>th roots can be assumed to be what is meant by a splitting field of the 
     monoid.<P/>
 
     <#Include Label="GeneralizedConjugacyClasses">

--- a/doc/z-chap11.xml
+++ b/doc/z-chap11.xml
@@ -305,7 +305,12 @@
     monoid in characteristic zero. The case for computing character tables and
     Cartan matrices for finite monoids over a splitting field of the 
     monoid in characteristic zero originates from <Cite Key="Balthazar2025aa"/> 
-    by Balthazar Charles.<P/>
+    by Balthazar Charles. 
+    An example of a splitting field for a finite monoid is the cyclotomic field 
+    with gth roots where g is the least common multiple of the exponents of every 
+    maximal subgroup of the finite monoid. In what follows cyclotomic field 
+    with gth roots can be assumed to be what is meant by a splitting field of the 
+    monoid.<P/>
 
     <#Include Label="GeneralizedConjugacyClasses">
     <#Include Label="DClassBicharacter">

--- a/gap/attributes/cartan.gd
+++ b/gap/attributes/cartan.gd
@@ -1,0 +1,43 @@
+#############################################################################
+##
+##  cartan.gd
+##  Copyright (C) 2024                                   Balthazar Charles
+##                                                             Joseph Ruiz
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+
+DeclareCategory("IsGeneralizedConjugacyClass", IsObject);
+DeclareAttribute("Representative", IsGeneralizedConjugacyClass);
+DeclareAttribute("ParentAttr", IsGeneralizedConjugacyClass);
+DeclareOperation("GeneralizedConjugacyClass",
+                 [IsSemigroup, IsMultiplicativeElement]);
+DeclareAttribute("GeneralizedConjugacyClassesRepresentatives", IsSemigroup);
+DeclareAttribute("GeneralizedConjugacyClasses", IsSemigroup);
+DeclareCategory("IsMonoidCharacterTable", IsObject);
+DeclareAttribute("ParentAttr", IsMonoidCharacterTable);
+DeclareAttribute("MonoidCharacterTable", IsSemigroup);
+
+DeclareCategory("IsMonoidCharacter", IsObject);
+DeclareOperation("MonoidCharacter", [IsMonoidCharacterTable, IsList]);
+DeclareOperation("PimMonoidCharacter",
+                 [IsMonoidCharacterTable, IsDenseList, IsMonoidCharacter]);
+DeclareAttribute("ParentAttr", IsMonoidCharacter);
+DeclareAttribute("ValuesOfMonoidClassFunction", IsMonoidCharacter);
+DeclareAttribute("ProjectiveCoverOf", IsMonoidCharacter);
+DeclareAttribute("ValuesOfCompositionFactorsFunction", IsMonoidCharacter);
+DeclareAttribute("DClassBicharacter", IsGreensDClass);
+DeclareAttribute("RegularRepresentationBicharacter", IsSemigroup);
+DeclareAttribute("RClassBicharacterOfGroupHClass", IsGroupHClass);
+DeclareAttribute("RClassRadicalOfGroupHClass", IsGroupHClass);
+DeclareAttribute("RClassRadicalBicharacterOfGroupHClass", IsGroupHClass);
+DeclareAttribute("BlockDiagonalMatrixOfCharacterTables", IsSemigroup);
+DeclareAttribute("Irr", IsMonoidCharacterTable);
+
+DeclareCategory("IsMonoidCartanMatrix", IsObject);
+DeclareAttribute("ParentAttr", IsMonoidCartanMatrix);
+DeclareAttribute("MonoidCartanMatrix", IsSemigroup);
+
+DeclareAttribute("Pims", IsMonoidCartanMatrix);

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -1,0 +1,700 @@
+#############################################################################
+##
+##  cartan.gi
+##  Copyright (C) 2024                                   Balthazar Charles
+##                                                             Joseph Ruiz
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+
+# This implementation of generalized conjugacy classes is very rundamentary
+# and is practically unused to compute the character table or Cartan matrix.
+# This object is to be a placeholder to eventually hold all the elements
+# which are in the same generalized conjugacy class. This will then allow
+# the monoid characters to work like characters in the case of groups.
+BindGlobal("GeneralizedConjugacyClassType",
+NewType(NewFamily("GeneralizedConjugacyClassFamily"),
+        IsGeneralizedConjugacyClass and
+        IsAttributeStoringRep));
+
+InstallMethod(GeneralizedConjugacyClass,
+              "for a semigroup and a multiplicative element",
+[IsSemigroup, IsMultiplicativeElement],
+function(S, s)
+  local result;
+  result := Objectify(GeneralizedConjugacyClassType, rec());
+  SetRepresentative(result, s);
+  SetParentAttr(result, S);
+  return result;
+end);
+
+InstallMethod(ViewString, "for a generalized conjugacy class",
+[IsGeneralizedConjugacyClass],
+function(generalizedconjugacyclass)
+  return StringFormatted(
+      "<generalized conjugacy class in {} for representative {}>",
+      ParentAttr(generalizedconjugacyclass),
+      Representative(generalizedconjugacyclass));
+end);
+
+InstallMethod(DisplayString, "for a generalized conjugacy class",
+[IsGeneralizedConjugacyClass],
+ViewString);
+
+InstallMethod(GeneralizedConjugacyClassesRepresentatives, "for a semigroup",
+[IsSemigroup],
+function(S)
+  local D, out, C, map, invmap;
+
+  D := List(RegularDClasses(S), GroupHClass);
+  D := List(D, IsomorphismPermGroup);
+  out := [];
+  for map in D do
+    C := List(ConjugacyClasses(OrdinaryCharacterTable(Range(map))),
+                               Representative);
+    # Ugly fix: ensures that the conjugacy classes are computed
+    # in the same order each time.
+    invmap := InverseGeneralMapping(map);
+    C := List(C, x -> x ^ invmap);
+    Append(out, C);
+  od;
+
+  return out;
+end);
+
+InstallMethod(GeneralizedConjugacyClasses, "for a semigroup",
+[IsSemigroup],
+function(S)
+  return List(GeneralizedConjugacyClassesRepresentatives(S),
+                 x -> GeneralizedConjugacyClass(S, x));
+end);
+
+BindGlobal("MonoidCharacterTableType",
+NewType(NewFamily("MonoidCharacterTableFamily"),
+        IsMonoidCharacterTable and
+        IsAttributeStoringRep));
+
+InstallMethod(MonoidCharacterTable,  "for a semigroup",
+[IsMonoidAsSemigroup],
+function(S)
+  local result;
+
+  result := Objectify(MonoidCharacterTableType, rec());
+  SetParentAttr(result, S);
+
+  return result;
+end);
+
+InstallMethod(ViewString, "for a monoid character table",
+[IsMonoidCharacterTable],
+function(ct)
+  return StringFormatted("MonoidCharacterTable( {} )",
+  ParentAttr(ct));
+end);
+
+# Notes to consider when changing the code for the display string
+# for IsMonoidCharacterTable.
+#
+# The following conventions were observed in the character tables of
+# groups.
+# Integer entries are never truncated and make their column bigger
+# -/A prefix makes a column bigger
+# Checking for redunacnies under *M is not implemented. However
+# character tables of groups do check for *M redundancies.
+# Column headers do not get padded to match wider columns.
+
+InstallMethod(DisplayString, "for a monoid character table",
+[IsMonoidCharacterTable],
+function(ct)
+  local str, columnlabels, rowlabels, strarray, sizetable, i, j, ctmatrix,
+  rosetastone, coltable, columnwidth, rowlabelwidth, currentwidth, currentpage,
+  screensizeassume, quotientcolumnwidthsums, temp, temp2, temp3, temp4;
+
+  str := StringFormatted("MonoidCharacterTable( {} )",
+  ParentAttr(ct));
+
+  if HasIrr(ct) then
+    sizetable := Length(Irr(ct));
+
+    strarray := List([1 .. sizetable], x -> List([1 .. sizetable], y -> "."));
+    ctmatrix := List(Irr(ct), ValuesOfMonoidClassFunction);
+    rosetastone := Filtered(Unique(Concatenation(List(Irr(ct),
+                                   ValuesOfMonoidClassFunction))),
+                                   x -> not IsInt(x));
+
+    columnlabels := List([1 .. 2], x -> List([1 .. sizetable], y -> " "));
+    rowlabels := List([1 .. (sizetable + 2)], x -> " ");
+
+    for i in [1 .. sizetable] do
+      rowlabels[i + 2] := Concatenation("X.", String(i));
+    od;
+
+    for j in [1 .. sizetable] do
+      columnlabels[1, j] := Concatenation("c.", String(j));
+    od;
+
+    for j in [1 .. sizetable] do
+      columnlabels[2, j] := " ";
+    od;
+
+    for i in [1 .. sizetable] do
+      for j in [1 .. sizetable] do
+        if IsInt(ctmatrix[i, j]) then
+          if not IsZero(ctmatrix[i, j]) then
+            strarray[i, j] := String(ctmatrix[i, j]);
+          fi;
+        else
+          strarray[i, j] := WordAlp("ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+                                    Position(rosetastone, ctmatrix[i, j]));
+        fi;
+      od;
+    od;
+
+    coltable := Concatenation(columnlabels, strarray);
+
+    columnwidth := List(List(TransposedMat(coltable),
+                        x -> List(x, Length)), Maximum) + 1;
+
+    rowlabelwidth := Maximum(List(rowlabels, Length));
+
+    for i in [1 .. Length(rowlabels)] do
+
+      rowlabels[i] := Concatenation(rowlabels[i],
+                            WordAlp(" ", rowlabelwidth - Length(rowlabels[i])));
+    od;
+
+    for i in [1 .. Length(coltable)] do
+      for j in [1 .. sizetable] do
+        coltable[i, j] := Concatenation(WordAlp(" ",
+                                       columnwidth[j] - Length(coltable[i, j])),
+                                       coltable[i, j]);
+      od;
+    od;
+
+    screensizeassume := Maximum(SizeScreen()[1], 20) - rowlabelwidth;
+    currentwidth := 0;
+    currentpage := 0;
+    quotientcolumnwidthsums := List(columnwidth, x -> 0);
+    for i in [1 .. sizetable] do
+      currentwidth := currentwidth + columnwidth[i];
+      if currentwidth + 1 < screensizeassume then
+        quotientcolumnwidthsums[i] := currentpage;
+      else
+        currentwidth := columnwidth[i];
+        currentpage := currentpage + 1;
+        quotientcolumnwidthsums[i] := currentpage;
+      fi;
+    od;
+
+    temp := Concatenation(List([0 .. Last(quotientcolumnwidthsums)],
+    k -> List(coltable,
+    x -> Concatenation(x{Positions(quotientcolumnwidthsums, k)}))));
+
+    temp2 := List(temp, x -> Concatenation(x, "\n"));
+
+    temp3 := Concatenation(List([1 .. Length(temp2)],
+           x -> Concatenation(rowlabels[((x - 1) mod Length(rowlabels)) + 1],
+                              temp2[x])));
+
+    temp4 := List([1 .. Length(rosetastone)],
+                  x -> Concatenation(WordAlp("ABCDEFGHIJKLMNOPQRSTUVWXYZ", x),
+                                     " := ", String(rosetastone[x]), "\n"));
+
+    str := Concatenation(temp3, "\n", Concatenation(temp4));
+
+  fi;
+
+  return str;
+end);
+
+BindGlobal("MonoidCartanMatrixType",
+NewType(NewFamily("MonoidCartanMatrixFamily"),
+        IsMonoidCartanMatrix and
+        IsAttributeStoringRep));
+
+InstallMethod(MonoidCartanMatrix,  "for a semigroup",
+[IsMonoidAsSemigroup],
+function(S)
+  local result;
+
+  result := Objectify(MonoidCartanMatrixType, rec());
+  SetParentAttr(result, S);
+
+  return result;
+end);
+
+InstallMethod(ViewString, "for a monoid cartan matrix",
+[IsMonoidCartanMatrix],
+function(cm)
+  return StringFormatted("MonoidCartanMatrix( {} )",
+  ParentAttr(cm));
+end);
+
+InstallMethod(DisplayString, "for a monoid cartan matrix",
+[IsMonoidCartanMatrix],
+function(cm)
+  local str, columnlabels, rowlabels, strarray, sizetable, i, j, cmmatrix,
+  coltable, columnwidth, rowlabelwidth, currentwidth, currentpage,
+  screensizeassume, quotientcolumnwidthsums, temp, temp2;
+
+  str := StringFormatted("MonoidCartanMatrix( {} )",
+  ParentAttr(cm));
+
+  if HasPims(cm) then
+    sizetable := Length(Pims(cm));
+
+    strarray := List([1 .. sizetable], x -> List([1 .. sizetable], y -> "."));
+    cmmatrix := List(Pims(cm), ValuesOfCompositionFactorsFunction);
+
+    columnlabels := List([1 .. 2], x -> List([1 .. sizetable], y -> " "));
+    rowlabels := List([1 .. (sizetable + 2)], x -> " ");
+
+    for i in [1 .. sizetable] do
+      rowlabels[i + 2] := Concatenation("P.", String(i));
+    od;
+
+    for j in [1 .. sizetable] do
+      columnlabels[1, j] := Concatenation("X.", String(j));
+    od;
+
+    for j in [1 .. sizetable] do
+      columnlabels[2, j] := " ";
+    od;
+
+    for i in [1 .. sizetable] do
+      for j in [1 .. sizetable] do
+        if not IsZero(cmmatrix[i, j]) then
+          strarray[i, j] := String(cmmatrix[i, j]);
+        fi;
+      od;
+    od;
+
+    coltable := Concatenation(columnlabels, strarray);
+
+    columnwidth := List(List(TransposedMat(coltable),
+                             x -> List(x, Length)), Maximum) + 1;
+
+    rowlabelwidth := Maximum(List(rowlabels, Length));
+
+    for i in [1 .. Length(rowlabels)] do
+      rowlabels[i] := Concatenation(rowlabels[i],
+                            WordAlp(" ", rowlabelwidth - Length(rowlabels[i])));
+    od;
+
+    for i in [1 .. Length(coltable)] do
+      for j in [1 .. sizetable] do
+        coltable[i, j] := Concatenation(WordAlp(" ",
+                                       columnwidth[j] - Length(coltable[i, j])),
+                                       coltable[i, j]);
+      od;
+    od;
+
+    screensizeassume := Maximum(SizeScreen()[1], 20) - rowlabelwidth;
+    currentwidth := 0;
+    currentpage := 0;
+    quotientcolumnwidthsums := List(columnwidth, x -> 0);
+    for i in [1 .. sizetable] do
+      currentwidth := currentwidth + columnwidth[i];
+      if currentwidth + 1 < screensizeassume then
+        quotientcolumnwidthsums[i] := currentpage;
+      else
+        currentwidth := columnwidth[i];
+        currentpage := currentpage + 1;
+        quotientcolumnwidthsums[i] := currentpage;
+      fi;
+    od;
+
+    temp := Concatenation(List([0 .. Last(quotientcolumnwidthsums)],
+    k -> List(coltable,
+    x -> Concatenation(x{Positions(quotientcolumnwidthsums, k)}))));
+
+    temp2 := List(temp, x -> Concatenation(x, "\n"));
+
+    str := Concatenation(List([1 .. Length(temp2)],
+           x -> Concatenation(rowlabels[((x - 1) mod Length(rowlabels)) + 1],
+                              temp2[x])));
+
+  fi;
+
+  return str;
+end);
+
+BindGlobal("MonoidCharacterType",
+NewType(NewFamily("MonoidCharacterFamily"),
+        IsMonoidCharacter and
+        IsAttributeStoringRep));
+
+InstallMethod(MonoidCharacter,  "for a monoid character table and dense list",
+[IsMonoidCharacterTable, IsDenseList],
+function(ct, values)
+  local result;
+
+  result := Objectify(MonoidCharacterType, rec());
+  SetParentAttr(result, ct);
+  SetValuesOfMonoidClassFunction(result, values);
+
+  return result;
+end);
+
+InstallMethod(ViewString, "for a monoid character",
+[IsMonoidCharacter],
+function(char)
+  local str;
+  if HasValuesOfMonoidClassFunction(char) then
+    str := StringFormatted("MonoidCharacter( {} , {} )",
+           ViewString(ParentAttr(char)),
+           ValuesOfMonoidClassFunction(char));
+  elif HasProjectiveCoverOf(char) then
+    str := StringFormatted("MonoidCharacter( {} , Projective Cover Of {} )",
+           ViewString(ParentAttr(char)),
+           ViewString(ProjectiveCoverOf(char)));
+  fi;
+
+  return str;
+end);
+
+InstallMethod(DClassBicharacter, "for a D-class",
+[IsGreensDClass],
+function(D)
+  local S, C, cS, M, i, j;
+
+  S   := ParentAttr(D);
+  C   := GeneralizedConjugacyClassesRepresentatives(S);
+  cS  := Length(C);
+  M   := List([1 .. cS], x -> List([1 .. cS], y -> 0));
+
+  for i in [1 .. cS] do
+    for j in [1 .. cS] do
+      M[i][j] := Number(D, d -> C[i] * d * C[j] = d);
+    od;
+  od;
+
+  return M;
+end);
+
+InstallMethod(DClassBicharacter, "for a D-class of an acting semigroup",
+[IsGreensDClass and IsActingSemigroupGreensClass],
+function(D)
+  local S, C, G, cardG, CG, cG, cS, d,
+        l_mults, lp_mults, l, lp, r_mults, rp_mults, r, rp,
+        LRec, RRec, h, k, i, j, g, pos, Diag;
+
+  S   := ParentAttr(D);
+  C   := GeneralizedConjugacyClassesRepresentatives(S);
+  G   := SchutzenbergerGroup(D);
+  cardG := Size(G);
+  CG  := ConjugacyClasses(G);
+  cG  := Length(CG);
+  cS  := Length(C);
+
+  d   := Representative(D);
+
+  l_mults  := List(HClassReps(LClass(S, d)),
+                   h -> LeftGreensMultiplierNC(S, d, h));
+  lp_mults := List(HClassReps(LClass(S, d)),
+                   h -> LeftGreensMultiplierNC(S, h, d));
+  r_mults  := List(HClassReps(RClass(S, d)),
+                   h -> RightGreensMultiplierNC(S, d, h));
+  rp_mults := List(HClassReps(RClass(S, d)),
+                   h -> RightGreensMultiplierNC(S, h, d));
+
+  LRec := List([1 .. cS], x -> List([1 .. cG], y -> 0));
+
+  for i in [1 .. cS] do
+    h := C[i];
+    for j in [1 .. Length(l_mults)] do
+      l  := l_mults[j];
+      lp := lp_mults[j];
+      if h * l * d in RClass(S, l * d) then
+        g := Inverse(LambdaPerm(S)(d, lp * h * l * d));
+        pos := Position(CG, ConjugacyClass(G, g));
+        LRec[i][pos] := LRec[i][pos] + 1;
+      fi;
+    od;
+  od;
+
+  RRec := List([1 .. cG], x -> List([1 .. cS], y -> 0));
+
+  for i in [1 .. cS] do
+    k := C[i];
+    for j in [1 .. Length(r_mults)] do
+      r  := r_mults[j];
+      rp := rp_mults[j];
+      if d * r * k in LClass(S, d * r) then
+        g   := LambdaPerm(S)(d, d * r * k * rp);
+        pos := Position(CG, ConjugacyClass(G, g));
+        RRec[pos][i] := RRec[pos][i] + 1;
+      fi;
+    od;
+  od;
+
+  Diag := DiagonalMat(List(CG, x -> cardG / Size(x)));
+
+  return LRec * Diag * RRec;
+end);
+
+# M[i][j] := Number(S, s -> C[i] * s * C[j] = s);
+
+InstallMethod(RegularRepresentationBicharacter, "for a semigroup",
+[IsSemigroup],
+function(S)
+  local C, D, c, mat;
+
+  C := GeneralizedConjugacyClassesRepresentatives(S);
+  c := Length(C);
+  mat := List([1 .. c], x -> List([1 .. c], x -> 0));
+
+  for D in DClasses(S) do
+    mat := mat + DClassBicharacter(D);
+  od;
+
+  return mat;
+end);
+
+# M[i][j] := Number(RClass(S, e), r -> CG[i] * r * CS[j] = r);
+
+InstallMethod(RClassBicharacterOfGroupHClass, "for group H-class",
+[IsGroupHClass],
+function(H)
+  local S, e, CS, map, invmap, HH, r_mults, rp_mults,
+        cS, CG, cG, M, CHH, CardCentralizer,
+        i, j, k, r, rp, y, c;
+
+  S   := ParentAttr(H);
+  CS  := GeneralizedConjugacyClassesRepresentatives(S);
+  e   := MultiplicativeNeutralElement(H);
+  map := IsomorphismPermGroup(H);
+  HH  := Range(map);
+
+  cS   := Length(CS);
+  CHH  := ConjugacyClasses(OrdinaryCharacterTable(HH));
+
+  invmap := InverseGeneralMapping(map);
+
+  CG   := List(List(CHH, Representative), x -> x ^ invmap);
+  cG   := Length(CG);
+  M    := List([1 .. cG], x -> List([1 .. cS], x -> 0));
+
+  CardCentralizer := List(CG, c -> Size(Centralizer(HH, c ^ map)));
+
+  r_mults  := List(HClassReps(RClassOfHClass(H)),
+                  h -> RightGreensMultiplierNC(S, e, h));
+  rp_mults := List(HClassReps(RClassOfHClass(H)),
+                  h -> RightGreensMultiplierNC(S, h, e));
+
+  for j in [1 .. cS] do
+      for k in [1 .. Length(r_mults)] do
+        r  := r_mults[k];
+        rp := rp_mults[k];
+        if e * r * CS[j] in HClass(S, e * r) then
+          y := Inverse((e * r * CS[j] * rp) ^ map);
+          c := ConjugacyClass(HH, y);
+          i := Position(CHH, c);
+          M[i][j] := M[i][j] + CardCentralizer[i];
+        fi;
+      od;
+  od;
+
+  return M;
+end);
+
+InstallMethod(RClassRadicalOfGroupHClass,  "for group H-class",
+[IsGroupHClass],
+function(H)
+  local S, e, ord, HH, LHH, map,
+        l_mults, r_mults, rp_mults, nl, nr,
+        M, Rad, c, j, r, k, i, l, x;
+
+  S   := ParentAttr(H);
+  e   := MultiplicativeNeutralElement(H);
+  ord := Size(H);
+  map := IsomorphismPermGroup(H);
+  HH  := Range(map);
+  LHH := List(HH);
+
+  l_mults  := List(HClassReps(LClassOfHClass(H)),
+                   h -> LeftGreensMultiplierNC(S, e, h) * e);
+  r_mults  := List(HClassReps(RClassOfHClass(H)),
+                   h -> e * RightGreensMultiplierNC(S, e, h));
+  rp_mults := List(HClassReps(RClassOfHClass(H)),
+                   h -> RightGreensMultiplierNC(S, h, e) * e);
+  nl := Length(l_mults);
+  nr := Length(r_mults);
+
+  M := List([1 .. ord * nl], x -> List([1 .. ord * nr], x -> 0));
+
+  c := 0;
+  for k in H do
+    for i in [1 .. nl] do
+      l := l_mults[i];
+      for j in [1 .. nr] do
+        r  := r_mults[j];
+        if (r * l) in H then
+          x := (k ^ map) * ((r * l) ^ map) ^ (-1);
+          M[i + nl * c][(j - 1) * ord + Position(LHH, x)] := 1;
+        fi;
+      od;
+    od;
+    c := c + 1;
+  od;
+
+  Rad := NullspaceMat(TransposedMatMutable(M));
+
+  return rec(rad := Rad,
+             transitions := r_mults,
+             returns := rp_mults,
+             HList := LHH);
+end);
+
+# M[i][j] := Trace of action x -> CG[i] * x * CS[j];
+
+InstallMethod(RClassRadicalBicharacterOfGroupHClass,  "for group H-class",
+[IsGroupHClass],
+function(H)
+  local S, e, Rec, Rad, LHH, map, invmap, r_mults, rp_mults,
+        ListLClass, n, HH, CHH, ord, B, dim,
+        CS, cS, CG, cG, mat, compt,
+        h, k, chi, ind_r, r, row, i, coeff,
+        ind_transition, ind_groupe, x, lp, g, ind_l_class;
+
+  S   := ParentAttr(H);
+  e   := MultiplicativeNeutralElement(H);
+
+  CS   := GeneralizedConjugacyClassesRepresentatives(S);
+  cS   := Length(CS);
+
+  map := IsomorphismPermGroup(H);
+  invmap := InverseGeneralMapping(map);
+
+  HH  := Range(map);
+  CHH  := ConjugacyClasses(OrdinaryCharacterTable(HH));
+
+  CG   := List(List(CHH, Representative), x -> x ^ invmap);
+  cG   := Length(CG);
+
+  Rec := RClassRadicalOfGroupHClass(H);
+  Rad := Rec.rad;
+  LHH := Rec.HList;
+  r_mults  := Rec.transitions;
+  rp_mults := Rec.returns;
+
+  ListLClass := List(r_mults, r -> LClass(S, e * r));
+
+  if Length(Rad) = 0 then
+    Rad := [[0]];
+  fi;
+  n    := Length(Rad[1]);
+  ord  := Length(LHH);
+  B    := Basis(VectorSpace(Rationals, Rad));
+  dim  := Length(B);
+
+  mat  := List([1 .. cG], x -> List([1 .. cS], x -> 0));
+
+  for h in CS do
+    for k in CG do
+      chi := 0;
+
+      # Computing the contribution to the trace of each basis vector
+      for ind_r in [1 .. dim] do
+        r   := B[ind_r];
+        row := List([1 .. n], x -> 0);
+        compt := 0;
+        # Computing the image of the vector
+        for i in [1 .. n] do
+          coeff := r[i];
+          if coeff = 0 then continue;
+          fi;
+          ind_transition := QuoInt(i - 1, ord) + 1;
+          ind_groupe := RemInt(i - 1, ord) + 1;
+          x := k * (LHH[ind_groupe] ^ invmap) * r_mults[ind_transition] * h;
+          ind_transition := Position(ListLClass, LClass(S, x));
+          # Changed from not ind_transition = fail
+          if ind_transition <> fail then
+            compt := compt + 1;
+
+            lp := rp_mults[ind_transition];
+
+            g  := (e * x * lp) ^ map;
+            ind_groupe  := Position(LHH, g);
+            ind_l_class := (ind_transition - 1) * ord + ind_groupe;
+            row[ind_l_class] := row[ind_l_class] + coeff;
+          fi;
+        od;
+        chi := chi + Coefficients(B, row)[ind_r];
+      od;
+      mat[Position(CG, k)][Position(CS, h)] := chi;
+    od;
+  od;
+
+  return mat;
+end);
+
+InstallMethod(BlockDiagonalMatrixOfCharacterTables,  "for a semigroup",
+[IsSemigroup],
+function(S)
+  # Removed loval variable CS
+  local transversalHclasses, maps, groups, charactertables,
+      irrs, mats;
+
+  # Removed following line of code as a part of linting.
+  # The following line of code was run early to ensures that the
+  # conjugacy classes were computed in the same order each time.
+  # As I have learned more about the GAP language this step might be
+  # unnecessary. Until I am sure, I will leave this line here with
+  # this comment.
+  # CS := GeneralizedConjugacyClassesRepresentatives(S);
+
+  transversalHclasses := List(RegularDClasses(S), GroupHClass);
+  maps := List(transversalHclasses, IsomorphismPermGroup);
+  groups := List(maps, Range);
+  charactertables := List(groups, CharacterTable);
+  irrs := List(charactertables, Irr);
+  mats := List(irrs, x -> List(x, ValuesOfClassFunction));
+
+  return DirectSumMat(mats);
+end);
+
+InstallMethod(Irr,  "for a monoid character table",
+[IsMonoidCharacterTable],
+function(ct)
+  local R, Rrad, D, transversalHclasses, irrvalues;
+
+  D := BlockDiagonalMatrixOfCharacterTables(ParentAttr(ct));
+  transversalHclasses := List(RegularDClasses(ParentAttr(ct)), GroupHClass);
+  R := Concatenation(List(transversalHclasses, RClassBicharacterOfGroupHClass));
+  Rrad := Concatenation(List(transversalHclasses,
+                        RClassRadicalBicharacterOfGroupHClass));
+  irrvalues := Inverse(TransposedMat(D)) * (R - Rrad);
+  return List(irrvalues, x -> MonoidCharacter(ct, x));
+end);
+
+InstallMethod(PimMonoidCharacter,
+"for a monoid character table, dense list, and monoid character",
+[IsMonoidCharacterTable, IsDenseList, IsMonoidCharacter],
+function(ct, values, char)
+  local result;
+
+  result := Objectify(MonoidCharacterType, rec());
+  SetParentAttr(result, ct);
+  SetValuesOfCompositionFactorsFunction(result, values);
+  SetProjectiveCoverOf(result, char);
+
+  return result;
+end);
+
+InstallMethod(Pims,  "for a monoid Cartan matrix",
+[IsMonoidCartanMatrix],
+function(cm)
+  local C, S, ct, M, out;
+
+  S := ParentAttr(cm);
+  ct := MonoidCharacterTable(S);
+  C := List(Irr(ct), ValuesOfMonoidClassFunction);
+  M := RegularRepresentationBicharacter(S);
+  out := Inverse(TransposedMatMutable(C)) * M * Inverse(C);
+
+  return List([1 .. Length(out)],
+                n -> PimMonoidCharacter(ct, out[n], Irr(ct)[n]));
+end);

--- a/gap/greens/acting.gi
+++ b/gap/greens/acting.gi
@@ -1732,6 +1732,7 @@ end);
 InstallMethod(LeftGreensMultiplierNC,
 "for an acting semigroup and L-related elements",
 [IsActingSemigroup, IsMultiplicativeElement, IsMultiplicativeElement],
+11,  # RankFilter(IsGroupAsSemigroup) - #RankFilter(IsActingSemigroup) + 1
 function(S, a, b)
   local o, l, m, result, p;
 

--- a/init.g
+++ b/init.g
@@ -114,6 +114,7 @@ ReadPackage("semigroups", "gap/tools/utils.gd");
 
 ReadPackage("semigroups", "gap/attributes/acting.gd");
 ReadPackage("semigroups", "gap/attributes/attr.gd");
+ReadPackage("semigroups", "gap/attributes/cartan.gd");
 ReadPackage("semigroups", "gap/attributes/dual.gd");
 ReadPackage("semigroups", "gap/attributes/factor.gd");
 ReadPackage("semigroups", "gap/attributes/inverse.gd");

--- a/read.g
+++ b/read.g
@@ -71,6 +71,7 @@ ReadPackage("semigroups", "gap/greens/generic.gi");
 
 ReadPackage("semigroups", "gap/attributes/acting.gi");
 ReadPackage("semigroups", "gap/attributes/attr.gi");
+ReadPackage("semigroups", "gap/attributes/cartan.gi");
 ReadPackage("semigroups", "gap/attributes/dual.gi");
 ReadPackage("semigroups", "gap/attributes/factor.gi");
 ReadPackage("semigroups", "gap/attributes/homomorph.gi");

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -1,0 +1,138 @@
+#############################################################################
+##
+#W  standard/attributes/cartan.tst
+#Y  Copyright (C) 2024                                   Balthazar Charles
+##                                                             Joseph Ruiz
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+
+#@local S, ct, D, H, cm, irr, known, pims, mat, M, m, ccm, matl, perm, i
+gap> START_TEST("Semigroups package: standard/attributes/cartan.tst");
+gap> LoadPackage("semigroups", false);;
+
+#
+gap> SEMIGROUPS.StartTest();
+
+#  Creation of a lazy monoid character table - 1
+gap> S := FullTransformationMonoid(3);;
+gap> MonoidCharacterTable(S);
+MonoidCharacterTable( Monoid( [ Transformation( [ 2, 3, 1 ] ), Transformation(\
+ [ 2, 1 ] ), Transformation( [ 1, 2, 1 ] ) ] ) )
+
+#  Basic GeneralizedConjugacyClass information is strored correctly
+gap> M := FullTransformationMonoid(3);;
+gap> m := Random(M);;
+gap> ccm := GeneralizedConjugacyClass(M, m);;
+gap> Representative(ccm) = m;
+true
+gap> ParentAttr(ccm) = M;
+true
+
+#  ViewString GeneralizedConjugacyClass test
+gap> M := FullTransformationMonoid(3);;
+gap> m := Transformation([3, 2, 2]);;
+gap> GeneralizedConjugacyClass(M, m);
+<generalized conjugacy class in Monoid( [ Transformation( [ 2, 3, 1 ] ), Trans\
+formation( [ 2, 1 ] ), Transformation( [ 1, 2, 1 ] ) ] ) for representative Tr\
+ansformation( [ 3, 2, 2 ] )>
+
+#  Simple check of a monoid character table  - 1
+gap> S := FullTransformationMonoid(3);;
+gap> ct := MonoidCharacterTable(S);;
+gap> irr := Irr(ct);;
+gap> mat := List(irr, ValuesOfMonoidClassFunction);;
+gap> known := [[1, -1, 1, 0, 0, 0],
+> [2, 0, -1, 0, 0, 0],
+> [1, 1, 1, 0, 0, 0],
+> [2, 0, -1, 1, -1, 0],
+> [3, 1, 0, 1, 1, 0],
+> [1, 1, 1, 1, 1, 1]];;
+gap> TransformingPermutations(mat, known) <> fail;
+true
+
+#  Creation of a lazy monoid cartan matrix - 1
+gap> S := FullTransformationMonoid(3);;
+gap> MonoidCartanMatrix(S);
+MonoidCartanMatrix( Monoid( [ Transformation( [ 2, 3, 1 ] ), Transformation( [\
+ 2, 1 ] ), Transformation( [ 1, 2, 1 ] ) ] ) )
+
+#  Simple check of a monoid cartan matrix  - 1
+gap> S := FullTransformationMonoid(3);;
+gap> cm := MonoidCartanMatrix(S);;
+gap> pims := Pims(cm);;
+gap> mat := List(pims, ValuesOfCompositionFactorsFunction);;
+gap> known := [[1, 0, 0, 0, 0, 0],
+> [0, 1, 0, 0, 0, 0],
+> [1, 0, 1, 1, 0, 0],
+> [1, 0, 0, 1, 0, 0],
+> [0, 0, 0, 0, 1, 0],
+> [0, 0, 0, 1, 0, 1]];;
+gap> TransformingPermutations(mat, known) <> fail;
+true
+
+#  Simple check of a monoid DClassBicharacter - 1
+gap> S := FullTransformationMonoid(3);;
+gap> D := DClasses(S);;
+gap> matl := List(D, DClassBicharacter);;
+gap> known := [[[6, 0, 0, 0, 0, 0],
+> [0, 2, 0, 0, 0, 0],
+> [0, 0, 3, 0, 0, 0],
+> [0, 0, 0, 0, 0, 0],
+> [0, 0, 0, 0, 0, 0],
+> [0, 0, 0, 0, 0, 0]],
+> [[18, 0, 0, 6, 0, 0],
+> [6, 0, 0, 2, 0, 0],
+> [0, 0, 0, 0, 0, 0],
+> [6, 0, 0, 2, 0, 0],
+> [0, 2, 0, 0, 2, 0],
+> [0, 0, 0, 0, 0, 0]],
+> [[3, 1, 0, 2, 0, 1],
+> [3, 1, 0, 2, 0, 1],
+> [3, 1, 0, 2, 0, 1],
+> [3, 1, 0, 2, 0, 1],
+> [3, 1, 0, 2, 0, 1],
+> [3, 1, 0, 2, 0, 1]]];;
+gap> for perm in PermutationsList(matl) do
+> if ForAll([1 .. Length(known)], i -> (TransformingPermutations(perm[i], known[i]) <> fail)) then
+> Display(ForAll([1 .. Length(known)], i -> (TransformingPermutations(perm[i], known[i]) <> fail)));
+> fi;
+> od;
+true
+
+#  Simple check of a monoid DClassBicharacter - 2
+gap> S := FullBooleanMatMonoid(2);;
+gap> D := DClasses(S);;
+gap> matl := List(D, DClassBicharacter);;
+gap> known := [[[1, 1, 1, 1, 1], 
+> [1, 1, 1, 1, 1], 
+> [1, 1, 1, 1, 1], 
+> [1, 1, 1, 1, 1], 
+> [1, 1, 1, 1, 1]], 
+> [[0, 0, 0, 0, 0], 
+> [0, 1, 2, 3, 1],
+> [0, 2, 4, 6, 2], 
+> [0, 3, 6, 9, 3], 
+> [0, 1, 2, 3, 1]], 
+> [[0, 0, 0, 0, 0], 
+> [0, 0, 0, 0, 0], 
+> [0, 0, 1, 2, 0], 
+> [0, 0, 2, 4, 0], 
+> [0, 0, 0, 0, 0]],
+> [[0, 0, 0, 0, 0], 
+> [0, 0, 0, 0, 0], 
+> [0, 0, 0, 0, 0], 
+> [0, 0, 0, 2, 0], 
+> [0, 0, 0, 0, 2]]];;
+gap> for perm in PermutationsList(matl) do
+> if ForAll([1 .. Length(known)], i -> (TransformingPermutations(perm[i], known[i]) <> fail)) then
+> Display(ForAll([1 .. Length(known)], i -> (TransformingPermutations(perm[i], known[i]) <> fail)));
+> fi;
+> od;
+true
+
+#
+gap> SEMIGROUPS.StopTest();
+gap> STOP_TEST("Semigroups package: standard/attributes/cartan.tst");

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -70,6 +70,7 @@ X.4   2   .  -1   1  -1   .
 X.5   3   1   .   1   1   .
 X.6   1   1   1   1   1   1
 
+
 #  Creation of a lazy monoid cartan matrix - 1
 gap> S := FullTransformationMonoid(3);;
 gap> MonoidCartanMatrix(S);

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -53,6 +53,23 @@ gap> known := [[1, -1, 1, 0, 0, 0],
 gap> TransformingPermutations(mat, known) <> fail;
 true
 
+# Check display string of MonoidCharacterTable - 1
+# Explicitly enable acting methods because the order of the D-classes
+# is not canonical and a permutation on the D-classes may be lead to
+# a different display string.
+gap> S := Monoid(FullTransformationMonoid(3), rec(acting := true));;
+gap> ct := MonoidCharacterTable(S);;
+gap> Irr(ct);;
+gap> Display(ct);
+    c.1 c.2 c.3 c.4 c.5 c.6
+                           
+X.1   1  -1   1   .   .   .
+X.2   2   .  -1   .   .   .
+X.3   1   1   1   .   .   .
+X.4   2   .  -1   1  -1   .
+X.5   3   1   .   1   1   .
+X.6   1   1   1   1   1   1
+
 #  Creation of a lazy monoid cartan matrix - 1
 gap> S := FullTransformationMonoid(3);;
 gap> MonoidCartanMatrix(S);
@@ -72,6 +89,23 @@ gap> known := [[1, 0, 0, 0, 0, 0],
 > [0, 0, 0, 1, 0, 1]];;
 gap> TransformingPermutations(mat, known) <> fail;
 true
+
+# Check display string of MonoidCartanMatrix - 1
+# Explicitly enable acting methods because the order of the D-classes
+# is not canonical and a permutation on the D-classes may be lead to
+# a different display string.
+gap> S := Monoid(FullTransformationMonoid(3), rec(acting := true));;
+gap> cm := MonoidCartanMatrix(S);;
+gap> Pims(cm);;
+gap> Display(cm);
+    X.1 X.2 X.3 X.4 X.5 X.6
+                           
+P.1   1   .   .   .   .   .
+P.2   .   1   .   .   .   .
+P.3   1   .   1   1   .   .
+P.4   1   .   .   1   .   .
+P.5   .   .   .   .   1   .
+P.6   .   .   .   1   .   1
 
 #  Simple check of a monoid DClassBicharacter - 1
 gap> S := FullTransformationMonoid(3);;


### PR DESCRIPTION
This PR add several functions which allow for the computation of the character table of a monoid and the Cartan matraix of a monoid which satisfy IsActingSemigroups. The current implementation is close to the original implementation of [Balthazar Charles](https://github.com/ZoltanCoccyx).