### PR TITLE
PermuteMultiplicationTable, refactor OnMultiplicationTable, add docs

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -28,6 +28,7 @@ KEXT_SOURCES += src/froidure-pin-min-plus-mat.cpp
 KEXT_SOURCES += src/froidure-pin-pbr.cpp
 KEXT_SOURCES += src/froidure-pin-pperm.cpp
 KEXT_SOURCES += src/froidure-pin-transf.cpp
+KEXT_SOURCES += src/isomorph.cpp
 KEXT_SOURCES += src/pkg.cpp
 KEXT_SOURCES += src/to_gap.cpp
 KEXT_SOURCES += gapbind14/src/gapbind14.cpp

--- a/doc/isomorph.xml
+++ b/doc/isomorph.xml
@@ -11,16 +11,20 @@
 <#GAPDoc Label="OnMultiplicationTable">
 <ManSection>
   <Oper Name = "OnMultiplicationTable" Arg = "table, p"/>
-  <Returns>
-    A multiplication table.
-  </Returns>
+  <Oper Name = "PermuteMultiplicationTable" Arg = "temp, table, p"/>
   <Description>
     If <A>table</A> is a multiplication table of a semigroup and the second
     argument <A>p</A> is a permutation of
-    <C>[1 .. Length(<A>table</A>)]</C>, then this operation returns a
+    <C>[1 .. Length(<A>table</A>)]</C>, then <C>OnMultiplicationTable</C> returns a
     multiplication table of a semigroup isomorphic to that defined by
     <A>table</A> where the elements <C>[1 .. Length(<A>table</A>)]</C> are
-    relabelled according to <A>p</A>.
+    relabelled according to <A>p</A>.<P/>
+
+    <C>PermuteMultiplicationTable</C> works similarly but takes an additional argument <A>temp</A>, 
+    which should be a list of mutable lists of the same dimensions as <A>table</A>.
+    The argument <A>temp</A> is modified in-place to store the multiplication table that would be given by 
+    <C>OnMultiplicationTable(<A>table</A>, <A>p</A>)</C>, while the argument <A>table</A> remains unchanged.
+    This approach is preferred over <C>OnMultiplicationTable</C> when the user does not need to create a separate result variable.
 
     <Example><![CDATA[
 gap> table := [[1, 1, 3, 4, 5, 6, 7, 8],
@@ -36,7 +40,12 @@ gap> OnMultiplicationTable(table, p);
 [ [ 1, 2, 4, 4, 5, 6, 7, 8 ], [ 1, 2, 2, 4, 5, 6, 7, 8 ],
   [ 1, 2, 2, 4, 5, 6, 7, 8 ], [ 1, 2, 2, 4, 5, 6, 7, 8 ],
   [ 7, 5, 5, 6, 5, 6, 7, 8 ], [ 7, 5, 5, 6, 5, 6, 7, 8 ],
-  [ 7, 5, 6, 6, 5, 6, 7, 8 ], [ 7, 5, 6, 6, 5, 6, 7, 8 ] ]]]></Example>
+  [ 7, 5, 6, 6, 5, 6, 7, 8 ], [ 7, 5, 6, 6, 5, 6, 7, 8 ] ]
+gap> temp := List([1 .. Size(table)], x -> [1 .. Size(table)]);;
+gap> PermuteMultiplicationTable(temp, table, p);;
+gap> temp = OnMultiplicationTable(table, p);
+true]]>
+  </Example>
   </Description>
 </ManSection>
 <#/GAPDoc>

--- a/doc/isomorph.xml
+++ b/doc/isomorph.xml
@@ -11,20 +11,22 @@
 <#GAPDoc Label="OnMultiplicationTable">
 <ManSection>
   <Oper Name = "OnMultiplicationTable" Arg = "table, p"/>
-  <Oper Name = "PermuteMultiplicationTable" Arg = "temp, table, p"/>
+  <Oper Name = "PermuteMultiplicationTable" Arg = "output, table, p"/>
+  <Oper Name = "PermuteMultiplicationTableNC" Arg = "output, table, p"/>
   <Description>
-    If <A>table</A> is a multiplication table of a semigroup and the second
-    argument <A>p</A> is a permutation of
-    <C>[1 .. Length(<A>table</A>)]</C>, then <C>OnMultiplicationTable</C> returns a
-    multiplication table of a semigroup isomorphic to that defined by
-    <A>table</A> where the elements <C>[1 .. Length(<A>table</A>)]</C> are
+    If <A>table</A> is a multiplication table of a semigroup and <A>p</A> is a permutation of
+    <C>[1 .. Length(<A>table</A>)]</C>, then <C>OnMultiplicationTable</C> returns the
+    multiplication table obtained from <A>table</A> where the elements <C>[1 .. Length(<A>table</A>)]</C> are
     relabelled according to <A>p</A>.<P/>
 
-    <C>PermuteMultiplicationTable</C> works similarly but takes an additional argument <A>temp</A>, 
+    <C>PermuteMultiplicationTable</C> works similarly but takes an additional argument <A>output</A>, 
     which should be a list of mutable lists of the same dimensions as <A>table</A>.
-    The argument <A>temp</A> is modified in-place to store the multiplication table that would be given by 
+    The argument <A>output</A> is modified in-place to store the multiplication table that would be given by 
     <C>OnMultiplicationTable(<A>table</A>, <A>p</A>)</C>, while the argument <A>table</A> remains unchanged.
-    This approach is preferred over <C>OnMultiplicationTable</C> when the user does not need to create a separate result variable.
+    This approach is preferred over <C>OnMultiplicationTable</C> when the user does not need to create a separate result variable.<P/>
+
+    <C>PermuteMultiplicationTableNC</C> is the operation called by <C>PermuteMultiplicationTable</C>. It assumes that the 
+    arguments <A>output</A>, <A>table</A> and <A>p</A> are well-formed and can therefore lead to unexpected results. <P/>
 
     <Example><![CDATA[
 gap> table := [[1, 1, 3, 4, 5, 6, 7, 8],

--- a/gap/attributes/isomorph.gi
+++ b/gap/attributes/isomorph.gi
@@ -19,9 +19,8 @@ InstallMethod(OnMultiplicationTable, "for a multiplication table, and perm",
 [IsRectangularTable, IsPerm],
 function(table, p)
   local out;
-  out := Permuted(table, p);
-  Apply(out, x -> OnTuples(x, p));
-  Apply(out, x -> Permuted(x, p));
+  out := List(table, ShallowCopy);
+  PermuteMultiplicationTable(out, table, p);
   return out;
 end);
 

--- a/src/isomorph.cpp
+++ b/src/isomorph.cpp
@@ -1,0 +1,61 @@
+#include "gap_all.h"
+#include "isomorph.hpp"
+
+
+Obj PermuteMultiplicationTable(Obj self, Obj temp, Obj M, Obj p) {
+    int n = LEN_LIST(M);
+
+    if (LEN_LIST(temp) != n) {
+        ErrorQuit("the arguments <temp> and <table> must have the same dimensions", 0L, 0L);
+    }
+    for (int i = 1; i <= n; i++) {
+        if (LEN_LIST(ELM_LIST(temp, i)) != n) {
+            ErrorQuit("the arguments <temp> and <table> must have the same dimensions", 0L, 0L);
+        }
+    }
+
+    if (IS_PERM(p) == 0) {
+        ErrorQuit("the argument <p> must be a permutation", 0L, 0L);
+    }
+  
+    int p_type = TNUM_OBJ(p);
+    if (p_type == T_PERM2) {
+        int deg_p = DEG_PERM2(p);
+        Obj q = STOREDINV_PERM(p);
+        if (q == 0) {
+            q = INV(p);
+            SET_STOREDINV_PERM(p, q);
+          }
+        int deg_q = DEG_PERM2(q);
+        for (int i = 1; i <= n; i++) {
+          Obj row = ELM_LIST(temp, i);
+          int ii = IMAGE(i - 1, CONST_ADDR_PERM2(q), deg_q) + 1;
+      
+          for (int j = 1; j <= n; j++) {
+            int home = Int_ObjInt(ELM_LIST(ELM_LIST(M, ii), IMAGE(j - 1, CONST_ADDR_PERM2(q), deg_q) + 1));
+            int new_val = IMAGE(home - 1, CONST_ADDR_PERM2(p), deg_p) + 1;
+            ASS_LIST(row, j, INTOBJ_INT(new_val));
+          }
+        }
+      } else {
+        int deg_p = DEG_PERM4(p);
+        Obj q = STOREDINV_PERM(p);
+        if (q == 0) {
+            q = INV(p);
+            SET_STOREDINV_PERM(p, q);
+          }
+        int deg_q = DEG_PERM4(q);
+        for (int i = 1; i <= n; i++) {
+          Obj row = ELM_LIST(temp, i);
+          int ii = IMAGE(i - 1, CONST_ADDR_PERM4(q), deg_q) + 1;
+      
+          for (int j = 1; j <= n; j++) {
+            int home = Int_ObjInt(ELM_LIST(ELM_LIST(M, ii), IMAGE(j - 1, CONST_ADDR_PERM4(q), deg_q) + 1));
+            int new_val = IMAGE(home - 1, CONST_ADDR_PERM4(p), deg_p) + 1;
+            ASS_LIST(row, j, INTOBJ_INT(new_val));
+          }
+        }
+      }
+    CHANGED_BAG(temp);
+    return 0L;
+  }

--- a/src/isomorph.cpp
+++ b/src/isomorph.cpp
@@ -57,7 +57,7 @@ Obj PermuteMultiplicationTableNC(Obj self, Obj output, Obj table, Obj p) {
       UInt ii  = IMAGE(i - 1, CONST_ADDR_PERM4(q), deg_q) + 1;
 
       for (UInt j = 1; j <= n; j++) {
-        UInt home    = Int_ObjInt(ELM_LIST(
+        UInt home    = INT_INTOBJ(ELM_LIST(
             ELM_LIST(table, ii), IMAGE(j - 1, CONST_ADDR_PERM4(q), deg_q) + 1));
         UInt new_val = IMAGE(home - 1, CONST_ADDR_PERM4(p), deg_p) + 1;
         ASS_LIST(row, j, INTOBJ_INT(new_val));

--- a/src/isomorph.cpp
+++ b/src/isomorph.cpp
@@ -21,12 +21,11 @@
 #include "semigroups-debug.hpp"  // for SEMIGROUPS_ASSERT
 
 Obj PermuteMultiplicationTableNC(Obj self, Obj output, Obj table, Obj p) {
-  SEMIGROUPS_ASSERT(IS_LIST(output));
   SEMIGROUPS_ASSERT(IS_LIST(table));
-  SEMIGROUPS_ASSERT(IS_PERM(p));
-  SEMIGROUPS_ASSERT(LEN_LIST(output) == LEN_LIST(table));
-
   UInt n = LEN_LIST(table);
+  SEMIGROUPS_ASSERT(IS_LIST(output));
+  SEMIGROUPS_ASSERT(IS_PERM(p));
+  SEMIGROUPS_ASSERT(LEN_LIST(output) == n);
 
   for (UInt i = 1; i <= n; i++) {
     SEMIGROUPS_ASSERT(IS_LIST(ELM_LIST(table, i)));

--- a/src/isomorph.cpp
+++ b/src/isomorph.cpp
@@ -1,6 +1,6 @@
 //
 // Semigroups package for GAP
-// Copyright (C) 2016 James D. Mitchell
+// Copyright (C) 2025 Pramoth Ragavan
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -20,86 +20,111 @@
 #include "gap_all.h"
 #include "semigroups-debug.hpp"  // for SEMIGROUPS_ASSERT
 
-Obj PermuteMultiplicationTable(Obj self, Obj temp, Obj table, Obj p) {
-  if (IS_LIST(temp) == 0 || IS_LIST(table) == 0) {
-    ErrorQuit("the arguments <temp> and <table> must be lists", 0L, 0L);
-  }
+Obj PermuteMultiplicationTableNC(Obj self, Obj output, Obj table, Obj p) {
+  UInt n = LEN_LIST(table);
 
-  int n = LEN_LIST(table);
-
-  if (LEN_LIST(temp) != n) {
-    ErrorQuit("the arguments <temp> and <table> must have the same dimensions",
-              0L,
-              0L);
-  }
-
-  for (int i = 1; i <= n; i++) {
-    if (IS_LIST(ELM_LIST(temp, i)) == 0 || IS_LIST(ELM_LIST(table, i)) == 0) {
-      ErrorQuit("the elements of <temp> and <table> must be lists", 0L, 0L);
-    }
-    if (LEN_LIST(ELM_LIST(temp, i)) != n || LEN_LIST(ELM_LIST(table, i)) != n) {
-      ErrorQuit("the arguments <temp> and <table> must be square tables of the "
-                "same dimensions",
-                0L,
-                0L);
-    }
-    for (int j = 1; j <= n; j++) {
-      Obj elem = ELM_LIST(ELM_LIST(table, i), j);
-      if (!IS_INTOBJ(elem) || Int_ObjInt(elem) < 1 || Int_ObjInt(elem) > n) {
-        ErrorQuit("all entries in <table> must be positive integers from 1 to "
-                  "Size(<table>)",
-                  0L,
-                  0L);
-      }
-    }
-  }
-
-  if (IS_PERM(p) == 0) {
-    ErrorQuit("the argument <p> must be a permutation", 0L, 0L);
-  }
-
-  int p_type = TNUM_OBJ(p);
-  if (p_type == T_PERM2) {
-    int deg_p = DEG_PERM2(p);
-    Obj q     = STOREDINV_PERM(p);
+  if (TNUM_OBJ(p) == T_PERM2) {
+    UInt deg_p = DEG_PERM2(p);
+    Obj  q     = STOREDINV_PERM(p);
     if (q == 0) {
       q = INV(p);
       SET_STOREDINV_PERM(p, q);
     }
     SEMIGROUPS_ASSERT(TNUM_OBJ(q) == T_PERM2);
-    int deg_q = DEG_PERM2(q);
-    for (int i = 1; i <= n; i++) {
-      Obj row = ELM_LIST(temp, i);
-      int ii  = IMAGE(i - 1, CONST_ADDR_PERM2(q), deg_q) + 1;
+    UInt deg_q = DEG_PERM2(q);
+    for (UInt i = 1; i <= n; i++) {
+      Obj  row = ELM_LIST(output, i);
+      UInt ii  = IMAGE(i - 1, CONST_ADDR_PERM2(q), deg_q) + 1;
 
-      for (int j = 1; j <= n; j++) {
-        int home    = Int_ObjInt(ELM_LIST(
+      for (UInt j = 1; j <= n; j++) {
+        UInt home    = Int_ObjInt(ELM_LIST(
             ELM_LIST(table, ii), IMAGE(j - 1, CONST_ADDR_PERM2(q), deg_q) + 1));
-        int new_val = IMAGE(home - 1, CONST_ADDR_PERM2(p), deg_p) + 1;
+        UInt new_val = IMAGE(home - 1, CONST_ADDR_PERM2(p), deg_p) + 1;
         ASS_LIST(row, j, INTOBJ_INT(new_val));
       }
     }
   } else {
-    int deg_p = DEG_PERM4(p);
-    Obj q     = STOREDINV_PERM(p);
+    UInt deg_p = DEG_PERM4(p);
+    Obj  q     = STOREDINV_PERM(p);
     if (q == 0) {
       q = INV(p);
       SET_STOREDINV_PERM(p, q);
     }
     SEMIGROUPS_ASSERT(TNUM_OBJ(q) == T_PERM4);
-    int deg_q = DEG_PERM4(q);
-    for (int i = 1; i <= n; i++) {
-      Obj row = ELM_LIST(temp, i);
-      int ii  = IMAGE(i - 1, CONST_ADDR_PERM4(q), deg_q) + 1;
+    UInt deg_q = DEG_PERM4(q);
+    for (UInt i = 1; i <= n; i++) {
+      Obj  row = ELM_LIST(output, i);
+      UInt ii  = IMAGE(i - 1, CONST_ADDR_PERM4(q), deg_q) + 1;
 
-      for (int j = 1; j <= n; j++) {
-        int home    = Int_ObjInt(ELM_LIST(
+      for (UInt j = 1; j <= n; j++) {
+        UInt home    = Int_ObjInt(ELM_LIST(
             ELM_LIST(table, ii), IMAGE(j - 1, CONST_ADDR_PERM4(q), deg_q) + 1));
-        int new_val = IMAGE(home - 1, CONST_ADDR_PERM4(p), deg_p) + 1;
+        UInt new_val = IMAGE(home - 1, CONST_ADDR_PERM4(p), deg_p) + 1;
         ASS_LIST(row, j, INTOBJ_INT(new_val));
       }
     }
   }
-  CHANGED_BAG(temp);
+  CHANGED_BAG(output);
+  return 0L;
+}
+
+Obj PermuteMultiplicationTable(Obj self, Obj output, Obj table, Obj p) {
+  if (!IS_LIST(output) || !IS_LIST(table)) {
+    ErrorMayQuit("the arguments <output> and <table> must be lists but found "
+                 "types '%s' and '%s' respectively",
+                 (Int) TNAM_OBJ(output),
+                 (Int) TNAM_OBJ(table));
+  }
+
+  UInt n = LEN_LIST(table);
+
+  if (LEN_LIST(output) != n) {
+    ErrorMayQuit("the arguments <output> and <table> must have the same "
+                 "dimensions but found lengths %d and %d, respectively",
+                 LEN_LIST(output),
+                 LEN_LIST(table));
+  }
+
+  for (UInt i = 1; i <= n; i++) {
+    if (!IS_LIST(ELM_LIST(output, i))) {
+      ErrorMayQuit("the elements of the first argument <output> must be lists, "
+                   "but found an element of type '%s' at position %d",
+                   (Int) TNAM_OBJ(ELM_LIST(output, i)),
+                   i);
+    }
+    if (!IS_LIST(ELM_LIST(table, i))) {
+      ErrorMayQuit("the elements of the second argument <table> must be lists, "
+                   "but found an element of type '%s' at position %d",
+                   (Int) TNAM_OBJ(ELM_LIST(table, i)),
+                   i);
+    }
+    if (LEN_LIST(ELM_LIST(output, i)) != n) {
+      ErrorMayQuit("the first argument <output> must be a square table, but "
+                   "found a list of length %d at position %d",
+                   LEN_LIST(ELM_LIST(output, i)),
+                   i);
+    }
+    if (LEN_LIST(ELM_LIST(table, i)) != n) {
+      ErrorMayQuit("the first argument <output> must be a square table, but "
+                   "found a list of length %d at position %d",
+                   LEN_LIST(ELM_LIST(table, i)),
+                   i);
+    }
+    for (UInt j = 1; j <= n; j++) {
+      Obj elem = ELM_LIST(ELM_LIST(table, i), j);
+      if (!IS_INTOBJ(elem) || Int_ObjInt(elem) < 1 || Int_ObjInt(elem) > n) {
+        ErrorMayQuit("all entries in the first argument <table> must be "
+                     "positive integers from 1 to "
+                     "Size(<table>) = %d",
+                     LEN_LIST(table),
+                     0L);
+      }
+    }
+  }
+  if (!IS_PERM(p)) {
+    ErrorMayQuit("the argument <p> must be a permutation", 0L, 0L);
+  }
+
+  PermuteMultiplicationTableNC(self, output, table, p);
   return 0L;
 }

--- a/src/isomorph.cpp
+++ b/src/isomorph.cpp
@@ -37,7 +37,7 @@ Obj PermuteMultiplicationTableNC(Obj self, Obj output, Obj table, Obj p) {
       UInt ii  = IMAGE(i - 1, CONST_ADDR_PERM2(q), deg_q) + 1;
 
       for (UInt j = 1; j <= n; j++) {
-        UInt home    = Int_ObjInt(ELM_LIST(
+        UInt home    = INT_INTOBJ(ELM_LIST(
             ELM_LIST(table, ii), IMAGE(j - 1, CONST_ADDR_PERM2(q), deg_q) + 1));
         UInt new_val = IMAGE(home - 1, CONST_ADDR_PERM2(p), deg_p) + 1;
         ASS_LIST(row, j, INTOBJ_INT(new_val));
@@ -112,7 +112,7 @@ Obj PermuteMultiplicationTable(Obj self, Obj output, Obj table, Obj p) {
     }
     for (UInt j = 1; j <= n; j++) {
       Obj elem = ELM_LIST(ELM_LIST(table, i), j);
-      if (!IS_INTOBJ(elem) || Int_ObjInt(elem) < 1 || Int_ObjInt(elem) > n) {
+      if (!IS_INTOBJ(elem) || INT_INTOBJ(elem) < 1 || INT_INTOBJ(elem) > n) {
         ErrorMayQuit("all entries in the first argument <table> must be "
                      "positive integers from 1 to "
                      "Size(<table>) = %d",

--- a/src/isomorph.cpp
+++ b/src/isomorph.cpp
@@ -117,21 +117,23 @@ Obj PermuteMultiplicationTable(Obj self, Obj output, Obj table, Obj p) {
                    i);
     }
     if (LEN_LIST(ELM_LIST(output, i)) != n) {
-      ErrorMayQuit("the first argument <output> must be a square table, but "
-                   "found a list of length %d at position %d",
-                   LEN_LIST(ELM_LIST(output, i)),
-                   i);
+      ErrorMayQuit("the first argument <output> must be a square table, "
+                   "(expected %d elements per row, but "
+                   "found a row of length %d)",
+                   n,
+                   LEN_LIST(ELM_LIST(output, i)));
     }
     if (LEN_LIST(ELM_LIST(table, i)) != n) {
-      ErrorMayQuit("the first argument <output> must be a square table, but "
-                   "found a list of length %d at position %d",
-                   LEN_LIST(ELM_LIST(table, i)),
-                   i);
+      ErrorMayQuit("the second argument <table> must be a square table, "
+                   "(expected %d elements per row, but "
+                   "found a row of length %d)",
+                   n,
+                   LEN_LIST(ELM_LIST(output, i)));
     }
     for (UInt j = 1; j <= n; j++) {
       Obj elem = ELM_LIST(ELM_LIST(table, i), j);
       if (!IS_INTOBJ(elem) || INT_INTOBJ(elem) < 1 || INT_INTOBJ(elem) > n) {
-        ErrorMayQuit("all entries in the first argument <table> must be "
+        ErrorMayQuit("all entries in the second argument <table> must be "
                      "positive integers from 1 to "
                      "Size(<table>) = %d",
                      LEN_LIST(table),
@@ -140,7 +142,9 @@ Obj PermuteMultiplicationTable(Obj self, Obj output, Obj table, Obj p) {
     }
   }
   if (!IS_PERM(p)) {
-    ErrorMayQuit("the argument <p> must be a permutation", 0L, 0L);
+    ErrorMayQuit("the argument <p> must be a permutation but found type %s",
+                 (Int) TNAM_OBJ(p),
+                 0L);
   }
 
   PermuteMultiplicationTableNC(self, output, table, p);

--- a/src/isomorph.cpp
+++ b/src/isomorph.cpp
@@ -16,8 +16,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-#include "isomorph.hpp"
 #include "gap_all.h"
+#include "isomorph.hpp"
 #include "semigroups-debug.hpp"  // for SEMIGROUPS_ASSERT
 
 Obj PermuteMultiplicationTable(Obj self, Obj temp, Obj table, Obj p) {

--- a/src/isomorph.cpp
+++ b/src/isomorph.cpp
@@ -29,10 +29,17 @@ Obj PermuteMultiplicationTableNC(Obj self, Obj output, Obj table, Obj p) {
   UInt n = LEN_LIST(table);
 
   for (UInt i = 1; i <= n; i++) {
-    SEMIGROUPS_ASSERT(IS_LIST(ELM_LIST(table, i)))
-    SEMIGROUPS_ASSERT(IS_LIST(ELM_LIST(output, i)))
+    SEMIGROUPS_ASSERT(IS_LIST(ELM_LIST(table, i)));
+    SEMIGROUPS_ASSERT(IS_LIST(ELM_LIST(output, i)));
     SEMIGROUPS_ASSERT(LEN_LIST(ELM_LIST(table, i)) == n);
     SEMIGROUPS_ASSERT(LEN_LIST(ELM_LIST(output, i)) == n);
+
+    for (UInt j = 1; j <= n; j++) {
+      Obj elem = ELM_LIST(ELM_LIST(table, i), j);
+      SEMIGROUPS_ASSERT(IS_INTOBJ(elem));
+      UInt val = INT_INTOBJ(elem);
+      SEMIGROUPS_ASSERT(val >= 1 && val <= n);
+    }
   }
 
   if (TNUM_OBJ(p) == T_PERM2) {

--- a/src/isomorph.cpp
+++ b/src/isomorph.cpp
@@ -21,7 +21,19 @@
 #include "semigroups-debug.hpp"  // for SEMIGROUPS_ASSERT
 
 Obj PermuteMultiplicationTableNC(Obj self, Obj output, Obj table, Obj p) {
+  SEMIGROUPS_ASSERT(IS_LIST(output));
+  SEMIGROUPS_ASSERT(IS_LIST(table));
+  SEMIGROUPS_ASSERT(IS_PERM(p));
+  SEMIGROUPS_ASSERT(LEN_LIST(output) == LEN_LIST(table));
+
   UInt n = LEN_LIST(table);
+
+  for (UInt i = 1; i <= n; i++) {
+    SEMIGROUPS_ASSERT(IS_LIST(ELM_LIST(table, i)))
+    SEMIGROUPS_ASSERT(IS_LIST(ELM_LIST(output, i)))
+    SEMIGROUPS_ASSERT(LEN_LIST(ELM_LIST(table, i)) == n);
+    SEMIGROUPS_ASSERT(LEN_LIST(ELM_LIST(output, i)) == n);
+  }
 
   if (TNUM_OBJ(p) == T_PERM2) {
     UInt deg_p = DEG_PERM2(p);

--- a/src/isomorph.cpp
+++ b/src/isomorph.cpp
@@ -16,8 +16,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-#include "gap_all.h"
 #include "isomorph.hpp"
+#include "gap_all.h"
 #include "semigroups-debug.hpp"  // for SEMIGROUPS_ASSERT
 
 Obj PermuteMultiplicationTable(Obj self, Obj temp, Obj table, Obj p) {

--- a/src/isomorph.cpp
+++ b/src/isomorph.cpp
@@ -1,61 +1,105 @@
-#include "gap_all.h"
+//
+// Semigroups package for GAP
+// Copyright (C) 2016 James D. Mitchell
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "isomorph.hpp"
+#include "gap_all.h"
+#include "semigroups-debug.hpp"  // for SEMIGROUPS_ASSERT
 
-
-Obj PermuteMultiplicationTable(Obj self, Obj temp, Obj M, Obj p) {
-    int n = LEN_LIST(M);
-
-    if (LEN_LIST(temp) != n) {
-        ErrorQuit("the arguments <temp> and <table> must have the same dimensions", 0L, 0L);
-    }
-    for (int i = 1; i <= n; i++) {
-        if (LEN_LIST(ELM_LIST(temp, i)) != n) {
-            ErrorQuit("the arguments <temp> and <table> must have the same dimensions", 0L, 0L);
-        }
-    }
-
-    if (IS_PERM(p) == 0) {
-        ErrorQuit("the argument <p> must be a permutation", 0L, 0L);
-    }
-  
-    int p_type = TNUM_OBJ(p);
-    if (p_type == T_PERM2) {
-        int deg_p = DEG_PERM2(p);
-        Obj q = STOREDINV_PERM(p);
-        if (q == 0) {
-            q = INV(p);
-            SET_STOREDINV_PERM(p, q);
-          }
-        int deg_q = DEG_PERM2(q);
-        for (int i = 1; i <= n; i++) {
-          Obj row = ELM_LIST(temp, i);
-          int ii = IMAGE(i - 1, CONST_ADDR_PERM2(q), deg_q) + 1;
-      
-          for (int j = 1; j <= n; j++) {
-            int home = Int_ObjInt(ELM_LIST(ELM_LIST(M, ii), IMAGE(j - 1, CONST_ADDR_PERM2(q), deg_q) + 1));
-            int new_val = IMAGE(home - 1, CONST_ADDR_PERM2(p), deg_p) + 1;
-            ASS_LIST(row, j, INTOBJ_INT(new_val));
-          }
-        }
-      } else {
-        int deg_p = DEG_PERM4(p);
-        Obj q = STOREDINV_PERM(p);
-        if (q == 0) {
-            q = INV(p);
-            SET_STOREDINV_PERM(p, q);
-          }
-        int deg_q = DEG_PERM4(q);
-        for (int i = 1; i <= n; i++) {
-          Obj row = ELM_LIST(temp, i);
-          int ii = IMAGE(i - 1, CONST_ADDR_PERM4(q), deg_q) + 1;
-      
-          for (int j = 1; j <= n; j++) {
-            int home = Int_ObjInt(ELM_LIST(ELM_LIST(M, ii), IMAGE(j - 1, CONST_ADDR_PERM4(q), deg_q) + 1));
-            int new_val = IMAGE(home - 1, CONST_ADDR_PERM4(p), deg_p) + 1;
-            ASS_LIST(row, j, INTOBJ_INT(new_val));
-          }
-        }
-      }
-    CHANGED_BAG(temp);
-    return 0L;
+Obj PermuteMultiplicationTable(Obj self, Obj temp, Obj table, Obj p) {
+  if (IS_LIST(temp) == 0 || IS_LIST(table) == 0) {
+    ErrorQuit("the arguments <temp> and <table> must be lists", 0L, 0L);
   }
+
+  int n = LEN_LIST(table);
+
+  if (LEN_LIST(temp) != n) {
+    ErrorQuit("the arguments <temp> and <table> must have the same dimensions",
+              0L,
+              0L);
+  }
+
+  for (int i = 1; i <= n; i++) {
+    if (IS_LIST(ELM_LIST(temp, i)) == 0 || IS_LIST(ELM_LIST(table, i)) == 0) {
+      ErrorQuit("the elements of <temp> and <table> must be lists", 0L, 0L);
+    }
+    if (LEN_LIST(ELM_LIST(temp, i)) != n || LEN_LIST(ELM_LIST(table, i)) != n) {
+      ErrorQuit("the arguments <temp> and <table> must be square tables of the "
+                "same dimensions",
+                0L,
+                0L);
+    }
+    for (int j = 1; j <= n; j++) {
+      Obj elem = ELM_LIST(ELM_LIST(table, i), j);
+      if (!IS_INTOBJ(elem) || Int_ObjInt(elem) < 1 || Int_ObjInt(elem) > n) {
+        ErrorQuit("all entries in <table> must be positive integers from 1 to "
+                  "Size(<table>)",
+                  0L,
+                  0L);
+      }
+    }
+  }
+
+  if (IS_PERM(p) == 0) {
+    ErrorQuit("the argument <p> must be a permutation", 0L, 0L);
+  }
+
+  int p_type = TNUM_OBJ(p);
+  if (p_type == T_PERM2) {
+    int deg_p = DEG_PERM2(p);
+    Obj q     = STOREDINV_PERM(p);
+    if (q == 0) {
+      q = INV(p);
+      SET_STOREDINV_PERM(p, q);
+    }
+    SEMIGROUPS_ASSERT(TNUM_OBJ(q) == T_PERM2);
+    int deg_q = DEG_PERM2(q);
+    for (int i = 1; i <= n; i++) {
+      Obj row = ELM_LIST(temp, i);
+      int ii  = IMAGE(i - 1, CONST_ADDR_PERM2(q), deg_q) + 1;
+
+      for (int j = 1; j <= n; j++) {
+        int home    = Int_ObjInt(ELM_LIST(
+            ELM_LIST(table, ii), IMAGE(j - 1, CONST_ADDR_PERM2(q), deg_q) + 1));
+        int new_val = IMAGE(home - 1, CONST_ADDR_PERM2(p), deg_p) + 1;
+        ASS_LIST(row, j, INTOBJ_INT(new_val));
+      }
+    }
+  } else {
+    int deg_p = DEG_PERM4(p);
+    Obj q     = STOREDINV_PERM(p);
+    if (q == 0) {
+      q = INV(p);
+      SET_STOREDINV_PERM(p, q);
+    }
+    SEMIGROUPS_ASSERT(TNUM_OBJ(q) == T_PERM4);
+    int deg_q = DEG_PERM4(q);
+    for (int i = 1; i <= n; i++) {
+      Obj row = ELM_LIST(temp, i);
+      int ii  = IMAGE(i - 1, CONST_ADDR_PERM4(q), deg_q) + 1;
+
+      for (int j = 1; j <= n; j++) {
+        int home    = Int_ObjInt(ELM_LIST(
+            ELM_LIST(table, ii), IMAGE(j - 1, CONST_ADDR_PERM4(q), deg_q) + 1));
+        int new_val = IMAGE(home - 1, CONST_ADDR_PERM4(p), deg_p) + 1;
+        ASS_LIST(row, j, INTOBJ_INT(new_val));
+      }
+    }
+  }
+  CHANGED_BAG(temp);
+  return 0L;
+}

--- a/src/isomorph.hpp
+++ b/src/isomorph.hpp
@@ -1,6 +1,6 @@
 //
 // Semigroups package for GAP
-// Copyright (C) 2016 James D. Mitchell
+// Copyright (C) 2025 Pramoth Ragavan
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -26,6 +26,7 @@
 extern "C" {
 #endif
 
+Obj PermuteMultiplicationTableNC(Obj self, Obj temp, Obj M, Obj p);
 Obj PermuteMultiplicationTable(Obj self, Obj temp, Obj M, Obj p);
 
 #ifdef __cplusplus

--- a/src/isomorph.hpp
+++ b/src/isomorph.hpp
@@ -1,7 +1,26 @@
-#ifndef ISOMORPH_HPP
-#define ISOMORPH_HPP
+//
+// Semigroups package for GAP
+// Copyright (C) 2016 James D. Mitchell
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+#ifndef SEMIGROUPS_SRC_ISOMORPH_HPP_
+#define SEMIGROUPS_SRC_ISOMORPH_HPP_
 
 #include "gap_all.h"
+#include "semigroups-debug.hpp"  // for SEMIGROUPS_ASSERT
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,4 +32,4 @@ Obj PermuteMultiplicationTable(Obj self, Obj temp, Obj M, Obj p);
 }
 #endif
 
-#endif
+#endif  // SEMIGROUPS_SRC_ISOMORPH_HPP_

--- a/src/isomorph.hpp
+++ b/src/isomorph.hpp
@@ -1,0 +1,16 @@
+#ifndef ISOMORPH_HPP
+#define ISOMORPH_HPP
+
+#include "gap_all.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+Obj PermuteMultiplicationTable(Obj self, Obj temp, Obj M, Obj p);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/pkg.cpp
+++ b/src/pkg.cpp
@@ -482,6 +482,7 @@ static StructGVarFunc GVarFuncs[] = {
                BIPART_NR_IDEMPOTENTS,
                4,
                "o, scc, lookup, nr_threads"),
+    GVAR_ENTRY("isomorph.cpp", PermuteMultiplicationTableNC, 3, "temp, M, p"),
     GVAR_ENTRY("isomorph.cpp", PermuteMultiplicationTable, 3, "temp, M, p"),
 
     {0, 0, 0, 0, 0} /* Finish with an empty entry */

--- a/src/pkg.cpp
+++ b/src/pkg.cpp
@@ -44,6 +44,7 @@
 #include "semigroups-debug.hpp"       // for SEMIGROUPS_ASSERT
 #include "to_cpp.hpp"                 // for to_cpp
 #include "to_gap.hpp"                 // for to_gap
+#include "isomorph.hpp"               // for permuting multiplication tables
 
 // Gapbind14 headers
 #include "gapbind14/cpp_fn.hpp"     // for overload_cast
@@ -481,6 +482,7 @@ static StructGVarFunc GVarFuncs[] = {
                BIPART_NR_IDEMPOTENTS,
                4,
                "o, scc, lookup, nr_threads"),
+    GVAR_ENTRY("isomorph.cpp", PermuteMultiplicationTable, 3, "temp, M, p"),
 
     {0, 0, 0, 0, 0} /* Finish with an empty entry */
 };

--- a/src/pkg.cpp
+++ b/src/pkg.cpp
@@ -41,10 +41,10 @@
 #include "conglatt.hpp"
 #include "froidure-pin-fallback.hpp"  // for RUN_FROIDURE_PIN
 #include "froidure-pin.hpp"           // for init_froidure_pin
+#include "isomorph.hpp"               // for permuting multiplication tables
 #include "semigroups-debug.hpp"       // for SEMIGROUPS_ASSERT
 #include "to_cpp.hpp"                 // for to_cpp
 #include "to_gap.hpp"                 // for to_gap
-#include "isomorph.hpp"               // for permuting multiplication tables
 
 // Gapbind14 headers
 #include "gapbind14/cpp_fn.hpp"     // for overload_cast
@@ -429,10 +429,8 @@ static StructGVarFilt GVarFilts[] = {
 
 typedef Obj (*GVarFunc)(/*arguments*/);
 
-#define GVAR_ENTRY(srcfile, name, nparam, params)                 \
-  {                                                               \
-#name, nparam, params, (GVarFunc) name, srcfile ":Func" #name \
-  }
+#define GVAR_ENTRY(srcfile, name, nparam, params) \
+  {#name, nparam, params, (GVarFunc) name, srcfile ":Func" #name}
 
 // Table of functions to export
 

--- a/src/pkg.cpp
+++ b/src/pkg.cpp
@@ -429,8 +429,10 @@ static StructGVarFilt GVarFilts[] = {
 
 typedef Obj (*GVarFunc)(/*arguments*/);
 
-#define GVAR_ENTRY(srcfile, name, nparam, params) \
-  {#name, nparam, params, (GVarFunc) name, srcfile ":Func" #name}
+#define GVAR_ENTRY(srcfile, name, nparam, params)                 \
+  {                                                               \
+#name, nparam, params, (GVarFunc) name, srcfile ":Func" #name \
+  }
 
 // Table of functions to export
 

--- a/tst/standard/attributes/isomorph.tst
+++ b/tst/standard/attributes/isomorph.tst
@@ -457,14 +457,16 @@ Error, List Element: <list>[4] must have an assigned value
 gap> PermuteMultiplicationTable(List([1 .. 3], x -> [1 .. 3]), S, 1);
 Error, the argument <p> must be a permutation
 gap> PermuteMultiplicationTable(List([1 .. 4], x -> [1 .. 4]), S, (1, 2));
-Error, the arguments <temp> and <table> must have the same dimensions
+Error, the arguments <output> and <table> must have the same dimensions but fo\
+und lengths 4 and 3, respectively
 gap> M := [[1 .. 4], [1 .. 4]];;
 gap> PermuteMultiplicationTable(M, S, (1, 2));
-Error, the arguments <temp> and <table> must have the same dimensions
+Error, the arguments <output> and <table> must have the same dimensions but fo\
+und lengths 2 and 3, respectively
 gap> S := M;;
 gap> PermuteMultiplicationTable(M, S, (1, 2));
-Error, the arguments <temp> and <table> must be square tables of the same dime\
-nsions
+Error, the first argument <output> must be a square table, but found a list of\
+ length 4 at position 1
 gap> S := MultiplicationTable(SymmetricInverseMonoid(2));;
 gap> M := List([1 .. 7], x -> [1 .. 7]);;
 gap> p := (1, 4, 2, 5, 7);;
@@ -473,5 +475,10 @@ false
 gap> PermuteMultiplicationTable(M, S, p);
 gap> OnMultiplicationTable(S, p) = M;
 true
+gap> OnMultiplicationTable([[1, 3], [1, 2]], (1, 2));
+Error, all entries in the first argument <table> must be positive integers fro\
+m 1 to Size(<table>) = 2
+
+#
 gap> SEMIGROUPS.StopTest();
 gap> STOP_TEST("Semigroups package: standard/attributes/isomorph.tst");

--- a/tst/standard/attributes/isomorph.tst
+++ b/tst/standard/attributes/isomorph.tst
@@ -9,7 +9,7 @@
 ##
 
 #@local A, BruteForceInverseCheck, BruteForceIsoCheck, F, G, S, T, U, V, inv
-#@local map, x, y, M, N, R, L
+#@local map, x, y, M, N, R, L, OldOnMultiplicationTable, p, out
 gap> START_TEST("Semigroups package: standard/attributes/isomorph.tst");
 gap> LoadPackage("semigroups", false);;
 
@@ -430,6 +430,48 @@ gap> AutomorphismGroup(S);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 2nd choice method found for `AutomorphismGroup' on 1 arguments
 
-#
+# OnMultiplicationTable/PermuteMultiplicationTable
+gap> OldOnMultiplicationTable := function(table, p)
+>  local out;
+>  out := Permuted(table, p);
+>  Apply(out, x -> OnTuples(x, p));
+>  Apply(out, x -> Permuted(x, p));
+>  return out;
+> end;;
+gap> S := MultiplicationTable(DualSymmetricInverseMonoid(2));;
+gap> p := (1, 2);;
+gap> OldOnMultiplicationTable(S, p) = OnMultiplicationTable(S, p);
+true
+gap> p := (1, 3);;
+gap> OldOnMultiplicationTable(S, p) = OnMultiplicationTable(S, p);
+true
+gap> p := (2, 3);;
+gap> OldOnMultiplicationTable(S, p) = OnMultiplicationTable(S, p);
+true
+gap> p := (1, 2, 3);;
+gap> OldOnMultiplicationTable(S, p) = OnMultiplicationTable(S, p);
+true
+gap> p := (1, 2, 3, 4);;
+gap> OnMultiplicationTable(S, p);
+Error, List Element: <list>[4] must have an assigned value
+gap> PermuteMultiplicationTable(List([1 .. 3], x -> [1 .. 3]), S, 1);
+Error, the argument <p> must be a permutation
+gap> PermuteMultiplicationTable(List([1 .. 4], x -> [1 .. 4]), S, (1, 2));
+Error, the arguments <temp> and <table> must have the same dimensions
+gap> M := [[1 .. 4], [1 .. 4]];;
+gap> PermuteMultiplicationTable(M, S, (1, 2));
+Error, the arguments <temp> and <table> must have the same dimensions
+gap> S := M;;
+gap> PermuteMultiplicationTable(M, S, (1, 2));
+Error, the arguments <temp> and <table> must be square tables of the same dime\
+nsions
+gap> S := MultiplicationTable(SymmetricInverseMonoid(2));;
+gap> M := List([1 .. 7], x -> [1 .. 7]);;
+gap> p := (1, 4, 2, 5, 7);;
+gap> OnMultiplicationTable(S, p) = M;
+false
+gap> PermuteMultiplicationTable(M, S, p);
+gap> OnMultiplicationTable(S, p) = M;
+true
 gap> SEMIGROUPS.StopTest();
 gap> STOP_TEST("Semigroups package: standard/attributes/isomorph.tst");

--- a/tst/standard/attributes/isomorph.tst
+++ b/tst/standard/attributes/isomorph.tst
@@ -455,7 +455,7 @@ gap> p := (1, 2, 3, 4);;
 gap> OnMultiplicationTable(S, p);
 Error, List Element: <list>[4] must have an assigned value
 gap> PermuteMultiplicationTable(List([1 .. 3], x -> [1 .. 3]), S, 1);
-Error, the argument <p> must be a permutation
+Error, the argument <p> must be a permutation but found type integer
 gap> PermuteMultiplicationTable(List([1 .. 4], x -> [1 .. 4]), S, (1, 2));
 Error, the arguments <output> and <table> must have the same dimensions but fo\
 und lengths 4 and 3, respectively
@@ -465,8 +465,8 @@ Error, the arguments <output> and <table> must have the same dimensions but fo\
 und lengths 2 and 3, respectively
 gap> S := M;;
 gap> PermuteMultiplicationTable(M, S, (1, 2));
-Error, the first argument <output> must be a square table, but found a list of\
- length 4 at position 1
+Error, the first argument <output> must be a square table, (expected 2 element\
+s per row, but found a row of length 4)
 gap> S := MultiplicationTable(SymmetricInverseMonoid(2));;
 gap> M := List([1 .. 7], x -> [1 .. 7]);;
 gap> p := (1, 4, 2, 5, 7);;
@@ -476,8 +476,8 @@ gap> PermuteMultiplicationTable(M, S, p);
 gap> OnMultiplicationTable(S, p) = M;
 true
 gap> OnMultiplicationTable([[1, 3], [1, 2]], (1, 2));
-Error, all entries in the first argument <table> must be positive integers fro\
-m 1 to Size(<table>) = 2
+Error, all entries in the second argument <table> must be positive integers fr\
+om 1 to Size(<table>) = 2
 
 #
 gap> SEMIGROUPS.StopTest();


### PR DESCRIPTION
This PR
- introduces a new function ``PermuteMultiplicationTable(temp, table, p)``, implemented in C, which permutes a multiplication table ``table`` and stores the result by changing ``temp`` in-place.
- refactors ``OnMultiplicationTable`` to call ``PermuteMultiplicationTable``.

I wasn't sure where to put the function, so I added a new file.