### PR TITLE
Replace custom type `GVarFunc` with GAP's `ObjFunc`

### DIFF
--- a/gapbind14/include/gapbind14/gapbind14.hpp
+++ b/gapbind14/include/gapbind14/gapbind14.hpp
@@ -70,8 +70,6 @@
 // Typdefs for GAP
 ////////////////////////////////////////////////////////////////////////
 
-typedef Obj (*GVarFunc)(/*arguments*/);
-
 namespace gapbind14 {
 
   // Forward decl
@@ -291,7 +289,7 @@ namespace gapbind14 {
       _funcs.push_back({detail::copy_c_str(nm),
                         sizeof...(Args) - 1,
                         detail::params_c_str(sizeof...(Args) - 1),
-                        (GVarFunc) func,
+                        (ObjFunc) func,
                         detail::copy_c_str(fnm + ":Func" + nm)});
     }
 
@@ -305,7 +303,7 @@ namespace gapbind14 {
           .push_back({detail::copy_c_str(nm),
                       sizeof...(Args) - 1,
                       detail::params_c_str(sizeof...(Args) - 1),
-                      (GVarFunc) func,
+                      (ObjFunc) func,
                       detail::copy_c_str(flnm + ":Func" + sbtyp + "::" + nm)});
     }
 

--- a/gapbind14/src/gapbind14.cpp
+++ b/gapbind14/src/gapbind14.cpp
@@ -25,8 +25,10 @@
 
 #include "gapbind14/gap_include.hpp"  // for Obj etc
 
-#define GVAR_ENTRY(srcfile, name, nparam, params) \
-  {#name, nparam, params, (GVarFunc) name, srcfile ":Func" #name}
+#define GVAR_ENTRY(srcfile, name, nparam, params)                \
+  {                                                              \
+#name, nparam, params, (ObjFunc) name, srcfile ":Func" #name \
+  }
 
 namespace gapbind14 {
   UInt T_GAPBIND14_OBJ = 0;

--- a/src/pkg.cpp
+++ b/src/pkg.cpp
@@ -427,11 +427,9 @@ static StructGVarFilt GVarFilts[] = {
 
 /*****************************************************************************/
 
-typedef Obj (*GVarFunc)(/*arguments*/);
-
-#define GVAR_ENTRY(srcfile, name, nparam, params)                 \
-  {                                                               \
-#name, nparam, params, (GVarFunc) name, srcfile ":Func" #name \
+#define GVAR_ENTRY(srcfile, name, nparam, params)                \
+  {                                                              \
+#name, nparam, params, (ObjFunc) name, srcfile ":Func" #name \
   }
 
 // Table of functions to export


### PR DESCRIPTION
This will improve compatibility with GCC 15 and future GAP versions.

For background see <https://github.com/gap-system/gap/pull/6010> and <https://github.com/gap-system/gap/issues/5857>

This is targeting `main` right now but I am happy to retarget it to your preferred branch.