### PR TITLE
Use gap_all.h instead of compiled.h

### DIFF
--- a/gapbind14/include/gapbind14/gap_include.hpp
+++ b/gapbind14/include/gapbind14/gap_include.hpp
@@ -20,7 +20,7 @@
 #define INCLUDE_GAPBIND14_GAP_INCLUDE_HPP_
 
 extern "C" {
-#include "compiled.h"
+#include "gap_all.h"
 }
 
 #endif  // INCLUDE_GAPBIND14_GAP_INCLUDE_HPP_

--- a/src/bipart.cpp
+++ b/src/bipart.cpp
@@ -31,7 +31,7 @@
 #include <vector>       // for vector
 
 // GAP headers
-#include "compiled.h"
+#include "gap_all.h"
 
 // libsemigroups headers
 #include "libsemigroups/bipart.hpp"  // for Blocks, Bipartition, validate

--- a/src/bipart.hpp
+++ b/src/bipart.hpp
@@ -20,7 +20,7 @@
 #define SEMIGROUPS_SRC_BIPART_HPP_
 
 // GAP headers
-#include "compiled.h"  // ADDR_OBJ, TNUM_OBJ
+#include "gap_all.h"  // ADDR_OBJ, TNUM_OBJ
 
 // Semigroups pkg headers
 #include "pkg.hpp"               // for T_BIPART, T_BLOCKS

--- a/src/cong.cpp
+++ b/src/cong.cpp
@@ -30,7 +30,7 @@
 #include "to_gap.hpp"        // for to_gap
 
 // GAP headers
-#include "compiled.h"  // for UInt2, UInt4
+#include "gap_all.h"  // for UInt2, UInt4
 
 // GapBind14 headers
 #include "gapbind14/gapbind14.hpp"  // for class_ etc

--- a/src/conglatt.cpp
+++ b/src/conglatt.cpp
@@ -35,7 +35,7 @@
 #include <vector>         // for vector
 
 // GAP headers
-#include "compiled.h"
+#include "gap_all.h"
 
 // Semigroups package for GAP headers
 #include "semigroups-debug.hpp"  // for SEMIGROUPS_ASSERT

--- a/src/conglatt.hpp
+++ b/src/conglatt.hpp
@@ -22,7 +22,7 @@
 #ifndef SEMIGROUPS_SRC_CONGLATT_HPP_
 #define SEMIGROUPS_SRC_CONGLATT_HPP_
 
-#include "compiled.h"  // for Obj, UInt
+#include "gap_all.h"  // for Obj, UInt
 
 namespace semigroups {
   Obj LATTICE_OF_CONGRUENCES(Obj list);

--- a/src/froidure-pin-fallback.cpp
+++ b/src/froidure-pin-fallback.cpp
@@ -25,7 +25,7 @@
 #include <string>     // for string
 
 // GAP headers
-#include "compiled.h"  // for RNamName etc
+#include "gap_all.h"  // for RNamName etc
 
 // Semigroups package for GAP headers
 #include "pkg.hpp"               // for HTAdd, HTValue, IsSemigroup, SEMIGROUPS

--- a/src/froidure-pin-fallback.hpp
+++ b/src/froidure-pin-fallback.hpp
@@ -19,7 +19,7 @@
 #ifndef SEMIGROUPS_SRC_FROIDURE_PIN_FALLBACK_HPP_
 #define SEMIGROUPS_SRC_FROIDURE_PIN_FALLBACK_HPP_
 
-#include "compiled.h"  // for Obj
+#include "gap_all.h"  // for Obj
 
 Obj RUN_FROIDURE_PIN(Obj self, Obj obj, Obj limit, Obj report);
 Obj SCC_UNION_LEFT_RIGHT_CAYLEY_GRAPHS(Obj, Obj, Obj);

--- a/src/pkg.cpp
+++ b/src/pkg.cpp
@@ -33,7 +33,7 @@
 #include <set>  // for set
 
 // GAP headers
-#include "compiled.h"
+#include "gap_all.h"
 
 // Semigroups package for GAP headers
 #include "bipart.hpp"  // for Blocks, Bipartition

--- a/src/pkg.hpp
+++ b/src/pkg.hpp
@@ -29,7 +29,7 @@
 
 #include <type_traits>  // for true_type
 
-#include "compiled.h"  // for Obj, UInt
+#include "gap_all.h"  // for Obj, UInt
 
 #include "gapbind14/gapbind14.hpp"
 

--- a/src/to_cpp.hpp
+++ b/src/to_cpp.hpp
@@ -35,7 +35,7 @@
 #include <vector>         // for vector
 
 // GAP headers
-#include "compiled.h"
+#include "gap_all.h"
 
 // Semigroups package headers
 #include "bipart.hpp"            // for bipart_get_cpp

--- a/src/to_gap.hpp
+++ b/src/to_gap.hpp
@@ -32,7 +32,7 @@
 #include <vector>       // for vector
 
 // GAP headers
-#include "compiled.h"  // for Obj etc
+#include "gap_all.h"  // for Obj etc
 
 // Semigroups package headers
 #include "bipart.hpp"            // for bipart_new_obj


### PR DESCRIPTION
Available since GAP 4.12, which this package requires anyway.
