### PR TITLE
Add a GitHub Actions workflow to make a release of the package

### DIFF
--- a/.github/workflows/release-pkg.yml
+++ b/.github/workflows/release-pkg.yml
@@ -1,0 +1,86 @@
+name: "Make a release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run: do not actually push the release to GitHub"
+        type: boolean
+        required: false
+        default: false
+      force:
+        description: "Allow overwriting an existing release, or making a release with an incorrect date"
+        type: boolean
+        required: false
+        default: false
+
+permissions: write-all
+
+jobs:
+  release:
+    name: "Make a release of the Semigroups package"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: gap-actions/setup-gap@v3
+        with:
+          gap-version: latest
+      - uses: gap-actions/build-pkg-docs@v2
+        with:
+          use-latex: true
+      - name: "Clean up additional files"
+        run: |
+          rm -f  .mailmap .codespellrc .clang-format .release
+          rm -rf etc ci tst/github_actions
+      - name: "Run prerequisites.sh to install libsemigroups"
+        run: ./prerequisites.sh
+      - name: "Extract the latest CHANGELOG entry to use as the GitHub release text"
+        run: |
+          # Extract the part of CHANGELOG that is relevant to this release
+          LINES=`grep -n "## Version " CHANGELOG.md | head -2 | cut -d':' -f1`
+
+          # Find the line number where the relevant section starts
+          # (Increment by 1 if that first line is empty)
+          START=`echo $LINES | cut -d' ' -f1`;
+          START=$((START + 1))
+          if [ "`sed \"${START}q;d\" CHANGELOG.md`" == "" ]; then
+            START=$(( START + 1 ));
+          fi
+
+          # Find the line number where the relevant section ends
+          # (Decrement by 1 if that last line is empty)
+          STOP=`echo $LINES | cut -d' ' -f2`;
+          STOP=$((STOP - 1))
+          if [ "`sed \"${STOP}q;d\" CHANGELOG.md`" == "" ]; then
+            STOP=$(( STOP - 1 ));
+          fi
+
+          # Store the potentially multi-line text in the BODY environment so
+          # that we can pass it to the release-pkg action as an input
+          {
+            echo 'BODY<<EOF'
+            sed -n "${START},${STOP}p" CHANGELOG.md
+            echo EOF
+          } >> "$GITHUB_ENV"
+
+      - uses: gap-actions/release-pkg@v1
+        with:
+          dry-run: ${{ inputs.dry-run }}
+          force: ${{ inputs.force }}
+          body-text: ${{ env.BODY }}
+
+      - uses: gap-actions/update-gh-pages@v1
+        if: ${{ !inputs.dry-run }}
+        with:
+          # The <clean> option stops the action from updating the website with
+          # the latest GitHubPagesForGAP code, because (I think?) we have
+          # customised our website, and these changes would be overwritten
+          # if this option was set to <true>, which is the default. However,
+          # we might want to manually update the GitHubPagesForGAP code from
+          # time to time, to receive any bugfixes or updates to parts of the
+          # website code that we haven't customised. But this would have to be
+          # done carefully.
+          clean: false
+          dry-run: ${{ inputs.dry-run }}
+          extra-files: "CHANGELOG.md"


### PR DESCRIPTION
This, again, is pretty much the same workflow as we now have in the Digraphs package. It replaces ReleaseTools.

Note that, as desired, this workflow updates the website with the latest `CHANGELOG.md` (#1082) and it uses the relevant part of the `CHANGELOG.md` as the text for the GitHub release.

To see that the workflow works, I just ran it on my fork of Semigroups on a branch that updated the package to a fake version v6.0.2, to produce the release https://github.com/wilfwilson/Semigroups/releases/tag/v6.0.2
(including getting the text to use from the `CHANGELOG.md` file), and it updated my fork of the website to look as it should, and with the correct `CHANGELOG`: https://wilfwilson.github.io/Semigroups.

You can also download the archive to inspect that it looks how it should, and doesn't contain any unwanted files.

Resolves #1080 and #1082.