### PR TITLE
CI: use the token to upload coverage data to Codecov, and fail if the `codecov/codecov-action` action doesn't work

### DIFF
--- a/.github/workflows/config-options.yml
+++ b/.github/workflows/config-options.yml
@@ -49,6 +49,9 @@ jobs:
         uses: gap-actions/run-pkg-tests@v2
       - uses: gap-actions/process-coverage@v2
       - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
       - name: "Run GAP's tst/testinstall.g"
         uses: gap-actions/run-pkg-tests@v2
         with:

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -62,6 +62,9 @@ jobs:
         uses: gap-actions/run-pkg-tests@v2
       - uses: gap-actions/process-coverage@v2
       - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
       - name: "Run GAP's tst/testinstall.g"
         uses: gap-actions/run-pkg-tests@v2
         with:
@@ -89,3 +92,6 @@ jobs:
            GAP_TESTFILE: "tst/teststandard.g"
        - uses: gap-actions/process-coverage@cygwin-v2
        - uses: codecov/codecov-action@v5
+         with:
+           token: ${{ secrets.CODECOV_TOKEN }}
+           fail_ci_if_error: true


### PR DESCRIPTION
The code coverage hasn't been working properly for a while, but we didn't notice. This should fix things and make it so that we notice any future problems more quickly.