### PR TITLE
Update the concurrency settings of the CI jobs

### DIFF
--- a/.github/workflows/config-options.yml
+++ b/.github/workflows/config-options.yml
@@ -10,6 +10,14 @@ on:
     # Every day at 4:15 AM UTC
     - cron: '15 4 * * *'
 
+concurrency:
+  # Group by workflow and ref; the last component ensures that for pull
+  # requests, we limit to one concurrent job, but for the default branch we
+  # don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != github.event.repository.default_branch && !startsWith(github.ref, 'refs/heads/stable-')) || github.run_number }}
+  # Only cancel intermediate pull request builds
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   enable-debug:
     name: "Enable debug"

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -11,6 +11,13 @@ on:
     # Every day at 2:30 AM UTC
     - cron: 30 2 * * *
 
+concurrency:
+  # Group by workflow and ref; the last component ensures that for pull
+  # requests, we limit to one concurrent job, but for the main branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/main' || github.run_number }}
+  # Only cancel intermediate pull request builds
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   extended:
     name: "${{ matrix.os }} / GAP ${{ matrix.gap-version }} / ${{ matrix.ABI }}-bit"

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -10,6 +10,13 @@ on:
     # Every day at 3:33 AM UTC
     - cron: '33 3 * * *'
 
+concurrency:
+  # Group by workflow and ref; the last component ensures that for pull
+  # requests, we limit to one concurrent job, but for the main branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/main' || github.run_number }}
+  # Only cancel intermediate pull request builds
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   manual:
     name: "compile and upload manual"

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -9,9 +9,13 @@ on:
   schedule:
     # Every day at 3:15 AM UTC
     - cron: '15 3 * * *'
+
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Group by workflow and ref; the last component ensures that for pull
+  # requests, we limit to one concurrent job, but for the main branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/main' || github.run_number }}
+  # Only cancel intermediate pull request builds
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   standard:


### PR DESCRIPTION
This saves resources by cancelling the expensive jobs on a pull request if there are newer jobs running.

But for pushes to our `main` and `stable-*` branches, I think it makes sense to let all jobs run to completion.