### PR TITLE
Update the CI workflows to use the latest versions of the `gap-actions` tools

### DIFF
--- a/.github/workflows/config-options.yml
+++ b/.github/workflows/config-options.yml
@@ -22,16 +22,18 @@ jobs:
           update_packager_index: false
           override_cache_key: ${{ runner.os }}-$GAPBRANCH-64-${{ github.ref }}
           override_cache_key_fallback: ${{ runner.os }}-$GAPBRANCH-64
-      - name: "Install GAP and clone/compile necessary packages"
-        uses: gap-actions/setup-gap@v2
-        with:
-          GAP_PKGS_TO_BUILD: "digraphs io orb datastructures profiling"
+      - name: "Install GAP"
+        uses: gap-actions/setup-gap@v3
+      - name: "Build necessary GAP packages"
+        run: |
+          cd ${GAPROOT}/pkg
+          ../bin/BuildPackages.sh --strict digraphs io orb datastructures profiling
       - name: "Build Semigroups"
-        uses: gap-actions/build-pkg@v1
+        uses: gap-actions/build-pkg@v2
         with:
           CONFIGFLAGS: --disable-hpcombi --enable-debug
       - name: "Run Semigroups package's tst/teststandard.g"
-        uses: gap-actions/run-pkg-tests@v2
+        uses: gap-actions/run-pkg-tests@v4
 
   enable-hpcombi:
     name: "Enable HPCombi"
@@ -39,20 +41,22 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         # Don't use ccache, since sometimes this fails when using -mavx
-      - name: "Install GAP and clone/compile necessary packages"
-        uses: gap-actions/setup-gap@v2
-        with:
-          GAP_PKGS_TO_BUILD: "digraphs io orb datastructures profiling"
+      - name: "Install GAP"
+        uses: gap-actions/setup-gap@v3
+      - name: "Build necessary GAP packages"
+        run: |
+          cd ${GAPROOT}/pkg
+          ../bin/BuildPackages.sh --strict digraphs io orb datastructures profiling
       - name: "Build Semigroups"
-        uses: gap-actions/build-pkg@v1
+        uses: gap-actions/build-pkg@v2
       - name: "Run Semigroups package's tst/teststandard.g"
-        uses: gap-actions/run-pkg-tests@v2
-      - uses: gap-actions/process-coverage@v2
+        uses: gap-actions/run-pkg-tests@v4
+      - uses: gap-actions/process-coverage@v3
       - uses: codecov/codecov-action@v5
       - name: "Run GAP's tst/testinstall.g"
-        uses: gap-actions/run-pkg-tests@v2
+        uses: gap-actions/run-pkg-tests@v4
         with:
-          GAP_TESTFILE: "ci/run-gap-testinstall.g"
+          testfile: "ci/run-gap-testinstall.g"
 
   with-external-libsemigroups:
     name: "External libsemigroups"
@@ -80,13 +84,15 @@ jobs:
           override_cache_key: ${{ runner.os }}-$GAPBRANCH-64-${{ github.ref }}
           override_cache_key_fallback: ${{ runner.os }}-$GAPBRANCH-64
       - run: mkdir libsemigroups
-      - name: "Install GAP and clone/compile necessary packages"
-        uses: gap-actions/setup-gap@v2
-        with:
-          GAP_PKGS_TO_BUILD: "digraphs io orb datastructures profiling"
+      - name: "Install GAP"
+        uses: gap-actions/setup-gap@v3
+      - name: "Build necessary GAP packages"
+        run: |
+          cd ${GAPROOT}/pkg
+          ../bin/BuildPackages.sh --strict digraphs io orb datastructures profiling
       - name: "Build Semigroups"
-        uses: gap-actions/build-pkg@v1
+        uses: gap-actions/build-pkg@v2
         with: # we use --with-external-fmt since this is available from conda
           CONFIGFLAGS: --disable-hpcombi --with-external-libsemigroups --enable-fmt --with-external-fmt
       - name: "Run Semigroups package's tst/teststandard.g"
-        uses: gap-actions/run-pkg-tests@v2
+        uses: gap-actions/run-pkg-tests@v4

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -27,11 +27,8 @@ jobs:
           - 32
 
         include:
-          # macOS job
-          - gap-version: master
-            # to ensure datastructures>= v0.2.6
-            pkgs-to-clone: "datastructures"
-            os: macOS
+          - os: macOS
+            gap-version: master
             ABI: 64
 
     steps:
@@ -39,6 +36,19 @@ jobs:
       - name: "Install macOS dependencies"
         if: ${{ runner.os == 'macOS' }}
         run: brew install automake libtool
+      - name: "Install 32-bit Ubuntu packages"
+        if: ${{ runner.os == 'Linux' && matrix.ABI == '32' }}
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          packages=(
+            libgmp-dev:i386
+            libreadline-dev:i386
+            zlib1g-dev:i386
+            gcc-multilib
+            g++-multilib
+          )
+          sudo apt-get install "${packages[@]}"
       # Setup ccache, to speed up repeated compilation of the same binaries
       # (i.e., GAP and the packages)
       - name: "Setup ccache"
@@ -48,25 +58,28 @@ jobs:
           update_packager_index: false
           override_cache_key: ${{ runner.os }}-${{ matrix.gap-version }}-${{ matrix.ABI }}-${{ github.ref }}
           override_cache_key_fallback: ${{ runner.os }}-${{ matrix.gap-version }}-${{ matrix.ABI }}
-      - name: "Install GAP and clone/compile necessary packages"
-        uses: gap-actions/setup-gap@v2
+      - name: "Install GAP"
+        uses: gap-actions/setup-gap@v3
         with:
-          # digraphs included here to ensure version >=1.5.0
-          GAP_PKGS_TO_CLONE: "digraphs/digraphs ${{ matrix.pkgs-to-clone }}"
-          GAP_PKGS_TO_BUILD: "digraphs io orb datastructures profiling"
-          GAPBRANCH: ${{ matrix.gap-version }}
           ABI: ${{ matrix.ABI }}
+          gap-version: ${{ matrix.gap-version }}
+      - name: "Build necessary GAP packages"
+        shell: bash
+        env:
+          ABI: ${{ matrix.ABI }}
+        run: |
+          cd ${GAPROOT}/pkg
+          ../bin/BuildPackages.sh --strict digraphs* io* orb* datastructures* profiling*
       - name: "Build Semigroups"
-        uses: gap-actions/build-pkg@v1
+        uses: gap-actions/build-pkg@v2
         with:
           ABI: ${{ matrix.ABI }}
           CONFIGFLAGS: --disable-hpcombi
       - name: "Run GAP's tst/teststandard.g"
-        uses: gap-actions/run-pkg-tests@v2
+        uses: gap-actions/run-pkg-tests@v4
         with:
-          GAP_TESTFILE: "ci/run-gap-teststandard.g"
+          testfile: "ci/run-gap-teststandard.g"
       - name: "Run GAP's tst/testbugfix.g"
-        uses: gap-actions/run-pkg-tests@v2
+        uses: gap-actions/run-pkg-tests@v4
         with:
-          GAP_TESTFILE: "ci/run-gap-testbugfix.g"
-
+          testfile: "ci/run-gap-testbugfix.g"

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -28,12 +28,8 @@ jobs:
           )
           sudo apt-get update
           sudo apt-get install "${packages[@]}"
-      - uses: gap-actions/setup-gap@v2
-        env:
-          GAP_BOOTSTRAP: "minimal"
-        with:
-          GAP_PKGS_TO_BUILD: ''
-      - uses: gap-actions/build-pkg-docs@v1
+      - uses: gap-actions/setup-gap@v3
+      - uses: gap-actions/build-pkg-docs@v2
       - name: "Upload compiled manuals"
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -25,8 +25,10 @@ jobs:
           - macOS
         gap-version:
           - master
-          - stable-4.12
-          - stable-4.13
+          - stable-4.15
+          - v4.14
+          - v4.13
+          - v4.12
         exclude:
           # We exclude this combination for the reasons discussed at:
           # https://github.com/semigroups/Semigroups/pull/1015
@@ -48,24 +50,36 @@ jobs:
           update_packager_index: false
           override_cache_key: ${{ runner.os }}-${{ matrix.gap-version }}-64-${{ github.ref }}
           override_cache_key_fallback: ${{ runner.os }}-${{ matrix.gap-version }}-64
-      - name: "Install GAP and clone/compile necessary packages"
-        uses: gap-actions/setup-gap@v2
+      - name: "Install GAP"
+        uses: gap-actions/setup-gap@v3
         with:
-          GAP_PKGS_TO_CLONE: digraphs/digraphs
-          GAP_PKGS_TO_BUILD: "digraphs io orb datastructures profiling"
-          GAPBRANCH: ${{ matrix.gap-version }}
+          gap-version: ${{ matrix.gap-version }}
+      - name: "Install necessary GAP package clones"
+        shell: bash
+        run: |
+          for PKG in https://github.com/digraphs/digraphs; do
+            PKGNAME=$(basename $PKG)
+            # Delete any already-installed version of this package, to be safe
+            rm -rf ${GAPROOT}/pkg/${PKGNAME}*
+            git clone $PKG ${GAPROOT}/pkg/${PKGNAME}
+          done
+      - name: "Build necessary GAP packages"
+        shell: bash
+        run: |
+          cd ${GAPROOT}/pkg
+          ../bin/BuildPackages.sh --strict digraphs* io* orb* datastructures* profiling*
       - name: "Build Semigroups"
-        uses: gap-actions/build-pkg@v1
+        uses: gap-actions/build-pkg@v2
         with:
           CONFIGFLAGS: --disable-hpcombi
       - name: "Run Semigroups package's tst/teststandard.g"
-        uses: gap-actions/run-pkg-tests@v2
-      - uses: gap-actions/process-coverage@v2
+        uses: gap-actions/run-pkg-tests@v4
+      - uses: gap-actions/process-coverage@v3
       - uses: codecov/codecov-action@v5
       - name: "Run GAP's tst/testinstall.g"
-        uses: gap-actions/run-pkg-tests@v2
+        uses: gap-actions/run-pkg-tests@v4
         with:
-          GAP_TESTFILE: "ci/run-gap-testinstall.g"
+          testfile: "ci/run-gap-testinstall.g"
 
   standard-cygwin:
      name: "Windows / GAP master / 64-bit"
@@ -75,17 +89,20 @@ jobs:
      steps:
        - uses: actions/checkout@v5
        - name: "Setup cygwin"
-         uses: gap-actions/setup-cygwin@v1
-       - name: "Setup GAP for cygwin"
-         uses: gap-actions/setup-gap@cygwin-v2
-         with:
-           GAP_PKGS_TO_BUILD: "digraphs io orb datastructures profiling"
+         uses: gap-actions/setup-cygwin@v2
+       - name: "Install GAP"
+         uses: gap-actions/setup-gap@v3
+       - name: "Build necessary GAP packages"
+         shell: bash
+         run: |
+           cd ${GAPROOT}/pkg
+           ../bin/BuildPackages.sh --strict digraphs* io* orb* datastructures* profiling*
        - name: "Build Semigroups"
-         uses: gap-actions/build-pkg@cygwin-v1
+         uses: gap-actions/build-pkg@v2
          with:
            CONFIGFLAGS: --disable-fmt --disable-hpcombi # to try and speed up compilation FIXME don't disable hpcombi
-       - uses: gap-actions/run-pkg-tests@cygwin-v2
+       - uses: gap-actions/run-pkg-tests@v4
          with:
-           GAP_TESTFILE: "tst/teststandard.g"
-       - uses: gap-actions/process-coverage@cygwin-v2
+           testfile: "tst/teststandard.g"
+       - uses: gap-actions/process-coverage@v3
        - uses: codecov/codecov-action@v5

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -29,12 +29,6 @@ jobs:
           - v4.14
           - v4.13
           - v4.12
-        exclude:
-          # We exclude this combination for the reasons discussed at:
-          # https://github.com/semigroups/Semigroups/pull/1015
-          # https://github.com/gap-system/gap/issues/5640
-          - os: macos
-            gap-version: stable-4.12
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
~I've added pull requests #1113, #1114, #1115, and #1116, all of which contain commits from this pull request.~

~Once those are merged, I'll rebase this pull request and mark it as ready for review, at which point it should have a rather smaller diff.~

The main thing to note is that `gap-actions/setup-gap@v3`, unlike `v2`, no longer clones or builds the packages that we want to be cloned or built. So we have to do it ourselves now.

To see that the updated "Extended tests" workflow works properly (it won't run here since it isn't set to run on pull requests), see https://github.com/wilfwilson/Semigroups/actions/runs/17761920802