### PR TITLE
macOS CI: reinstate testing Semigroups on GAP 4.12

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -29,12 +29,6 @@ jobs:
           - stable-4.13
         ABI:
           - 64
-        exclude:
-          # We exclude this combination for the reasons discussed at:
-          # https://github.com/semigroups/Semigroups/pull/1015
-          # https://github.com/gap-system/gap/issues/5640
-          - os: macos
-            gap-branch: stable-4.12
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  standard:
     name: "${{ matrix.gap-branch }} / ${{ matrix.os }} / ${{ matrix.ABI }}-bit"
     runs-on: "${{ matrix.os }}-latest"
     strategy:
@@ -75,7 +75,7 @@ jobs:
         with:
           GAP_TESTFILE: "ci/run-gap-testinstall.g"
 
-  test-cygwin:
+  standard-cygwin:
      name: "master / cygwin / 64-bit"
      runs-on: windows-latest
      env:


### PR DESCRIPTION
Whatever was the cause of us wanting to exclude this, doesn't seem to be an issue any longer.