### PR TITLE
Update GitHub Actions workflows to use `actions/checkout@v5`

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -15,7 +15,7 @@ jobs:
     name: Formatting check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: "Run clang-format style checks on src/*.[hc]pp . . ."
       uses: jidicula/clang-format-action@v4.14.0
       with:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -10,5 +10,5 @@ jobs:
   codespell:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: codespell-project/actions-codespell@v2.1

--- a/.github/workflows/config-options.yml
+++ b/.github/workflows/config-options.yml
@@ -15,7 +15,7 @@ jobs:
     name: "Enable debug"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: "Setup ccache"
         uses: Chocobo1/setup-ccache-action@v1
         with:
@@ -37,7 +37,7 @@ jobs:
     name: "Enable HPCombi"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         # Don't use ccache, since sometimes this fails when using -mavx
       - name: "Install GAP and clone/compile necessary packages"
         uses: gap-actions/setup-gap@v2
@@ -65,7 +65,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: "Install conda environment from environment.yml . . ."
         uses: mamba-org/setup-micromamba@v2
         with:

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -35,7 +35,7 @@ jobs:
             ABI: 64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: "Install macOS dependencies"
         if: ${{ runner.os == 'macOS' }}
         run: brew install automake libtool

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -15,7 +15,7 @@ jobs:
     name: "compile and upload manual"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: "Install TeX Live"
         run: |
           packages=(

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -35,7 +35,7 @@ jobs:
             gap-version: stable-4.12
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: "Install macOS dependencies"
         if: ${{ runner.os == 'macOS' }}
         run: brew install automake libtool
@@ -73,7 +73,7 @@ jobs:
      env:
        CHERE_INVOKING: 1
      steps:
-       - uses: actions/checkout@v4
+       - uses: actions/checkout@v5
        - name: "Setup cygwin"
          uses: gap-actions/setup-cygwin@v1
        - name: "Setup GAP for cygwin"

--- a/.github/workflows/workspaces.yml
+++ b/.github/workflows/workspaces.yml
@@ -32,7 +32,7 @@ jobs:
       steps:
           - name: "Checkout the Semigroups GAP package"
 
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
           - name: "Install git + autotools"
             run: |
               sudo apt-get --yes update


### PR DESCRIPTION
I think dependabot will have already done this in the `main` branch. But I'm making all of these changes on the `stable-5.5` branch.