### PR TITLE
`brew install` less stuff in the macOS GitHub Actions CI

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: "Install dependencies (macOS only!)"
         if: ${{ runner.os == 'macOS' }}
-        run: brew install automake autoconf zlib gmp pkg-config libtool
+        run: brew install automake libtool
       # Setup ccache, to speed up repeated compilation of the same binaries
       # (i.e., GAP and the packages)
       - name: "Setup ccache"

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: "Install dependencies (macOS only!)"
         if: ${{ runner.os == 'macOS' }}
-        run: brew install automake autoconf zlib gmp pkg-config libtool
+        run: brew install automake libtool
       # Setup ccache, to speed up repeated compilation of the same binaries
       # (i.e., GAP and the packages)
       - name: "Setup ccache"


### PR DESCRIPTION
The removed things are now already installed on the GitHub Actions runners.