### PR TITLE
Stop adding `-pthread` to `LDFLAGS` in the GitHub Actions CI

### DIFF
--- a/.github/workflows/config-options.yml
+++ b/.github/workflows/config-options.yml
@@ -25,10 +25,6 @@ jobs:
           override_cache_key_fallback: ${{ runner.os }}-$GAPBRANCH-$ABI
       - name: "Install GAP and clone/compile necessary packages"
         uses: gap-actions/setup-gap@v2
-        env:
-          # We don't understand why this is necessary. Hopefully it can be
-          # removed in the fullness of time.
-          LDFLAGS: "-pthread"
         with:
           GAP_PKGS_TO_BUILD: "digraphs io orb datastructures profiling"
       - name: "Build Semigroups"
@@ -89,10 +85,6 @@ jobs:
       - run: mkdir libsemigroups
       - name: "Install GAP and clone/compile necessary packages"
         uses: gap-actions/setup-gap@v2
-        env:
-          # We don't understand why this is necessary. Hopefully it can be
-          # removed in the fullness of time.
-          LDFLAGS: "-pthread"
         with:
           GAP_PKGS_TO_BUILD: "digraphs io orb datastructures profiling"
       - name: "Build Semigroups"

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -50,10 +50,6 @@ jobs:
           override_cache_key_fallback: ${{ runner.os }}-${{ matrix.gap-branch }}-${{ matrix.ABI }}
       - name: "Install GAP and clone/compile necessary packages"
         uses: gap-actions/setup-gap@v2
-        env:
-          # We don't understand why this is necessary. Hopefully it can be
-          # removed in the fullness of time.
-          LDFLAGS: "-pthread"
         with:
           # digraphs included here to ensure version >=1.5.0
           GAP_PKGS_TO_CLONE: "digraphs/digraphs ${{ matrix.pkgs-to-clone }}"

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -52,10 +52,6 @@ jobs:
           override_cache_key_fallback: ${{ runner.os }}-${{ matrix.gap-branch }}-${{ matrix.ABI }}
       - name: "Install GAP and clone/compile necessary packages"
         uses: gap-actions/setup-gap@v2
-        env:
-          # We don't understand why this is necessary. Hopefully it can be
-          # removed in the fullness of time.
-          LDFLAGS: "-pthread"
         with:
           GAP_PKGS_TO_CLONE: digraphs/digraphs
           GAP_PKGS_TO_BUILD: "digraphs io orb datastructures profiling"

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  standard:
     name: "${{ matrix.gap-branch }} / ${{ matrix.os }} / ${{ matrix.ABI }}-bit"
     runs-on: "${{ matrix.os }}-latest"
     strategy:
@@ -75,7 +75,7 @@ jobs:
         with:
           GAP_TESTFILE: "ci/run-gap-testinstall.g"
 
-  test-cygwin:
+  standard-cygwin:
      name: "master / cygwin / 64-bit"
      runs-on: windows-latest
      env:


### PR DESCRIPTION
It doesn't seem to be needed any more, as in, not having it there isn't causing any crashes.