### PR TITLE
Disallow duplicate named generators in `FreeBand` and `FreeInverseSemigroup`

### DIFF
--- a/doc/freeband.xml
+++ b/doc/freeband.xml
@@ -37,13 +37,14 @@ true]]></Example>
 <#GAPDoc Label="FreeBand" >
 <ManSection>
     <Func Name = "FreeBand" Arg = "rank[, name]" Label = "for a given rank"/>
-    <Func Name = "FreeBand" Arg = "name1, name2, .. ." Label = "for a list of names"/>
-    <Func Name = "FreeBand" Arg = "names" Label = "for various names"/>
+    <Func Name = "FreeBand" Arg = "name1, name2, ..." Label = "for a list of distinct names"/>
+    <Func Name = "FreeBand" Arg = "names" Label = "for various distinct names"/>
     <Returns> A free band.</Returns>
     <Description>
      Returns a free band on <A>rank</A> generators, for a positive integer
      <A>rank</A>. If <A>rank</A> is not specified, the number of <A>names</A>
-     is used. The resulting semigroup is always finite.
+     is used. In the second and third forms, the <A>names</A> must be distinct.
+     The resulting semigroup is always finite.
 <Example><![CDATA[
 gap> FreeBand(6);
 <free band on the generators [ x1, x2, x3, x4, x5, x6 ]>

--- a/doc/freeinverse.xml
+++ b/doc/freeinverse.xml
@@ -21,7 +21,9 @@
   <Description>
     Returns a free inverse semigroup on <A>rank</A> generators, where
     <A>rank</A> is a positive integer. If <A>rank</A> is not
-    specified, the number of <A>names</A> is used. If <C>S</C> is a
+    specified, the number of <A>names</A> is used.
+    In the second and third forms, the <A>names</A> must be distinct.
+    If <C>S</C> is a
     free inverse semigroup, then the generators can be accessed by
     <C>S.1</C>, <C>S.2</C> and so on.
 <Example><![CDATA[

--- a/gap/fp/freeband.gi
+++ b/gap/fp/freeband.gi
@@ -104,6 +104,10 @@ function(arg...)
     ErrorNoReturn("FreeBand(<name1>,<name2>..) or FreeBand(<rank> [, name])");
   fi;
 
+  if not IsDuplicateFreeList(names) then
+    ErrorNoReturn("the generator names must be distinct");
+  fi;
+
   MakeImmutable(names);
 
   F := NewFamily("FreeBandElementsFamily", IsFreeBandElement,

--- a/gap/fp/freeinverse.gi
+++ b/gap/fp/freeinverse.gi
@@ -67,6 +67,8 @@ function(arg...)
   if IsEmpty(names) then
     ErrorNoReturn("the number of generators of a free inverse semigroup must ",
                   "be non-zero");
+  elif not IsDuplicateFreeList(names) then
+    ErrorNoReturn("the generator names must be distinct");
   fi;
 
   F := NewFamily("FreeInverseSemigroupElementsFamily",

--- a/tst/standard/fp/freeband.tst
+++ b/tst/standard/fp/freeband.tst
@@ -306,6 +306,16 @@ Error, expected int, found list (string)
 gap> EqualInFreeBand([1], [2, 2, 2]);
 false
 
+# Duplicate named generators
+gap> FreeBand("x", "x", "x", "x");
+Error, the generator names must be distinct
+gap> FreeBand("x", "y", "x");
+Error, the generator names must be distinct
+gap> FreeBand(["a", "x", "y", "x", "d", "x", "a"]);
+Error, the generator names must be distinct
+gap> FreeBand(["a", "x", "y", "x", "d"]);
+Error, the generator names must be distinct
+
 #
 gap> SEMIGROUPS.StopTest();
 gap> STOP_TEST("Semigroups package: standard/fp/freeband.tst");

--- a/tst/standard/fp/freeinverse.tst
+++ b/tst/standard/fp/freeinverse.tst
@@ -142,6 +142,16 @@ gap> for i in [1 .. 10] do
 > MinimalWord(x * y);
 > od; 
 
+# Duplicate named generators
+gap> FreeInverseSemigroup("x", "x", "x", "x");
+Error, the generator names must be distinct
+gap> FreeInverseSemigroup("x", "y", "x");
+Error, the generator names must be distinct
+gap> FreeInverseSemigroup(["a", "x", "y", "x", "d", "x", "a"]);
+Error, the generator names must be distinct
+gap> FreeInverseSemigroup(["a", "x", "y", "x", "d"]);
+Error, the generator names must be distinct
+
 #
 gap> SEMIGROUPS.StopTest();
 gap> STOP_TEST("Semigroups package: standard/fp/freeinverse.tst");


### PR DESCRIPTION
As discussed in #1117.

The case of duplicate named generators did not previously come up in the tests or documentation, suggesting that this was simply not considered. Let's disallow it.

If you want to consider this to be a breaking change, then please change the base to `main`.

Resolves #1117.