### PR TITLE
CI: further standardise the concurrency settings

### DIFF
--- a/.github/workflows/config-options.yml
+++ b/.github/workflows/config-options.yml
@@ -11,10 +11,9 @@ on:
     - cron: '15 4 * * *'
 
 concurrency:
-  # Group by workflow and ref; the last component ensures that for pull
-  # requests, we limit to one concurrent job, but for the default branch we
-  # don't
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != github.event.repository.default_branch && !startsWith(github.ref, 'refs/heads/stable-')) || github.run_number }}
+  # Group by workflow and ref; the last component ensures that for pull requests
+  # we limit to one concurrent job, but for the main/stable branches we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/stable-')) || github.run_number }}
   # Only cancel intermediate pull request builds
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -12,9 +12,9 @@ on:
     - cron: 30 2 * * *
 
 concurrency:
-  # Group by workflow and ref; the last component ensures that for pull
-  # requests, we limit to one concurrent job, but for the main branch we don't
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/main' || github.run_number }}
+  # Group by workflow and ref; the last component ensures that for pull requests
+  # we limit to one concurrent job, but for the main/stable branches we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/stable-')) || github.run_number }}
   # Only cancel intermediate pull request builds
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -11,9 +11,9 @@ on:
     - cron: '33 3 * * *'
 
 concurrency:
-  # Group by workflow and ref; the last component ensures that for pull
-  # requests, we limit to one concurrent job, but for the main branch we don't
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/main' || github.run_number }}
+  # Group by workflow and ref; the last component ensures that for pull requests
+  # we limit to one concurrent job, but for the main/stable branches we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/stable-')) || github.run_number }}
   # Only cancel intermediate pull request builds
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -11,9 +11,9 @@ on:
     - cron: '15 3 * * *'
 
 concurrency:
-  # Group by workflow and ref; the last component ensures that for pull
-  # requests, we limit to one concurrent job, but for the main branch we don't
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/main' || github.run_number }}
+  # Group by workflow and ref; the last component ensures that for pull requests
+  # we limit to one concurrent job, but for the main/stable branches we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/stable-')) || github.run_number }}
   # Only cancel intermediate pull request builds
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 

--- a/.github/workflows/workspaces.yml
+++ b/.github/workflows/workspaces.yml
@@ -15,8 +15,11 @@ on:
     - cron: '15 3 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Group by workflow and ref; the last component ensures that for pull requests
+  # we limit to one concurrent job, but for the main/stable branches we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/stable-')) || github.run_number }}
+  # Only cancel intermediate pull request builds
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   workspaces:


### PR DESCRIPTION
I made an additional change to the concurrency settings in `config-options.yml` that I intended to apply to the rest of the relevant workflow files, but I forgot to get around to it.

The change makes it so that we can run concurrent tests on the stable branches, as well as on the main branch.

I also didn't notice that `workspaces.yml` had some custom concurrency settings, so I've brought them in line too..