### PR TITLE
Remove some spurious `.tar.gz` suffixes from directory names in the manual

### DIFF
--- a/doc/z-chap02.xml
+++ b/doc/z-chap02.xml
@@ -61,7 +61,7 @@
       <Item>
         locate your &GAP; directory, the one containing the directories
         <F>lib</F>, <F>doc</F> and so on. Move the directory
-        <F>&ARCHIVENAME;</F> into the <F>pkg</F> subdirectory of your &GAP;
+        <F>semigroups-&VERSION;</F> into the <F>pkg</F> subdirectory of your &GAP;
         directory.
       </Item>
 
@@ -109,7 +109,7 @@
     &SEMIGROUPS; package without compiling it.
     <P/>
 
-    To compile the kernel component inside the <F>pkg/&ARCHIVENAME;</F>
+    To compile the kernel component inside the <F>pkg/semigroups-&VERSION;</F>
     directory, type
     <Listing><![CDATA[
 ./configure && make


### PR DESCRIPTION
Currently there are a couple of sentences like "To compile the kernel component inside the pkg/semigroups-5.5.4.tar.gz directory".