### PR TITLE
Narrow declarations of `Factorization` and `WreathProduct`

### DIFF
--- a/gap/attributes/attr.gd
+++ b/gap/attributes/attr.gd
@@ -53,7 +53,6 @@ DeclareAttribute("SmallestElementSemigroup", IsSemigroup);
 DeclareAttribute("LargestElementSemigroup", IsSemigroup);
 
 DeclareAttribute("StructureDescription", IsBrandtSemigroup);
-DeclareAttribute("StructureDescription", IsGroupAsSemigroup);
 DeclareAttribute("StructureDescriptionMaximalSubgroups",
                  IsSemigroup);
 DeclareAttribute("MaximalDClasses", IsSemigroup);

--- a/gap/attributes/attr.gi
+++ b/gap/attributes/attr.gi
@@ -396,7 +396,7 @@ end);
 
 # same method for ideals
 
-InstallMethod(StructureDescription, "for a group as semigroup",
+InstallOtherMethod(StructureDescription, "for a group as semigroup",
 [IsGroupAsSemigroup],
 function(S)
   if IsGroup(S) then

--- a/gap/attributes/factor.gd
+++ b/gap/attributes/factor.gd
@@ -13,5 +13,9 @@ DeclareOperation("MinimalFactorization",
 DeclareOperation("NonTrivialFactorization",
                  [IsSemigroup, IsMultiplicativeElement]);
 DeclareOperation("Factorization", [IsLambdaOrb, IsPosInt, IsPerm]);
-DeclareOperation("Factorization", [IsSemigroup, IsMultiplicativeElement]);
+DeclareOperation("Factorization",
+                 [IsSemigroup and CanUseFroidurePin, IsMultiplicativeElement]);
+DeclareOperation("Factorization",
+                 [IsActingSemigroup and HasGeneratorsOfSemigroup,
+                  IsMultiplicativeElement]);
 DeclareOperation("TraceSchreierTreeForward", [IsSemigroupData, IsPosInt]);

--- a/gap/semigroups/semifp.gd
+++ b/gap/semigroups/semifp.gd
@@ -26,3 +26,8 @@ DeclareOperation("ReversedOp", [IsElementOfFpMonoid]);
 
 DeclareGlobalFunction("FreeMonoidAndAssignGeneratorVars");
 DeclareGlobalFunction("FreeSemigroupAndAssignGeneratorVars");
+
+DeclareOperation("Factorization", [IsFpSemigroup, IsElementOfFpSemigroup]);
+DeclareOperation("Factorization", [IsFpMonoid, IsElementOfFpMonoid]);
+DeclareOperation("Factorization", [IsFreeSemigroup, IsWord]);
+DeclareOperation("Factorization", [IsFreeMonoid, IsWord]);

--- a/gap/semigroups/semitrans.gd
+++ b/gap/semigroups/semitrans.gd
@@ -42,8 +42,11 @@ DeclareOperation("EndomorphismMonoid", [IsDigraph, IsHomogeneousList]);
 DeclareAttribute("DigraphCore", IsDigraph);
 
 DeclareOperation("WreathProduct",
-                 [IsMultiplicativeElementCollection,
-                  IsMultiplicativeElementCollection]);
+                 [IsTransformationMonoid, IsPermGroup]);
+DeclareOperation("WreathProduct",
+                 [IsPermGroup, IsTransformationSemigroup]);
+DeclareOperation("WreathProduct",
+                 [IsTransformationMonoid, IsTransformationSemigroup]);
 
 DeclareAttribute("SmallestElementRClass", IsGreensRClass);
 DeclareAttribute("LargestElementRClass", IsGreensRClass);


### PR DESCRIPTION
This PR partially resolves:

https://github.com/gap-system/gap/issues/6282

The part not resolved is that for `StructureDescription`, it seems that `IsRcwaGroup` and `IsRcwaGroupOverZ` imply `IsGroupAsSemigroup` (which make sense and is fine), but then the methods installed for `StructureDescription` for `IsGroupAsSemigroup` and something else (maybe `IsGroup`) collide. I'm not sure how to resolve this. Any suggestions @fingolfin ?

