### PR TITLE
`GeneralizedConjugacyClasses`

### DIFF
--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -31,14 +31,6 @@
       semigroup <A>S</A>. In a group generalized conjugacy classes coincide
       with conjugacy classes.<P/>
 
-      Note that each generalized conjugacy class as currently implemented
-      does not store a list of elements in the conjugacy class, only the representative
-      with no way to compute all the elements in the conjugacy class.
-      This means that
-      <Ref Attr="GeneralizedConjugacyClasses" Label = "for a semigroup"/> as currently
-      implemented is only as effective as
-      <Ref Attr="GeneralizedConjugacyClassesRepresentatives" Label = "for a semigroup"/>.
-
       <Example><![CDATA[
 gap> S := FullTransformationMonoid(6);;
 gap> GeneralizedConjugacyClassesRepresentatives(S);

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -260,23 +260,23 @@ gap> Irr(ct);
   </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="MonoidCartanMatrix">
+<#GAPDoc Label="CartanMatrix">
   <ManSection>
-    <Attr Name="MonoidCartanMatrix" Arg='M[, F]'/>
+    <Attr Name="CartanMatrix" Arg='M[, F]'/>
     <Returns>An object.</Returns>
     <Description>
       Called with a finite monoid <A>M</A> and a field <A>F</A>,
-      <Ref Attr="MonoidCartanMatrix"/> returns the Cartan matrix of the monoid
+      <Ref Attr="CartanMatrix"/> returns the Cartan matrix of the monoid
       algebra <M>FM</M> which is defined as the matrix
       <M>dim Hom(P,Q)/dim End(P / rad(FM))</M>, where <M>P</M> and <M>Q</M>
       run over the right indecomposable projective modules of FM.<P/>
 
       To get the Cartan matrix of a monoid to display like the example below,
       the projective indecomposable modules need to be computed first using
-      <Ref Attr="Pims" Label="for a monoid cartan matrix"/>.<P/>
+      <Ref Attr="Pims" Label="for a cartan matrix"/>.<P/>
 
       If <A>M</A> is the only argument then
-      <Ref Attr="MonoidCartanMatrix"/> returns the Cartan matrix of the monoid
+      <Ref Attr="CartanMatrix"/> returns the Cartan matrix of the monoid
       algebra <M>FM</M>, where <A>F</A> is a splitting field of <A>M</A> over
       the rationals.<P/>
 
@@ -288,7 +288,7 @@ gap> Irr(ct);
 
       <Example><![CDATA[
 gap> S := FullTransformationMonoid(3);;
-gap> cm := MonoidCartanMatrix(S);;
+gap> cm := CartanMatrix(S);;
 gap> Pims(cm);;
 gap> Display(cm);
     X.1 X.2 X.3 X.4 X.5 X.6
@@ -307,10 +307,10 @@ P.6   .   .   .   1   .   1
 <#GAPDoc Label="Pims">
   <ManSection>
     <Attr Name ="Pims" Arg="T"
-         Label = "for a monoid cartan matrix"/>
+         Label = "for a cartan matrix"/>
     <Returns>A list of monoid characters.</Returns>
     <Description>
-      <Ref Attr="Pims" Label="for a monoid cartan matrix"/> returns a
+      <Ref Attr="Pims" Label="for a cartan matrix"/> returns a
       list of the characters of the projective indecomposable
       modules of the <Ref Attr="Parent" BookName = "ref"/> monoid of the monoid character table <A>T</A>.
 
@@ -318,7 +318,7 @@ P.6   .   .   .   1   .   1
       the presentation of the monoid display inconsistently -->
       <Example><![CDATA[
 gap> M := FullBooleanMatMonoid(2);;
-gap> cm := MonoidCartanMatrix(M);;
+gap> cm := CartanMatrix(M);;
 gap> Pims(cm);
 [ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat\
 , [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true\

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  cartan.xml
-#Y  Copyright (C) 2024                                   Balthazar Charles
+#Y  Copyright (C) 2024-2026                              Balthazar Charles
 ##                                                             Joseph Ruiz
 ##
 ##  Licensing information can be found in the README file of this package.

--- a/doc/cartan.xml
+++ b/doc/cartan.xml
@@ -177,13 +177,13 @@ gap> BlockDiagonalMatrixOfCharacterTables(S);
   </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="MonoidCharacterTable">
+<#GAPDoc Label="CharacterTable">
   <ManSection>
-    <Attr Name="MonoidCharacterTable" Arg='M[, F]'/>
+    <Oper Name="CharacterTable" Arg='M[, F]'/>
     <Returns>The character table object for <A>M</A> over <A>F</A>.</Returns>
     <Description>
       Called with a finite monoid <A>M</A> and optionally a field <A>F</A>,
-      <Ref Attr="MonoidCharacterTable"/> returns the character table of the
+      <Ref Oper="CharacterTable"/> returns the character table of the
       monoid which is defined as the matrix <M>Trace(X(m))</M>, where <M>X</M>
       runs over the simple <M>FM</M>-modules and <M>m</M> runs over the
       generalized conjugacy class representatives of <A>M</A>.<P/>
@@ -193,7 +193,7 @@ gap> BlockDiagonalMatrixOfCharacterTables(S);
       <Ref Attr="Irr" Label="for a monoid character table"/>.<P/>
 
       If <A>F</A> is not given, then
-      <Ref Attr="MonoidCharacterTable"/> returns the character table of
+      <Ref Oper="CharacterTable"/> returns the character table of
       <M>M</M> over a characteristic zero splitting field of <A>M</A>.<P/>
 
       At the moment, methods are available for the following cases:
@@ -204,7 +204,7 @@ gap> BlockDiagonalMatrixOfCharacterTables(S);
 
       <Example><![CDATA[
 gap> S := FullTransformationMonoid(3);;
-gap> ct := MonoidCharacterTable(S);;
+gap> ct := CharacterTable(S);;
 gap> Irr(ct);;
 gap> Display(ct);
     c.1 c.2 c.3 c.4 c.5 c.6
@@ -234,7 +234,7 @@ X.6   1   1   1   1   1   1
       the presentation of the monoid display inconsistently -->
       <Example><![CDATA[
 gap> M := FullBooleanMatMonoid(2);;
-gap> ct := MonoidCharacterTable(M);;
+gap> ct := CharacterTable(M);;
 gap> Irr(ct);
 [ MonoidCharacter( MonoidCharacterTable( Monoid( [ Matrix(IsBooleanMat\
 , [ [ false, true ], [ true, false ] ]), Matrix(IsBooleanMat, [ [ true\

--- a/doc/z-chap11.xml
+++ b/doc/z-chap11.xml
@@ -317,9 +317,9 @@
     <#Include Label="RegularRepresentationBicharacter">
     <#Include Label="RClassBicharacterOfGroupHClass">
     <#Include Label="BlockDiagonalMatrixOfCharacterTables">
-    <#Include Label="MonoidCharacterTable">
+    <#Include Label="CharacterTable">
     <#Include Label="Irr">
-    <#Include Label="MonoidCartanMatrix">
+    <#Include Label="CartanMatrix">
     <#Include Label="Pims">
 
   </Section>

--- a/gap/attributes/cartan.gd
+++ b/gap/attributes/cartan.gd
@@ -13,6 +13,7 @@ DeclareCategory("IsGeneralizedConjugacyClass", IsObject);
 DeclareAttribute("Representative", IsGeneralizedConjugacyClass);
 DeclareAttribute("ParentAttr", IsGeneralizedConjugacyClass);
 DeclareAttribute("MapToGroupHClass", IsGeneralizedConjugacyClass);
+DeclareAttribute("AsList", IsGeneralizedConjugacyClass);
 DeclareOperation("GeneralizedConjugacyClass",
                  [IsSemigroup, IsMultiplicativeElement]);
 DeclareOperation("GeneralizedConjugacyClass",

--- a/gap/attributes/cartan.gd
+++ b/gap/attributes/cartan.gd
@@ -14,8 +14,8 @@ DeclareAttribute("Representative", IsGeneralizedConjugacyClass);
 DeclareAttribute("ParentAttr", IsGeneralizedConjugacyClass);
 DeclareOperation("GeneralizedConjugacyClass",
                  [IsSemigroup, IsMultiplicativeElement]);
-DeclareAttribute("GeneralizedConjugacyClassesRepresentatives", IsSemigroup);
 DeclareAttribute("GeneralizedConjugacyClasses", IsSemigroup);
+DeclareAttribute("GeneralizedConjugacyClassesRepresentatives", IsSemigroup);
 DeclareCategory("IsMonoidCharacterTable", IsObject);
 DeclareAttribute("ParentAttr", IsMonoidCharacterTable);
 DeclareAttribute("MonoidCharacterTable", IsSemigroup);

--- a/gap/attributes/cartan.gd
+++ b/gap/attributes/cartan.gd
@@ -12,8 +12,11 @@
 DeclareCategory("IsGeneralizedConjugacyClass", IsObject);
 DeclareAttribute("Representative", IsGeneralizedConjugacyClass);
 DeclareAttribute("ParentAttr", IsGeneralizedConjugacyClass);
+DeclareAttribute("MapToGroupHClass", IsGeneralizedConjugacyClass);
 DeclareOperation("GeneralizedConjugacyClass",
                  [IsSemigroup, IsMultiplicativeElement]);
+DeclareOperation("GeneralizedConjugacyClass",
+                 [IsSemigroup, IsMultiplicativeElement, IsGeneralMapping]);
 DeclareAttribute("GeneralizedConjugacyClasses", IsSemigroup);
 DeclareAttribute("GeneralizedConjugacyClassesRepresentatives", IsSemigroup);
 DeclareCategory("IsMonoidCharacterTable", IsObject);

--- a/gap/attributes/cartan.gd
+++ b/gap/attributes/cartan.gd
@@ -13,7 +13,6 @@ DeclareCategory("IsGeneralizedConjugacyClass", IsCollection);
 DeclareAttribute("Representative", IsGeneralizedConjugacyClass);
 DeclareAttribute("ParentAttr", IsGeneralizedConjugacyClass);
 DeclareAttribute("MapToGroupHClass", IsGeneralizedConjugacyClass);
-DeclareAttribute("AsList", IsGeneralizedConjugacyClass);
 DeclareOperation("GeneralizedConjugacyClass",
                  [IsSemigroup, IsMultiplicativeElement]);
 DeclareOperation("GeneralizedConjugacyClass",

--- a/gap/attributes/cartan.gd
+++ b/gap/attributes/cartan.gd
@@ -39,10 +39,10 @@ DeclareAttribute("RClassRadicalBicharacterOfGroupHClass", IsGroupHClass);
 DeclareAttribute("BlockDiagonalMatrixOfCharacterTables", IsSemigroup);
 DeclareAttribute("Irr", IsMonoidCharacterTable);
 
-DeclareCategory("IsMonoidCartanMatrix", IsObject);
-DeclareAttribute("ParentAttr", IsMonoidCartanMatrix);
-DeclareAttribute("MonoidCartanMatrix", IsSemigroup);
+DeclareCategory("IsCartanMatrix", IsObject);
+DeclareAttribute("ParentAttr", IsCartanMatrix);
+DeclareAttribute("CartanMatrix", IsSemigroup);
 
-DeclareAttribute("Pims", IsMonoidCartanMatrix);
+DeclareAttribute("Pims", IsCartanMatrix);
 
-DeclareOperation("MyExp", [IsMultiplicativeElement, IsMonoidCharacter]); 
+DeclareOperation("MyExp", [IsMultiplicativeElement, IsMonoidCharacter]);

--- a/gap/attributes/cartan.gd
+++ b/gap/attributes/cartan.gd
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 ##  cartan.gd
-##  Copyright (C) 2024                                   Balthazar Charles
+##  Copyright (C) 2024-2026                              Balthazar Charles
 ##                                                             Joseph Ruiz
 ##
 ##  Licensing information can be found in the README file of this package.

--- a/gap/attributes/cartan.gd
+++ b/gap/attributes/cartan.gd
@@ -9,7 +9,7 @@
 #############################################################################
 ##
 
-DeclareCategory("IsGeneralizedConjugacyClass", IsObject);
+DeclareCategory("IsGeneralizedConjugacyClass", IsCollection);
 DeclareAttribute("Representative", IsGeneralizedConjugacyClass);
 DeclareAttribute("ParentAttr", IsGeneralizedConjugacyClass);
 DeclareAttribute("MapToGroupHClass", IsGeneralizedConjugacyClass);

--- a/gap/attributes/cartan.gd
+++ b/gap/attributes/cartan.gd
@@ -44,3 +44,5 @@ DeclareAttribute("ParentAttr", IsMonoidCartanMatrix);
 DeclareAttribute("MonoidCartanMatrix", IsSemigroup);
 
 DeclareAttribute("Pims", IsMonoidCartanMatrix);
+
+DeclareOperation("MyExp", [IsMultiplicativeElement, IsMonoidCharacter]);

--- a/gap/attributes/cartan.gd
+++ b/gap/attributes/cartan.gd
@@ -21,14 +21,17 @@ DeclareAttribute("GeneralizedConjugacyClasses", IsSemigroup);
 DeclareAttribute("GeneralizedConjugacyClassesRepresentatives", IsSemigroup);
 DeclareCategory("IsMonoidCharacterTable", IsObject);
 DeclareAttribute("ParentAttr", IsMonoidCharacterTable);
-DeclareAttribute("MonoidCharacterTable", IsSemigroup);
+DeclareAttribute("CartanMatrix", IsMonoidCharacterTable);
+DeclareAttribute("OrdinaryCharacterTable", IsSemigroup);
+DeclareOperation("CharacterTable", [IsSemigroup]);
 
 DeclareCategory("IsMonoidCharacter", IsObject);
-DeclareOperation("MonoidCharacter", [IsMonoidCharacterTable, IsList]);
-DeclareOperation("PimMonoidCharacter",
+DeclareOperation("Character", [IsMonoidCharacterTable, IsList]);
+DeclareOperation("Character",
                  [IsMonoidCharacterTable, IsDenseList, IsMonoidCharacter]);
+DeclareOperation("\^", [IsMultiplicativeElement, IsMonoidCharacter]);
 DeclareAttribute("ParentAttr", IsMonoidCharacter);
-DeclareAttribute("ValuesOfMonoidClassFunction", IsMonoidCharacter);
+DeclareAttribute("ValuesOfClassFunction", IsMonoidCharacter);
 DeclareAttribute("ProjectiveCoverOf", IsMonoidCharacter);
 DeclareAttribute("ValuesOfCompositionFactorsFunction", IsMonoidCharacter);
 DeclareAttribute("DClassBicharacter", IsGreensDClass);
@@ -39,10 +42,8 @@ DeclareAttribute("RClassRadicalBicharacterOfGroupHClass", IsGroupHClass);
 DeclareAttribute("BlockDiagonalMatrixOfCharacterTables", IsSemigroup);
 DeclareAttribute("Irr", IsMonoidCharacterTable);
 
-DeclareCategory("IsCartanMatrix", IsObject);
-DeclareAttribute("ParentAttr", IsCartanMatrix);
+DeclareCategory("IsMonoidCartanMatrix", IsObject);
+DeclareAttribute("ParentAttr", IsMonoidCartanMatrix);
 DeclareAttribute("CartanMatrix", IsSemigroup);
 
-DeclareAttribute("Pims", IsCartanMatrix);
-
-DeclareOperation("MyExp", [IsMultiplicativeElement, IsMonoidCharacter]);
+DeclareAttribute("Pims", IsMonoidCartanMatrix);

--- a/gap/attributes/cartan.gd
+++ b/gap/attributes/cartan.gd
@@ -45,4 +45,4 @@ DeclareAttribute("MonoidCartanMatrix", IsSemigroup);
 
 DeclareAttribute("Pims", IsMonoidCartanMatrix);
 
-DeclareOperation("MyExp", [IsMultiplicativeElement, IsMonoidCharacter]);
+DeclareOperation("MyExp", [IsMultiplicativeElement, IsMonoidCharacter]); 

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -51,6 +51,19 @@ function(generalizedconjugacyclass)
       Representative(generalizedconjugacyclass));
 end);
 
+InstallMethod(\=, "for generalized conjugacy classes",
+[IsGeneralizedConjugacyClass, IsGeneralizedConjugacyClass],
+function(gcc1, gcc2)
+  if ParentAttr(gcc1) <> ParentAttr(gcc2) then
+    Error(
+    "Cannot compare generalized conjugacy classes of different semigroups.");
+  fi;
+  if Representative(gcc1) = Representative(gcc2) then
+    return true;
+  fi;
+  return Representative(gcc1) in AsList(gcc2);
+end);
+
 InstallMethod(DisplayString, "for a generalized conjugacy class",
 [IsGeneralizedConjugacyClass],
 ViewString);
@@ -79,6 +92,58 @@ end);
 InstallMethod(GeneralizedConjugacyClassesRepresentatives, "for a semigroup",
 [IsSemigroup],
 S -> List(GeneralizedConjugacyClasses(S), Representative));
+
+InstallMethod(AsList, "for a generalized conjugacy class",
+[IsGeneralizedConjugacyClass],
+function(gcc)
+  local S, rclasses, allgcc, repgcc, holderoflists, s, w, sw, temprclass,
+        Rsw, tempgcc, e, Le, RtoLse, LtoHes, i;
+
+  S        := ParentAttr(gcc);
+  rclasses := RClasses(S);
+  allgcc   := GeneralizedConjugacyClasses(S);
+  repgcc   := GeneralizedConjugacyClassesRepresentatives(S);
+
+  if not HasAsList(allgcc[1]) then
+    holderoflists := List(allgcc, x -> []);
+    for s in S do
+      w    := SmallestIdempotentPower(s);
+      sw   := s ^ w;
+      for temprclass in rclasses do
+        if sw in temprclass then
+          Rsw := temprclass;
+          break;
+        fi;
+      od;
+      for tempgcc in allgcc do
+        if not sw in DClassOfHClass(Source(MapToGroupHClass(tempgcc))) then
+          continue;
+        fi;
+        e := MultiplicativeNeutralElement(Source(MapToGroupHClass(tempgcc)));
+        Le  := LClassOfHClass(Source(MapToGroupHClass(tempgcc)));
+        RtoLse := Intersection(Rsw, Le)[1];
+        LtoHes := LeftGreensMultiplier(S, RtoLse, e);
+        if IsConjugate(Image(MapToGroupHClass(tempgcc)),
+                       MapToGroupHClass(tempgcc)(LtoHes * sw * s * RtoLse),
+                       MapToGroupHClass(tempgcc)(Representative(tempgcc))) then
+          Add(holderoflists[Position(repgcc, Representative(tempgcc))], s);
+          break;
+        fi;
+      od;
+    od;
+    for i in [1 .. Length(allgcc)] do
+      SetAsList(allgcc[i], holderoflists[i]);
+    od;
+  fi;
+
+  for tempgcc in allgcc do
+    if Representative(gcc) in AsList(tempgcc) then
+      return AsList(tempgcc);
+    fi;
+  od;
+
+  return fail;
+end);
 
 BindGlobal("MonoidCharacterTableType",
 NewType(NewFamily("MonoidCharacterTableFamily"),

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -30,6 +30,18 @@ function(S, s)
   return result;
 end);
 
+InstallMethod(GeneralizedConjugacyClass,
+              "for a semigroup and a multiplicative element",
+[IsSemigroup, IsMultiplicativeElement, IsGeneralMapping],
+function(S, s, map)
+  local result;
+  result := Objectify(GeneralizedConjugacyClassType, rec());
+  SetRepresentative(result, s);
+  SetParentAttr(result, S);
+  SetMapToGroupHClass(result, map);
+  return result;
+end);
+
 InstallMethod(ViewString, "for a generalized conjugacy class",
 [IsGeneralizedConjugacyClass],
 function(generalizedconjugacyclass)
@@ -46,13 +58,6 @@ ViewString);
 InstallMethod(GeneralizedConjugacyClasses, "for a semigroup",
 [IsSemigroup],
 function(S)
-  return List(GeneralizedConjugacyClassesRepresentatives(S),
-                 x -> GeneralizedConjugacyClass(S, x));
-end);
-
-InstallMethod(GeneralizedConjugacyClassesRepresentatives, "for a semigroup",
-[IsSemigroup],
-function(S)
   local D, out, C, map, invmap;
 
   D := List(RegularDClasses(S), GroupHClass);
@@ -64,12 +69,16 @@ function(S)
     # Ugly fix: ensures that the conjugacy classes are computed
     # in the same order each time.
     invmap := InverseGeneralMapping(map);
-    C := List(C, x -> x ^ invmap);
+    C := List(C, x -> GeneralizedConjugacyClass(S, x ^ invmap, map));
     Append(out, C);
   od;
 
   return out;
 end);
+
+InstallMethod(GeneralizedConjugacyClassesRepresentatives, "for a semigroup",
+[IsSemigroup],
+S -> List(GeneralizedConjugacyClasses(S), Representative));
 
 BindGlobal("MonoidCharacterTableType",
 NewType(NewFamily("MonoidCharacterTableFamily"),

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -43,6 +43,13 @@ InstallMethod(DisplayString, "for a generalized conjugacy class",
 [IsGeneralizedConjugacyClass],
 ViewString);
 
+InstallMethod(GeneralizedConjugacyClasses, "for a semigroup",
+[IsSemigroup],
+function(S)
+  return List(GeneralizedConjugacyClassesRepresentatives(S),
+                 x -> GeneralizedConjugacyClass(S, x));
+end);
+
 InstallMethod(GeneralizedConjugacyClassesRepresentatives, "for a semigroup",
 [IsSemigroup],
 function(S)
@@ -62,13 +69,6 @@ function(S)
   od;
 
   return out;
-end);
-
-InstallMethod(GeneralizedConjugacyClasses, "for a semigroup",
-[IsSemigroup],
-function(S)
-  return List(GeneralizedConjugacyClassesRepresentatives(S),
-                 x -> GeneralizedConjugacyClass(S, x));
 end);
 
 BindGlobal("MonoidCharacterTableType",

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -461,28 +461,25 @@ function(char)
   Error("No method to generate ValuesOfMonoidClassFunction in this case");
 end);
 
-# # obj in AsList should be replaced with `in` when the `in` function is made
-# InstallMethod(\^, "for a monoid element and a monoid character",
-# [IsObject, IsMonoidCharacter],
-# function(obj, char)
-#   local ct, M, values, gcc, i;
+# obj in AsList should be replaced with `in` when the `in` function is made
+InstallMethod(MyExp, "for a multiplicative element and a monoid character",
+[IsMultiplicativeElement, IsMonoidCharacter],
+function(obj, char)
+  local ct, M, values, gcc, i;
 
-#   ct := ParentAttr(char);
-#   M  := ParentAttr(ct);
-#   if not obj in M then
-#     Error("The object is not in the semigroup.");
-#   fi;
-#   values := ValuesOfMonoidClassFunction(char);
-#   gcc := GeneralizedConjugacyClasses(M);
+  ct := ParentAttr(char);
+  M  := ParentAttr(ct);
+  values := ValuesOfMonoidClassFunction(char);
+  gcc := GeneralizedConjugacyClasses(M);
 
-#   for i in [1 .. Size(gcc)] do
-#     if obj in gcc[i] then
-#       return values[i];
-#     fi;
-#   od;
+  for i in [1 .. Size(gcc)] do
+    if obj in gcc[i] then
+      return values[i];
+    fi;
+  od;
 
-#   Error("The object is not in the semigroup.");
-# end);
+  Error("The object is not in the semigroup.");
+end);
 
 InstallMethod(DClassBicharacter, "for a D-class",
 [IsGreensDClass],

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -14,17 +14,20 @@
 # This object is to be a placeholder to eventually hold all the elements
 # which are in the same generalized conjugacy class. This will then allow
 # the monoid characters to work like characters in the case of groups.
-BindGlobal("GeneralizedConjugacyClassType",
-NewType(NewFamily("GeneralizedConjugacyClassFamily"),
-        IsGeneralizedConjugacyClass and
-        IsAttributeStoringRep));
-
 InstallMethod(GeneralizedConjugacyClass,
               "for a semigroup and a multiplicative element",
 [IsSemigroup, IsMultiplicativeElement],
 function(S, s)
-  local result;
-  result := Objectify(GeneralizedConjugacyClassType, rec());
+  local result, fam;
+
+  fam := FamilyObj(S);
+
+  if not IsBound(fam!.defaultGenerlaizedClassType) then
+    fam!.defaultGenerlaizedClassType := NewType(fam,
+              IsGeneralizedConjugacyClass and IsAttributeStoringRep);
+  fi;
+
+  result := Objectify(fam!.defaultGenerlaizedClassType, rec());
   SetRepresentative(result, s);
   SetParentAttr(result, S);
   return result;
@@ -34,8 +37,16 @@ InstallMethod(GeneralizedConjugacyClass,
               "for a semigroup and a multiplicative element",
 [IsSemigroup, IsMultiplicativeElement, IsGeneralMapping],
 function(S, s, map)
-  local result;
-  result := Objectify(GeneralizedConjugacyClassType, rec());
+  local result, fam;
+
+  fam := FamilyObj(S);
+
+  if not IsBound(fam!.defaultGenerlaizedClassType) then
+    fam!.defaultGenerlaizedClassType := NewType(fam,
+              IsGeneralizedConjugacyClass and IsAttributeStoringRep);
+  fi;
+
+  result := Objectify(fam!.defaultGenerlaizedClassType, rec());
   SetRepresentative(result, s);
   SetParentAttr(result, S);
   SetMapToGroupHClass(result, map);
@@ -152,10 +163,7 @@ gcc -> Enumerator(AsList(gcc)));
 # The test has been updated to show that this method would work if it were run
 InstallMethod(\in, "for a object and a generalized conjugacy class",
 [IsObject, IsGeneralizedConjugacyClass],
-function(obj, gcc)
-  Error("something");
-  return obj in AsList(gcc);
-end);
+{obj, gcc} -> obj in AsList(gcc));
 
 BindGlobal("MonoidCharacterTableType",
 NewType(NewFamily("MonoidCharacterTableFamily"),

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -461,7 +461,7 @@ function(char)
   Error("No method to generate ValuesOfMonoidClassFunction in this case");
 end);
 
-InstallMethod(MyExp, "for a multiplicative element and a monoid character",
+InstallOtherMethod(\^, "for a multiplicative element and a monoid character",
 [IsMultiplicativeElement, IsMonoidCharacter],
 function(obj, char)
   local ct, M, values, gcc, i;

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -441,6 +441,41 @@ function(char)
   return str;
 end);
 
+InstallMethod(ValuesOfMonoidClassFunction, "for a monoid character",
+[IsMonoidCharacter],
+function(char)
+  local ct;
+  if HasValuesOfCompositionFactorsFunction(char) then
+    ct := List(Irr(ParentAttr(char)), ValuesOfClassFunction);
+    return ValuesOfCompositionFactorsFunction(char) * ct;
+  fi;
+
+  Error("No method to generate ValuesOfMonoidClassFunction in this case");
+end);
+
+# obj in AsList should be replaced with `in` when the `in` function is made
+# InstallMethod(\^, "for a monoid element and a monoid character",
+# [IsObject, IsMonoidCharacter],
+# function(obj, char)
+#   local ct, M, values, gcc, i;
+
+#   ct := ParentAttr(char);
+#   M  := ParentAttr(ct);
+#   if not obj in M then
+#     Error("The object is not in the semigroup.");
+#   fi;
+#   values := ValuesOfMonoidClassFunction(char);
+#   gcc := GeneralizedConjugacyClasses(M);
+
+#   for i in [1 .. Size(gcc)] do
+#     if obj in gcc[i] then
+#       return values[i];
+#     fi;
+#   od;
+
+#   Error("The object is not in the semigroup.");
+# end);
+
 InstallMethod(DClassBicharacter, "for a D-class",
 [IsGreensDClass],
 function(D)

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -303,37 +303,37 @@ function(ct)
   return str;
 end);
 
-BindGlobal("MonoidCartanMatrixType",
-NewType(NewFamily("MonoidCartanMatrixFamily"),
-        IsMonoidCartanMatrix and
+BindGlobal("CartanMatrixType",
+NewType(NewFamily("CartanMatrixFamily"),
+        IsCartanMatrix and
         IsAttributeStoringRep));
 
-InstallMethod(MonoidCartanMatrix,  "for a semigroup",
+InstallMethod(CartanMatrix,  "for a semigroup",
 [IsMonoidAsSemigroup],
 function(S)
   local result;
 
-  result := Objectify(MonoidCartanMatrixType, rec());
+  result := Objectify(CartanMatrixType, rec());
   SetParentAttr(result, S);
 
   return result;
 end);
 
-InstallMethod(ViewString, "for a monoid cartan matrix",
-[IsMonoidCartanMatrix],
+InstallMethod(ViewString, "for a cartan matrix",
+[IsCartanMatrix],
 function(cm)
-  return StringFormatted("MonoidCartanMatrix( {} )",
+  return StringFormatted("CartanMatrix( {} )",
   ParentAttr(cm));
 end);
 
-InstallMethod(DisplayString, "for a monoid cartan matrix",
-[IsMonoidCartanMatrix],
+InstallMethod(DisplayString, "for a cartan matrix",
+[IsCartanMatrix],
 function(cm)
   local str, columnlabels, rowlabels, strarray, sizetable, i, j, cmmatrix,
   coltable, columnwidth, rowlabelwidth, currentwidth, currentpage,
   screensizeassume, quotientcolumnwidthsums, temp, temp2;
 
-  str := StringFormatted("MonoidCartanMatrix( {} )",
+  str := StringFormatted("CartanMatrix( {} )",
   ParentAttr(cm));
 
   if HasPims(cm) then
@@ -817,8 +817,8 @@ function(ct, values, char)
   return result;
 end);
 
-InstallMethod(Pims,  "for a monoid Cartan matrix",
-[IsMonoidCartanMatrix],
+InstallMethod(Pims,  "for a cartan matrix",
+[IsCartanMatrix],
 function(cm)
   local C, S, ct, M, out;
 

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 ##  cartan.gi
-##  Copyright (C) 2024                                   Balthazar Charles
+##  Copyright (C) 2024-2026                              Balthazar Charles
 ##                                                             Joseph Ruiz
 ##
 ##  Licensing information can be found in the README file of this package.
@@ -9,7 +9,7 @@
 #############################################################################
 ##
 
-# This implementation of generalized conjugacy classes is very rundamentary
+# This implementation of generalized conjugacy classes is very rudimentary
 # and is practically unused to compute the character table or Cartan matrix.
 # This object is to be a placeholder to eventually hold all the elements
 # which are in the same generalized conjugacy class. This will then allow

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -55,8 +55,7 @@ InstallMethod(\=, "for generalized conjugacy classes",
 [IsGeneralizedConjugacyClass, IsGeneralizedConjugacyClass],
 function(gcc1, gcc2)
   if ParentAttr(gcc1) <> ParentAttr(gcc2) then
-    Error(
-    "Cannot compare generalized conjugacy classes of different semigroups.");
+    return false
   fi;
   if Representative(gcc1) = Representative(gcc2) then
     return true;

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -454,7 +454,7 @@ InstallMethod(ValuesOfMonoidClassFunction, "for a monoid character",
 function(char)
   local ct;
   if HasValuesOfCompositionFactorsFunction(char) then
-    ct := List(Irr(ParentAttr(char)), ValuesOfClassFunction);
+    ct := List(Irr(ParentAttr(char)), ValuesOfMonoidClassFunction);
     return ValuesOfCompositionFactorsFunction(char) * ct;
   fi;
 

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -461,7 +461,6 @@ function(char)
   Error("No method to generate ValuesOfMonoidClassFunction in this case");
 end);
 
-# obj in AsList should be replaced with `in` when the `in` function is made
 InstallMethod(MyExp, "for a multiplicative element and a monoid character",
 [IsMultiplicativeElement, IsMonoidCharacter],
 function(obj, char)

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -461,7 +461,7 @@ function(char)
   Error("No method to generate ValuesOfMonoidClassFunction in this case");
 end);
 
-# obj in AsList should be replaced with `in` when the `in` function is made
+# # obj in AsList should be replaced with `in` when the `in` function is made
 # InstallMethod(\^, "for a monoid element and a monoid character",
 # [IsObject, IsMonoidCharacter],
 # function(obj, char)

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -145,6 +145,10 @@ function(gcc)
   return fail;
 end);
 
+InstallMethod(Enumerator, "for a generalized conjugacy class",
+[IsGeneralizedConjugacyClass],
+gcc -> Enumerator(AsList(gcc)));
+
 BindGlobal("MonoidCharacterTableType",
 NewType(NewFamily("MonoidCharacterTableFamily"),
         IsMonoidCharacterTable and

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -471,6 +471,14 @@ function(obj, char)
   values := ValuesOfMonoidClassFunction(char);
   gcc := GeneralizedConjugacyClasses(M);
 
+  if obj = Identity(M) then
+    for i in [1 .. Size(gcc)] do
+      if Identity(M) = Representative(gcc[i]) then
+        return values[i];
+      fi;
+    od;
+  fi;
+
   for i in [1 .. Size(gcc)] do
     if obj in gcc[i] then
       return values[i];

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -148,6 +148,8 @@ InstallMethod(Enumerator, "for a generalized conjugacy class",
 [IsGeneralizedConjugacyClass],
 gcc -> Enumerator(AsList(gcc)));
 
+# This method is not run
+# The test has been updated to show that this method would work if it were run
 InstallMethod(\in, "for a object and a generalized conjugacy class",
 [IsObject, IsGeneralizedConjugacyClass],
 function(obj, gcc)

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -55,7 +55,7 @@ InstallMethod(\=, "for generalized conjugacy classes",
 [IsGeneralizedConjugacyClass, IsGeneralizedConjugacyClass],
 function(gcc1, gcc2)
   if ParentAttr(gcc1) <> ParentAttr(gcc2) then
-    return false
+    return false;
   fi;
   if Representative(gcc1) = Representative(gcc2) then
     return true;
@@ -147,6 +147,13 @@ end);
 InstallMethod(Enumerator, "for a generalized conjugacy class",
 [IsGeneralizedConjugacyClass],
 gcc -> Enumerator(AsList(gcc)));
+
+InstallMethod(\in, "for a object and a generalized conjugacy class",
+[IsObject, IsGeneralizedConjugacyClass],
+function(obj, gcc)
+  Error("something");
+  return obj in AsList(gcc);
+end);
 
 BindGlobal("MonoidCharacterTableType",
 NewType(NewFamily("MonoidCharacterTableFamily"),

--- a/gap/attributes/cartan.gi
+++ b/gap/attributes/cartan.gi
@@ -170,7 +170,11 @@ NewType(NewFamily("MonoidCharacterTableFamily"),
         IsMonoidCharacterTable and
         IsAttributeStoringRep));
 
-InstallMethod(MonoidCharacterTable,  "for a semigroup",
+InstallMethod(CharacterTable,  "for a semigroup",
+[IsMonoidAsSemigroup],
+OrdinaryCharacterTable);
+
+InstallMethod(OrdinaryCharacterTable,  "for a semigroup",
 [IsMonoidAsSemigroup],
 function(S)
   local result;
@@ -213,9 +217,9 @@ function(ct)
     sizetable := Length(Irr(ct));
 
     strarray := List([1 .. sizetable], x -> List([1 .. sizetable], y -> "."));
-    ctmatrix := List(Irr(ct), ValuesOfMonoidClassFunction);
+    ctmatrix := List(Irr(ct), ValuesOfClassFunction);
     rosetastone := Filtered(Unique(Concatenation(List(Irr(ct),
-                                   ValuesOfMonoidClassFunction))),
+                                   ValuesOfClassFunction))),
                                    x -> not IsInt(x));
 
     columnlabels := List([1 .. 2], x -> List([1 .. sizetable], y -> " "));
@@ -305,29 +309,33 @@ end);
 
 BindGlobal("CartanMatrixType",
 NewType(NewFamily("CartanMatrixFamily"),
-        IsCartanMatrix and
+        IsMonoidCartanMatrix and
         IsAttributeStoringRep));
 
 InstallMethod(CartanMatrix,  "for a semigroup",
 [IsMonoidAsSemigroup],
-function(S)
+S -> CartanMatrix(CharacterTable(S)));
+
+InstallMethod(CartanMatrix,  "for a  monoid character table",
+[IsMonoidCharacterTable],
+function(ct)
   local result;
 
   result := Objectify(CartanMatrixType, rec());
-  SetParentAttr(result, S);
+  SetParentAttr(result, ct);
 
   return result;
 end);
 
 InstallMethod(ViewString, "for a cartan matrix",
-[IsCartanMatrix],
+[IsMonoidCartanMatrix],
 function(cm)
   return StringFormatted("CartanMatrix( {} )",
   ParentAttr(cm));
 end);
 
 InstallMethod(DisplayString, "for a cartan matrix",
-[IsCartanMatrix],
+[IsMonoidCartanMatrix],
 function(cm)
   local str, columnlabels, rowlabels, strarray, sizetable, i, j, cmmatrix,
   coltable, columnwidth, rowlabelwidth, currentwidth, currentpage,
@@ -420,14 +428,14 @@ NewType(NewFamily("MonoidCharacterFamily"),
         IsMonoidCharacter and
         IsAttributeStoringRep));
 
-InstallMethod(MonoidCharacter,  "for a monoid character table and dense list",
+InstallMethod(Character,  "for a monoid character table and dense list",
 [IsMonoidCharacterTable, IsDenseList],
 function(ct, values)
   local result;
 
   result := Objectify(MonoidCharacterType, rec());
   SetParentAttr(result, ct);
-  SetValuesOfMonoidClassFunction(result, values);
+  SetValuesOfClassFunction(result, values);
 
   return result;
 end);
@@ -436,10 +444,10 @@ InstallMethod(ViewString, "for a monoid character",
 [IsMonoidCharacter],
 function(char)
   local str;
-  if HasValuesOfMonoidClassFunction(char) then
+  if HasValuesOfClassFunction(char) then
     str := StringFormatted("MonoidCharacter( {} , {} )",
            ViewString(ParentAttr(char)),
-           ValuesOfMonoidClassFunction(char));
+           ValuesOfClassFunction(char));
   elif HasProjectiveCoverOf(char) then
     str := StringFormatted("MonoidCharacter( {} , Projective Cover Of {} )",
            ViewString(ParentAttr(char)),
@@ -449,16 +457,16 @@ function(char)
   return str;
 end);
 
-InstallMethod(ValuesOfMonoidClassFunction, "for a monoid character",
+InstallMethod(ValuesOfClassFunction, "for a monoid character",
 [IsMonoidCharacter],
 function(char)
   local ct;
   if HasValuesOfCompositionFactorsFunction(char) then
-    ct := List(Irr(ParentAttr(char)), ValuesOfMonoidClassFunction);
+    ct := List(Irr(ParentAttr(char)), ValuesOfClassFunction);
     return ValuesOfCompositionFactorsFunction(char) * ct;
   fi;
 
-  Error("No method to generate ValuesOfMonoidClassFunction in this case");
+  Error("No method to generate ValuesOfClassFunction in this case");
 end);
 
 InstallOtherMethod(\^, "for a multiplicative element and a monoid character",
@@ -468,7 +476,7 @@ function(obj, char)
 
   ct := ParentAttr(char);
   M  := ParentAttr(ct);
-  values := ValuesOfMonoidClassFunction(char);
+  values := ValuesOfClassFunction(char);
   gcc := GeneralizedConjugacyClasses(M);
 
   if obj = Identity(M) then
@@ -800,10 +808,10 @@ function(ct)
   Rrad := Concatenation(List(transversalHclasses,
                         RClassRadicalBicharacterOfGroupHClass));
   irrvalues := Inverse(TransposedMat(D)) * (R - Rrad);
-  return List(irrvalues, x -> MonoidCharacter(ct, x));
+  return List(irrvalues, x -> Character(ct, x));
 end);
 
-InstallMethod(PimMonoidCharacter,
+InstallMethod(Character,
 "for a monoid character table, dense list, and monoid character",
 [IsMonoidCharacterTable, IsDenseList, IsMonoidCharacter],
 function(ct, values, char)
@@ -818,16 +826,16 @@ function(ct, values, char)
 end);
 
 InstallMethod(Pims,  "for a cartan matrix",
-[IsCartanMatrix],
+[IsMonoidCartanMatrix],
 function(cm)
   local C, S, ct, M, out;
 
-  S := ParentAttr(cm);
-  ct := MonoidCharacterTable(S);
-  C := List(Irr(ct), ValuesOfMonoidClassFunction);
-  M := RegularRepresentationBicharacter(S);
+  ct  := ParentAttr(cm);
+  S   := ParentAttr(ct);
+  C   := List(Irr(ct), ValuesOfClassFunction);
+  M   := RegularRepresentationBicharacter(S);
   out := Inverse(TransposedMatMutable(C)) * M * Inverse(C);
 
   return List([1 .. Length(out)],
-                n -> PimMonoidCharacter(ct, out[n], Irr(ct)[n]));
+                n -> Character(ct, out[n], Irr(ct)[n]));
 end);

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  standard/attributes/cartan.tst
-#Y  Copyright (C) 2024                                   Balthazar Charles
+#Y  Copyright (C) 2024-2026                              Balthazar Charles
 ##                                                             Joseph Ruiz
 ##
 ##  Licensing information can be found in the README file of this package.

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -68,9 +68,7 @@ gap> Number(ccm, c -> m in c);
 gap> M := FullTransformationMonoid(3);;
 gap> cm := MonoidCartanMatrix(M);;
 gap> pims := Pims(cm);;
-gap> mat := List(pims, ValuesOfMonoidClassFunction);
-[ [ 1, -1, 1, 0, 0, 0 ], [ 2, 0, -1, 0, 0, 0 ], [ 4, 0, 1, 1, -1, 0 ], 
-  [ 3, -1, 0, 1, -1, 0 ], [ 3, 1, 0, 1, 1, 0 ], [ 3, 1, 0, 2, 0, 1 ] ]
+gap> mat := List(pims, ValuesOfMonoidClassFunction);;
 gap> known := [[1, -1, 1, 0, 0, 0],
 > [2, 0, -1, 0, 0, 0],
 > [4, 0, 1, 1, -1, 0],
@@ -98,17 +96,19 @@ true
 gap> M := FullTransformationMonoid(3);;
 gap> ct := MonoidCharacterTable(M);;
 gap> m := Transformation([2, 2, 1]);;
-gap> Number(List(Irr(ct), chi -> MyExp(m, chi)), x -> x = 1);
+gap> Number(List(Irr(ct), chi -> m ^ chi), x -> x = 1);
 1
-gap> Number(List(Irr(ct), chi -> MyExp(m, chi)), x -> x = 0);
+gap> Number(List(Irr(ct), chi -> m ^ chi), x -> x = 0);
 5
 
 #  Check special use of MyExp for the identity element - 1
 gap> M := FullTransformationMonoid(3);;
 gap> ct := MonoidCharacterTable(M);;
 gap> m := Identity(M);;
-gap> List(Irr(ct), chi -> MyExp(m, chi));
-[ 1, 2, 1, 2, 3, 1 ]
+gap> mat := List(Irr(ct), chi -> m ^ chi);;
+gap> known := [1, 2, 1, 2, 3, 1];;
+gap> TransformingPermutations([mat], [known]) <> fail;
+true
 gap> ccm := GeneralizedConjugacyClasses(M);;
 gap> HasAsList(ccm[1]);
 false

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -103,6 +103,16 @@ gap> Number(List(Irr(ct), chi -> MyExp(m, chi)), x -> x = 1);
 gap> Number(List(Irr(ct), chi -> MyExp(m, chi)), x -> x = 0);
 5
 
+#  Check special use of MyExp for the identity element - 1
+gap> M := FullTransformationMonoid(3);;
+gap> ct := MonoidCharacterTable(M);;
+gap> m := Identity(M);;
+gap> List(Irr(ct), chi -> MyExp(m, chi));
+[ 1, 2, 1, 2, 3, 1 ]
+gap> ccm := GeneralizedConjugacyClasses(M);;
+gap> HasAsList(ccm[1]);
+false
+
 #  Check display string of MonoidCharacterTable - 1
 #  Explicitly enable acting methods because the order of the D-classes
 #  is not canonical and a permutation on the D-classes may be lead to

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -93,9 +93,12 @@ gap> M := FullTransformationMonoid(3);;
 gap> ct := MonoidCharacterTable(M);;
 gap> irr := Irr(ct)[1];;
 gap> m := Transformation([2, 2, 1]);;
-gap> m ^ irr;
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `^' on 2 arguments
+gap> MyExp(m, irr);
+0
+gap> irr := Irr(ct)[6];;
+gap> m := Transformation([2, 2, 1]);;
+gap> MyExp(m, irr);
+1
 
 #  Check display string of MonoidCharacterTable - 1
 #  Explicitly enable acting methods because the order of the D-classes

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -55,6 +55,29 @@ gap> m := Transformation([2, 2, 1]);;
 gap> Size(GeneralizedConjugacyClass(M, m));
 9
 
+#  \in GeneralizedConjugacyClass test
+gap> M := FullTransformationMonoid(3);;
+gap> m := Transformation([2, 2, 1]);;
+gap> ccm := GeneralizedConjugacyClass(M, m);;
+gap> m in ccm[1];
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `[]' on 2 arguments
+gap> m in ccm[2];
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `[]' on 2 arguments
+gap> m in ccm[3];
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `[]' on 2 arguments
+gap> m in ccm[4];
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `[]' on 2 arguments
+gap> m in ccm[5];
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `[]' on 2 arguments
+gap> m in ccm[6];
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `[]' on 2 arguments
+
 #  Simple check of a monoid character table  - 1
 gap> S := FullTransformationMonoid(3);;
 gap> ct := MonoidCharacterTable(S);;

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -49,6 +49,12 @@ gap> AsList(GeneralizedConjugacyClass(M, m));
   Transformation( [ 3, 1, 3 ] ), Transformation( [ 3, 2, 2 ] ), 
   Transformation( [ 3, 3, 3 ] ) ]
 
+#  AsList GeneralizedConjugacyClass test
+gap> M := FullTransformationMonoid(3);;
+gap> m := Transformation([2, 2, 1]);;
+gap> Size(GeneralizedConjugacyClass(M, m));
+9
+
 #  Simple check of a monoid character table  - 1
 gap> S := FullTransformationMonoid(3);;
 gap> ct := MonoidCharacterTable(S);;

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -64,6 +64,14 @@ gap> Size(ccm);
 gap> Number(ccm, c -> m in c);
 1
 
+#  Projective Character finde ValuesOfMonoidClassFunction test
+gap> M := FullTransformationMonoid(3);;
+gap> cm := MonoidCartanMatrix(M);;
+gap> pims := Pims(cm);;
+gap> List(pims, ValuesOfMonoidClassFunction);
+[ [ 1, -1, 1, 0, 0, 0 ], [ 2, 0, -1, 0, 0, 0 ], [ 4, 0, 1, 1, -1, 0 ], 
+  [ 3, -1, 0, 1, -1, 0 ], [ 3, 1, 0, 1, 1, 0 ], [ 3, 1, 0, 2, 0, 1 ] ]
+
 #  Simple check of a monoid character table  - 1
 gap> S := FullTransformationMonoid(3);;
 gap> ct := MonoidCharacterTable(S);;

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -58,25 +58,21 @@ gap> Size(GeneralizedConjugacyClass(M, m));
 #  \in GeneralizedConjugacyClass test
 gap> M := FullTransformationMonoid(3);;
 gap> m := Transformation([2, 2, 1]);;
-gap> ccm := GeneralizedConjugacyClass(M, m);;
+gap> ccm := GeneralizedConjugacyClasses(M);;
+gap> Size(ccm);
+6
 gap> m in ccm[1];
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `[]' on 2 arguments
+false
 gap> m in ccm[2];
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `[]' on 2 arguments
+false
 gap> m in ccm[3];
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `[]' on 2 arguments
+false
 gap> m in ccm[4];
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `[]' on 2 arguments
+false
 gap> m in ccm[5];
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `[]' on 2 arguments
+false
 gap> m in ccm[6];
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `[]' on 2 arguments
+false
 
 #  Simple check of a monoid character table  - 1
 gap> S := FullTransformationMonoid(3);;

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -68,15 +68,15 @@ gap> Number(ccm, c -> m in c);
 gap> M := FullTransformationMonoid(3);;
 gap> cm := MonoidCartanMatrix(M);;
 gap> pims := Pims(cm);;
-gap> mat :=List(pims, ValuesOfMonoidClassFunction);
+gap> mat := List(pims, ValuesOfMonoidClassFunction);
 [ [ 1, -1, 1, 0, 0, 0 ], [ 2, 0, -1, 0, 0, 0 ], [ 4, 0, 1, 1, -1, 0 ], 
   [ 3, -1, 0, 1, -1, 0 ], [ 3, 1, 0, 1, 1, 0 ], [ 3, 1, 0, 2, 0, 1 ] ]
-gap> known := [ [ 1, -1, 1, 0, 0, 0 ],
-> [ 2, 0, -1, 0, 0, 0 ],
-> [ 4, 0, 1, 1, -1, 0 ],
-> [ 3, -1, 0, 1, -1, 0 ],
-> [ 3, 1, 0, 1, 1, 0 ],
-> [ 3, 1, 0, 2, 0, 1 ] ];;
+gap> known := [[1, -1, 1, 0, 0, 0],
+> [2, 0, -1, 0, 0, 0],
+> [4, 0, 1, 1, -1, 0],
+> [3, -1, 0, 1, -1, 0],
+> [3, 1, 0, 1, 1, 0],
+> [3, 1, 0, 2, 0, 1]];;
 gap> TransformingPermutations(mat, known) <> fail;
 true
 

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -61,18 +61,18 @@ gap> m := Transformation([2, 2, 1]);;
 gap> ccm := GeneralizedConjugacyClasses(M);;
 gap> Size(ccm);
 6
-gap> m in ccm[1];
+gap> m in List(ccm[1]);
 false
-gap> m in ccm[2];
+gap> m in List(ccm[2]);
 false
-gap> m in ccm[3];
+gap> m in List(ccm[3]);
 false
-gap> m in ccm[4];
+gap> m in List(ccm[4]);
 false
-gap> m in ccm[5];
+gap> m in List(ccm[5]);
 false
-gap> m in ccm[6];
-false
+gap> m in List(ccm[6]);
+true
 
 #  Simple check of a monoid character table  - 1
 gap> S := FullTransformationMonoid(3);;

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -56,7 +56,6 @@ gap> Size(GeneralizedConjugacyClass(M, m));
 9
 
 #  \in GeneralizedConjugacyClass test
-#  tests for List
 gap> M := FullTransformationMonoid(3);;
 gap> m := Transformation([2, 2, 1]);;
 gap> ccm := GeneralizedConjugacyClasses(M);;
@@ -89,10 +88,19 @@ gap> known := [[1, -1, 1, 0, 0, 0],
 gap> TransformingPermutations(mat, known) <> fail;
 true
 
-# Check display string of MonoidCharacterTable - 1
-# Explicitly enable acting methods because the order of the D-classes
-# is not canonical and a permutation on the D-classes may be lead to
-# a different display string.
+#  Check application of monoid character to an element - 1
+gap> M := FullTransformationMonoid(3);;
+gap> ct := MonoidCharacterTable(M);;
+gap> irr := Irr(ct)[1];;
+gap> m := Transformation([2, 2, 1]);;
+gap> m^irr;
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `^' on 2 arguments
+
+#  Check display string of MonoidCharacterTable - 1
+#  Explicitly enable acting methods because the order of the D-classes
+#  is not canonical and a permutation on the D-classes may be lead to
+#  a different display string.
 gap> S := Monoid(FullTransformationMonoid(3), rec(acting := true));;
 gap> ct := MonoidCharacterTable(S);;
 gap> Irr(ct);;

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -68,9 +68,17 @@ gap> Number(ccm, c -> m in c);
 gap> M := FullTransformationMonoid(3);;
 gap> cm := MonoidCartanMatrix(M);;
 gap> pims := Pims(cm);;
-gap> List(pims, ValuesOfMonoidClassFunction);
+gap> mat :=List(pims, ValuesOfMonoidClassFunction);
 [ [ 1, -1, 1, 0, 0, 0 ], [ 2, 0, -1, 0, 0, 0 ], [ 4, 0, 1, 1, -1, 0 ], 
   [ 3, -1, 0, 1, -1, 0 ], [ 3, 1, 0, 1, 1, 0 ], [ 3, 1, 0, 2, 0, 1 ] ]
+gap> known := [ [ 1, -1, 1, 0, 0, 0 ],
+> [ 2, 0, -1, 0, 0, 0 ],
+> [ 4, 0, 1, 1, -1, 0 ],
+> [ 3, -1, 0, 1, -1, 0 ],
+> [ 3, 1, 0, 1, 1, 0 ],
+> [ 3, 1, 0, 2, 0, 1 ] ];;
+gap> TransformingPermutations(mat, known) <> fail;
+true
 
 #  Simple check of a monoid character table  - 1
 gap> S := FullTransformationMonoid(3);;

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -61,18 +61,8 @@ gap> m := Transformation([2, 2, 1]);;
 gap> ccm := GeneralizedConjugacyClasses(M);;
 gap> Size(ccm);
 6
-gap> m in ccm[1];
-false
-gap> m in ccm[2];
-false
-gap> m in ccm[3];
-false
-gap> m in ccm[4];
-false
-gap> m in ccm[5];
-false
-gap> m in ccm[6];
-true
+gap> Number(ccm, c -> m in c);
+1
 
 #  Simple check of a monoid character table  - 1
 gap> S := FullTransformationMonoid(3);;
@@ -91,14 +81,11 @@ true
 #  Check application of monoid character to an element - 1
 gap> M := FullTransformationMonoid(3);;
 gap> ct := MonoidCharacterTable(M);;
-gap> irr := Irr(ct)[1];;
 gap> m := Transformation([2, 2, 1]);;
-gap> MyExp(m, irr);
-0
-gap> irr := Irr(ct)[6];;
-gap> m := Transformation([2, 2, 1]);;
-gap> MyExp(m, irr);
+gap> Number(List(Irr(ct), chi -> MyExp(m, chi)), x -> x = 1);
 1
+gap> Number(List(Irr(ct), chi -> MyExp(m, chi)), x -> x = 0);
+5
 
 #  Check display string of MonoidCharacterTable - 1
 #  Explicitly enable acting methods because the order of the D-classes

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -93,7 +93,7 @@ gap> M := FullTransformationMonoid(3);;
 gap> ct := MonoidCharacterTable(M);;
 gap> irr := Irr(ct)[1];;
 gap> m := Transformation([2, 2, 1]);;
-gap> m^irr;
+gap> m ^ irr;
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `^' on 2 arguments
 

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -56,22 +56,23 @@ gap> Size(GeneralizedConjugacyClass(M, m));
 9
 
 #  \in GeneralizedConjugacyClass test
+#  tests for List
 gap> M := FullTransformationMonoid(3);;
 gap> m := Transformation([2, 2, 1]);;
 gap> ccm := GeneralizedConjugacyClasses(M);;
 gap> Size(ccm);
 6
-gap> m in List(ccm[1]);
+gap> m in ccm[1];
 false
-gap> m in List(ccm[2]);
+gap> m in ccm[2];
 false
-gap> m in List(ccm[3]);
+gap> m in ccm[3];
 false
-gap> m in List(ccm[4]);
+gap> m in ccm[4];
 false
-gap> m in List(ccm[5]);
+gap> m in ccm[5];
 false
-gap> m in List(ccm[6]);
+gap> m in ccm[6];
 true
 
 #  Simple check of a monoid character table  - 1

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -18,7 +18,7 @@ gap> SEMIGROUPS.StartTest();
 
 #  Creation of a lazy monoid character table - 1
 gap> S := FullTransformationMonoid(3);;
-gap> MonoidCharacterTable(S);
+gap> CharacterTable(S);
 MonoidCharacterTable( Monoid( [ Transformation( [ 2, 3, 1 ] ), Transformation(\
  [ 2, 1 ] ), Transformation( [ 1, 2, 1 ] ) ] ) )
 
@@ -64,11 +64,11 @@ gap> Size(ccm);
 gap> Number(ccm, c -> m in c);
 1
 
-#  Projective Character finde ValuesOfMonoidClassFunction test
+#  Projective Character finde ValuesOfClassFunction test
 gap> M := FullTransformationMonoid(3);;
 gap> cm := CartanMatrix(M);;
 gap> pims := Pims(cm);;
-gap> mat := List(pims, ValuesOfMonoidClassFunction);;
+gap> mat := List(pims, ValuesOfClassFunction);;
 gap> known := [[1, -1, 1, 0, 0, 0],
 > [2, 0, -1, 0, 0, 0],
 > [4, 0, 1, 1, -1, 0],
@@ -80,9 +80,9 @@ true
 
 #  Simple check of a monoid character table  - 1
 gap> S := FullTransformationMonoid(3);;
-gap> ct := MonoidCharacterTable(S);;
+gap> ct := CharacterTable(S);;
 gap> irr := Irr(ct);;
-gap> mat := List(irr, ValuesOfMonoidClassFunction);;
+gap> mat := List(irr, ValuesOfClassFunction);;
 gap> known := [[1, -1, 1, 0, 0, 0],
 > [2, 0, -1, 0, 0, 0],
 > [1, 1, 1, 0, 0, 0],
@@ -94,7 +94,7 @@ true
 
 #  Check application of monoid character to an element - 1
 gap> M := FullTransformationMonoid(3);;
-gap> ct := MonoidCharacterTable(M);;
+gap> ct := CharacterTable(M);;
 gap> m := Transformation([2, 2, 1]);;
 gap> Number(List(Irr(ct), chi -> m ^ chi), x -> x = 1);
 1
@@ -103,7 +103,7 @@ gap> Number(List(Irr(ct), chi -> m ^ chi), x -> x = 0);
 
 #  Check special use of MyExp for the identity element - 1
 gap> M := FullTransformationMonoid(3);;
-gap> ct := MonoidCharacterTable(M);;
+gap> ct := CharacterTable(M);;
 gap> m := Identity(M);;
 gap> mat := List(Irr(ct), chi -> m ^ chi);;
 gap> known := [1, 2, 1, 2, 3, 1];;
@@ -118,7 +118,7 @@ false
 #  is not canonical and a permutation on the D-classes may be lead to
 #  a different display string.
 gap> S := Monoid(FullTransformationMonoid(3), rec(acting := true));;
-gap> ct := MonoidCharacterTable(S);;
+gap> ct := CharacterTable(S);;
 gap> Irr(ct);;
 gap> Display(ct);
     c.1 c.2 c.3 c.4 c.5 c.6
@@ -134,8 +134,7 @@ X.6   1   1   1   1   1   1
 #  Creation of a lazy cartan matrix - 1
 gap> S := FullTransformationMonoid(3);;
 gap> CartanMatrix(S);
-CartanMatrix( Monoid( [ Transformation( [ 2, 3, 1 ] ), Transformation( [\
- 2, 1 ] ), Transformation( [ 1, 2, 1 ] ) ] ) )
+CartanMatrix( <object> )
 
 #  Simple check of a cartan matrix  - 1
 gap> S := FullTransformationMonoid(3);;

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -39,6 +39,16 @@ gap> GeneralizedConjugacyClass(M, m);
 formation( [ 2, 1 ] ), Transformation( [ 1, 2, 1 ] ) ] ) for representative Tr\
 ansformation( [ 3, 2, 2 ] )>
 
+#  AsList GeneralizedConjugacyClass test
+gap> M := FullTransformationMonoid(3);;
+gap> m := Transformation([3, 2, 2]);;
+gap> AsList(GeneralizedConjugacyClass(M, m));
+[ Transformation( [ 1, 1, 1 ] ), Transformation( [ 1, 1, 2 ] ), 
+  Transformation( [ 1, 3, 1 ] ), Transformation( [ 2, 2, 1 ] ), 
+  Transformation( [ 2, 2, 2 ] ), Transformation( [ 2, 3, 3 ] ), 
+  Transformation( [ 3, 1, 3 ] ), Transformation( [ 3, 2, 2 ] ), 
+  Transformation( [ 3, 3, 3 ] ) ]
+
 #  Simple check of a monoid character table  - 1
 gap> S := FullTransformationMonoid(3);;
 gap> ct := MonoidCharacterTable(S);;

--- a/tst/standard/attributes/cartan.tst
+++ b/tst/standard/attributes/cartan.tst
@@ -66,7 +66,7 @@ gap> Number(ccm, c -> m in c);
 
 #  Projective Character finde ValuesOfMonoidClassFunction test
 gap> M := FullTransformationMonoid(3);;
-gap> cm := MonoidCartanMatrix(M);;
+gap> cm := CartanMatrix(M);;
 gap> pims := Pims(cm);;
 gap> mat := List(pims, ValuesOfMonoidClassFunction);;
 gap> known := [[1, -1, 1, 0, 0, 0],
@@ -131,15 +131,15 @@ X.5   3   1   .   1   1   .
 X.6   1   1   1   1   1   1
 
 
-#  Creation of a lazy monoid cartan matrix - 1
+#  Creation of a lazy cartan matrix - 1
 gap> S := FullTransformationMonoid(3);;
-gap> MonoidCartanMatrix(S);
-MonoidCartanMatrix( Monoid( [ Transformation( [ 2, 3, 1 ] ), Transformation( [\
+gap> CartanMatrix(S);
+CartanMatrix( Monoid( [ Transformation( [ 2, 3, 1 ] ), Transformation( [\
  2, 1 ] ), Transformation( [ 1, 2, 1 ] ) ] ) )
 
-#  Simple check of a monoid cartan matrix  - 1
+#  Simple check of a cartan matrix  - 1
 gap> S := FullTransformationMonoid(3);;
-gap> cm := MonoidCartanMatrix(S);;
+gap> cm := CartanMatrix(S);;
 gap> pims := Pims(cm);;
 gap> mat := List(pims, ValuesOfCompositionFactorsFunction);;
 gap> known := [[1, 0, 0, 0, 0, 0],
@@ -151,12 +151,12 @@ gap> known := [[1, 0, 0, 0, 0, 0],
 gap> TransformingPermutations(mat, known) <> fail;
 true
 
-# Check display string of MonoidCartanMatrix - 1
+# Check display string of CartanMatrix - 1
 # Explicitly enable acting methods because the order of the D-classes
 # is not canonical and a permutation on the D-classes may be lead to
 # a different display string.
 gap> S := Monoid(FullTransformationMonoid(3), rec(acting := true));;
-gap> cm := MonoidCartanMatrix(S);;
+gap> cm := CartanMatrix(S);;
 gap> Pims(cm);;
 gap> Display(cm);
     X.1 X.2 X.3 X.4 X.5 X.6


### PR DESCRIPTION
Continuation of pull request #1136. To implement the generalized conjugacy class functionality of monoids in a similar way to conjugacy classes of groups in gap.