### PR TITLE
Remove moduleState init from gapbind14 kernel extension

### DIFF
--- a/gapbind14/demo/src/gapbind_demo.cc
+++ b/gapbind14/demo/src/gapbind_demo.cc
@@ -131,10 +131,6 @@ static StructInitInfo module = {
     /* preSave     = */ 0,
     /* postSave    = */ 0,
     /* postRestore = */ 0,
-    /* moduleStateSize      = */ 0,
-    /* moduleStateOffsetPtr = */ 0,
-    /* initModuleState      = */ 0,
-    /* destroyModuleState   = */ 0,
 };
 
 extern "C" StructInitInfo* Init__Dynamic(void) {


### PR DESCRIPTION
Global variables are zero-initialized anyway, so this makes no
difference.

Note that module state only matters for HPC-GAP. In the future,
I'd like to hide the moduleStateSize and moduleStateOffsetPtr
for "regular" GAP builds.
