### PR TITLE
Remove test for 'Matrix(GF(3), [[]]);'  (targeting stable-5.6 branch)

### DIFF
--- a/tst/standard/elements/semiringmat.tst
+++ b/tst/standard/elements/semiringmat.tst
@@ -562,10 +562,6 @@ gap> Matrix(IsTropicalMaxPlusMatrix, [[2, 2], [0, 1]], 10) <
 > Matrix(IsTropicalMaxPlusMatrix, [[2, 2], [0, 1]], 10);
 false
 
-# Test Matrix for a finite field and list consisting of an empty list
-gap> Matrix(GF(3), [[]]);
-[ [  ] ]
-
 # Pickling
 gap> filename := Concatenation(SEMIGROUPS.PackageDir,
 > "/tst/standard/elements/semiringmat.tst");;


### PR DESCRIPTION
This is purely testing GAP library code as far as I can tell, and is currently failing on GAP master. For details, see <https://github.com/gap-system/gap/issues/6393>.

Duplicate of PR #1180 but targeting stable-5.6 -- done in part so that I can see the state of CI there (it seems you run daily CI tests for your `main`, but not your active stable branch)