### PR TITLE
require c++17 standard for libsemigroups

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Both [orb][] and [Semigroups][] perform better when [orb][] is compiled, so comp
 
 * from version 3.0.0, it is necessary to compile the [Semigroups][] package.
   [Semigroups][] uses the [libsemigroups][] C++ library, which requires a compiler
-  implementing the C++14 standard.
+  implementing the C++17 standard.
 
   You may either build [libsemigroups][] along with [Semigroups][], or have it
   installed at a custom or standard location, as explained in its

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ dnl ##
 AC_PROG_CXX
 AC_LANG([C++])
 
-AX_CXX_COMPILE_STDCXX_14(,[mandatory])
+AX_CXX_COMPILE_STDCXX([17],,[mandatory])
 
 dnl compiler builtins
 AC_DEFUN([CHECK_COMPILER_BUILTIN],

--- a/doc/z-chap02.xml
+++ b/doc/z-chap02.xml
@@ -71,7 +71,7 @@
         <URL Text="libsemigroups">
           https://libsemigroups.github.io/libsemigroups/
         </URL>
-        C++ library, which requires a compiler implementing the C++14 standard.
+        C++ library, which requires a compiler implementing the C++17 standard.
         Inside the <F>pkg/semigroups-&VERSION;</F> directory, in your terminal
         type
         <Listing><![CDATA[


### PR DESCRIPTION
this pr aims to address issue #1191, however there are likely places I've missed since I'm not very familiar with this repo