### PR TITLE
Adjust kernel extension code setting up StructInitInfo

### DIFF
--- a/gapbind14/demo/src/gapbind_demo.cc
+++ b/gapbind14/demo/src/gapbind_demo.cc
@@ -119,18 +119,10 @@ static Int InitLibrary(StructInitInfo* module) {
 }
 
 static StructInitInfo module = {
-    /* type        = */ MODULE_DYNAMIC,
-    /* name        = */ "gapbind_demo",
-    /* revision_c  = */ 0,
-    /* revision_h  = */ 0,
-    /* version     = */ 0,
-    /* crc         = */ 0,
-    /* initKernel  = */ InitKernel,
-    /* initLibrary = */ InitLibrary,
-    /* checkInit   = */ 0,
-    /* preSave     = */ 0,
-    /* postSave    = */ 0,
-    /* postRestore = */ 0,
+    .type        = MODULE_DYNAMIC,
+    .name        = "gapbind_demo",
+    .initKernel  = InitKernel,
+    .initLibrary = InitLibrary,
 };
 
 extern "C" StructInitInfo* Init__Dynamic(void) {

--- a/src/pkg.cpp
+++ b/src/pkg.cpp
@@ -509,18 +509,13 @@ static Int InitLibrary(StructInitInfo* module) {
 /******************************************************************************
  *F  InitInfopl()  . . . . . . . . . . . . . . . . . table of init functions
  */
-static StructInitInfo module = {/* type        = */ MODULE_DYNAMIC,
-                                /* name        = */ "semigroups",
-                                /* revision_c  = */ 0,
-                                /* revision_h  = */ 0,
-                                /* version     = */ 0,
-                                /* crc         = */ 0,
-                                /* initKernel  = */ InitKernel,
-                                /* initLibrary = */ InitLibrary,
-                                /* checkInit   = */ 0,
-                                /* preSave     = */ 0,
-                                /* postSave    = */ 0,
-                                /* postRestore = */ PostRestore};
+static StructInitInfo module = {
+    .type        = MODULE_DYNAMIC,
+    .name        = "semigroups",
+    .initKernel  = InitKernel,
+    .initLibrary = InitLibrary,
+    .postRestore = PostRestore,
+};
 
 extern "C" StructInitInfo* Init__Dynamic(void) {
   return &module;


### PR DESCRIPTION
Currently GAP's `StructInitInfo` struct type contains several
obsolete fields which cannot be removed or replaced because of
kernel extensions relying on the specific layout of this struct.

This patch removes this reliance for this package and thus gets
us one step closer to eventually allowing such a refactoring of
the struct in the GAP kernel.

The technique employed here used to work only in C, but at least
locally it works for me in this C++ code base, too. Not sure if
that is due to enhancements in newer C++ standards, or a non-portable
compiler extension, or something else...
