### PR TITLE
Some minor Graph Inverse Semigroup related fixes/additions

### DIFF
--- a/gap/semigroups/semigraph.gd
+++ b/gap/semigroups/semigraph.gd
@@ -10,7 +10,8 @@
 
 DeclareOperation("GraphInverseSemigroup", [IsDigraph]);
 
-DeclareCategory("IsGraphInverseSemigroupElement", IsAssociativeElement);
+DeclareCategory("IsGraphInverseSemigroupElement", 
+                 IsAssociativeElement and IsPositionalObjectRep);
 DeclareCategoryCollections("IsGraphInverseSemigroupElement");
 
 DeclareSynonymAttr("IsGraphInverseSubsemigroup",
@@ -37,4 +38,6 @@ DeclareProperty("IsZero", IsGraphInverseSemigroupElement);
 DeclareOperation("IndexOfVertexOfGraphInverseSemigroup",
                  [IsGraphInverseSemigroupElement]);
 DeclareAttribute("VerticesOfGraphInverseSemigroup",
+                 IsGraphInverseSemigroup);
+DeclareAttribute("EdgesOfGraphInverseSemigroup",
                  IsGraphInverseSemigroup);

--- a/gap/semigroups/semigraph.gd
+++ b/gap/semigroups/semigraph.gd
@@ -10,7 +10,7 @@
 
 DeclareOperation("GraphInverseSemigroup", [IsDigraph]);
 
-DeclareCategory("IsGraphInverseSemigroupElement", 
+DeclareCategory("IsGraphInverseSemigroupElement",
                  IsAssociativeElement and IsPositionalObjectRep);
 DeclareCategoryCollections("IsGraphInverseSemigroupElement");
 

--- a/gap/semigroups/semigraph.gi
+++ b/gap/semigroups/semigraph.gi
@@ -282,6 +282,13 @@ function(S)
   return result;
 end);
 
+InstallMethod(EdgesOfGraphInverseSemigroup,
+"for a graph inverse semigroup",
+[IsGraphInverseSemigroup],
+function(S)
+  return Difference(GeneratorsOfInverseSemigroup(S), VerticesOfGraphInverseSemigroup(S));
+end);
+
 InstallMethod(IndexOfVertexOfGraphInverseSemigroup,
 "for a graph inverse semigroup element",
 [IsGraphInverseSemigroupElement],
@@ -290,4 +297,11 @@ function(x)
     ErrorNoReturn(x, " must be a vertex of a graph inverse semigroup");
   fi;
   return x![1][1] - DigraphNrEdges(x![2]);
+end);
+
+InstallMethod(IsWholeFamily,
+"for a subsemigroup of a graph inverse semigroup",
+[IsGraphInverseSubsemigroup],
+function(S)
+  return Size(ElementsFamily(FamilyObj(S))!.semigroup) = Size(S);
 end);

--- a/gap/semigroups/semigraph.gi
+++ b/gap/semigroups/semigraph.gi
@@ -285,9 +285,8 @@ end);
 InstallMethod(EdgesOfGraphInverseSemigroup,
 "for a graph inverse semigroup",
 [IsGraphInverseSemigroup],
-function(S)
-  return Difference(GeneratorsOfInverseSemigroup(S), VerticesOfGraphInverseSemigroup(S));
-end);
+S -> Difference(GeneratorsOfInverseSemigroup(S),
+VerticesOfGraphInverseSemigroup(S)));
 
 InstallMethod(IndexOfVertexOfGraphInverseSemigroup,
 "for a graph inverse semigroup element",
@@ -302,6 +301,4 @@ end);
 InstallMethod(IsWholeFamily,
 "for a subsemigroup of a graph inverse semigroup",
 [IsGraphInverseSubsemigroup],
-function(S)
-  return Size(ElementsFamily(FamilyObj(S))!.semigroup) = Size(S);
-end);
+S -> Size(ElementsFamily(FamilyObj(S))!.semigroup) = Size(S));


### PR DESCRIPTION
Set `IsPositionalObjectRep` filter on graph inverse semigroup elements, 

Added attribute `EdgesOfGraphInverseSemigroup`, which returns the generators of the semigroup which are not vertices,

Added `IsWholeFamily` test to subsemigroups, which returns true if the subsemigroup is equal to the graph inverse semigroup of the graph it is defined on.