### PR TITLE
Fix of MinimalHereditarySubsetsVertex filter

### DIFF
--- a/gap/congruences/congsemigraph.gd
+++ b/gap/congruences/congsemigraph.gd
@@ -23,6 +23,6 @@ DeclareOperation("CongruenceByWangPair",
 DeclareOperation("AsCongruenceByWangPair", [IsSemigroupCongruence]);
 
 DeclareOperation("MinimalHereditarySubsetsVertex",
-                 [IsGraphInverseSemigroup, IsPosInt]);
+                 [IsDigraph, IsPosInt]);
 
 DeclareAttribute("GeneratingCongruencesOfLattice", IsGraphInverseSemigroup);


### PR DESCRIPTION
`MinimalHereditarySubsetsVertex` should take an input of a digraph and integer:

`  if IsMultiDigraph(D) then
    ErrorNoReturn("the 1st argument (a digraph) must not have multiple edges"); `

But it was previously defined with the filter

`DeclareOperation("MinimalHereditarySubsetsVertex",
                 [IsGraphInverseSemigroup, IsPosInt]); `

I have changed this to require a digraph instead of a GIS