### PR TITLE
Make smallgrp an explicit dependency

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -424,7 +424,8 @@ Dependencies := rec(
                           ["genss", ">=1.6.5"],
                           ["images", ">=1.3.1"],
                           ["IO", ">=4.5.1"],
-                          ["orb", ">=4.8.2"]],  # TODO bump to v5.1.0
+                          ["orb", ">=4.8.2"],  # TODO bump to v5.1.0
+                          ["smallgrp", ">=1.0"]],
   SuggestedOtherPackages := [["GAPDoc", ">=1.6.3"],
                              ["AutoDoc", ">=2020.08.11"]],
 


### PR DESCRIPTION
SEMIGROUPS_ProcessRandomArgsCons for IsReesMatrixSemigroup picks a random group when the caller does not supply one, using NumberSmallGroups and SmallGroup. Without the SmallGrp package this fails, e.g. in a GAP started with `--bare':

    gap> RandomSemigroup(IsReesMatrixSemigroup);;
    Error, Variable: 'NumberSmallGroups' must have an assigned value

This is the only place in Semigroups using the small groups library.

See https://github.com/gap-system/gap/issues/2434

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

Of course you could also rework the code to not use SmallGrp, that'd be perfectly cromulent :-)