### PR TITLE
kernel: suppress libsemigroups reporting by default

### DIFF
--- a/src/pkg.cpp
+++ b/src/pkg.cpp
@@ -64,8 +64,12 @@ using libsemigroups::Blocks;
 using libsemigroups::word_type;
 
 namespace {
-  void LIBSEMIGROUPS_REPORTING_ENABLED(bool const val) {
+  void enable_libsemigroups_reporting(bool val) {
     static std::unique_ptr<libsemigroups::ReportGuard> rg;
+    // Reset first so that reporting is disabled, then set the new value. Just
+    // doing the assignment has this the other way around, and results in
+    // reporting always being disabled.
+    rg.reset();
     rg = std::make_unique<libsemigroups::ReportGuard>(val);
   }
 }  // namespace
@@ -76,7 +80,7 @@ GAPBIND14_MODULE(libsemigroups) {
   ////////////////////////////////////////////////////////////////////////
 
   gapbind14::InstallGlobalFunction("set_report",
-                                   &LIBSEMIGROUPS_REPORTING_ENABLED);
+                                   &enable_libsemigroups_reporting);
   gapbind14::InstallGlobalFunction("reporting_enabled",
                                    &libsemigroups::reporting_enabled);
   gapbind14::InstallGlobalFunction("hardware_concurrency",
@@ -487,6 +491,8 @@ static Int InitKernel(StructInitInfo* module) {
 }
 
 static Int PostRestore(StructInitInfo* module) {
+  // Disable reporting by default, including after loading a workspace.
+  enable_libsemigroups_reporting(false);
   return 0;
 }
 

--- a/tst/standard/libsemigroups/froidure-pin.tst
+++ b/tst/standard/libsemigroups/froidure-pin.tst
@@ -21,6 +21,16 @@ gap> LoadPackage("semigroups", false);;
 #
 gap> SEMIGROUPS.StartTest();
 
+# libsemigroups reporting can be re-enabled after being disabled by default
+gap> libsemigroups.reporting_enabled();
+false
+gap> libsemigroups.set_report(true);;
+gap> libsemigroups.reporting_enabled();
+true
+gap> libsemigroups.set_report(false);;
+gap> libsemigroups.reporting_enabled();
+false
+
 # FroidurePinMemFnRec
 gap> FroidurePinMemFnRec(FullTransformationSemigroup(1));
 rec( add_generator := function( arg1, arg2 ) ... end, 

--- a/tst/workspaces/load-workspace.tst
+++ b/tst/workspaces/load-workspace.tst
@@ -18,6 +18,8 @@
 
 # Set up testing environment
 gap> START_TEST("Semigroups package: workspaces/load-workspace.tst");
+gap> libsemigroups.reporting_enabled();
+false
 gap> SEMIGROUPS.StartTest();
 
 #############################################################################


### PR DESCRIPTION
@cdwensley I think this should fix the issue you reported to me by email today:

~~~
Some of the Groupoids tests have suddenly coming up with unexpected output such as:

#0: FroidurePin: enumerating until all elements are found . . .
#0: FroidurePin: ⌀ 1    (Cayley graph) | 3           (elements) | 0         (rules) | 41ns    (total)  
#0: FroidurePin: ⌀ 2    (Cayley graph) | 6           (elements) | 6         (rules) | 549µs   (total)  
#0: FroidurePin: ⌀ 3    (Cayley graph) | 10          (elements) | 7         (rules) | 555µs   (total)  
#0: FroidurePin: ⌀ 4    (Cayley graph) | 12          (elements) | 10        (rules) | 558µs   (total)  
#0: FroidurePin: ⌀ 5    (Cayley graph) | 13          (elements) | 11        (rules) | 569µs   (total)  
#0: FroidurePin:  #0: FroidurePin: number of products was  21 of 39 (53.846%)

and

FroidurePin: enumerating until ~8,195 elements are found
#0: FroidurePin: running until predicate returns true or finished
#0: FroidurePin: ⌀ 1    (Cayley graph) | 3           (elements) | 0         (rules) | 42ns    (total)  
#0: FroidurePin: ⌀ 2    (Cayley graph) | 11          (elements) | 1         (rules) | 13µs    (total)  
#0: FroidurePin: ⌀ 3    (Cayley graph) | 17          (elements) | 17        (rules) | 19µs    (total)  
#0: FroidurePin:  #0: FroidurePin: number of products was  37 of 51 (72.549%)
~~~