### PR TITLE
Added `LeftOne` and `RightOne` for graph inverse semigroups

### DIFF
--- a/doc/semigraph.xml
+++ b/doc/semigraph.xml
@@ -303,7 +303,7 @@ true
   <Description>
     <C>RightOne(<A>x</A>)</C> returns the unique idempotent
     <C>e</C> such that <C><A>x</A> * e = <A>x</A></C> and
-    <C>e</C> and <A>x</A> are related by Green's L-relation.
+    <C>e</C> and <A>x</A> are related by Green's &L;-relation.
     <Example><![CDATA[
 gap> S := GraphInverseSemigroup(ChainDigraph(3));
 <finite graph inverse semigroup with 3 vertices, 2 edges>

--- a/doc/semigraph.xml
+++ b/doc/semigraph.xml
@@ -281,7 +281,7 @@ gap> IndexOfVertexOfGraphInverseSemigroup(v_3);
   <Description>
     <C>LeftOne(<A>x</A>)</C> returns the unique idempotent
     <C>e</C> such that <C>e * <A>x</A> = <A>x</A></C> and
-    <C>e</C> and <A>x</A> are related by Green's R-relation.
+    <C>e</C> and <A>x</A> are related by Green's &R;-relation.
     <Example><![CDATA[
 gap> S := GraphInverseSemigroup(ChainDigraph(3));
 <finite graph inverse semigroup with 3 vertices, 2 edges>

--- a/doc/semigraph.xml
+++ b/doc/semigraph.xml
@@ -273,3 +273,49 @@ gap> IndexOfVertexOfGraphInverseSemigroup(v_3);
   </Description>
 </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="LeftOne">
+<ManSection>
+  <Oper Name = "LeftOne" Arg = "x" Label="for an element with an inverse"/>
+  <Returns>A semigroup element.</Returns>
+  <Description>
+    if <A>x</A> has an inverse element <C>x ^ -1</C>, then
+    <C>LeftOne(<A>x</A>)</C> returns the unique idempotent
+    <C>e</C> such that <C>e * <A>x</A> = <A>x</A></C> and
+    <C>e</C> and <A>x</A> are related by Green's R-relation.
+    <Example><![CDATA[
+gap> S := GraphInverseSemigroup(ChainDigraph(3));
+<finite graph inverse semigroup with 3 vertices, 2 edges>
+gap> x := S.1 * S.2;
+e_1e_2
+gap> LeftOne(x);
+e_1e_2e_2^-1e_1^-1
+gap> LeftOne(x) * x = x;
+true
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="RightOne">
+<ManSection>
+  <Oper Name = "RightOne" Arg = "x" Label="for an element with an inverse"/>
+  <Returns>A semigroup element.</Returns>
+  <Description>
+    if <A>x</A> has an inverse element <C>x ^ -1</C>, then
+    <C>RightOne(<A>x</A>)</C> returns the unique idempotent
+    <C>e</C> such that <C><A>x</A> * e = <A>x</A></C> and
+    <C>e</C> and <A>x</A> are related by Green's L-relation.
+    <Example><![CDATA[
+gap> S := GraphInverseSemigroup(ChainDigraph(3));
+<finite graph inverse semigroup with 3 vertices, 2 edges>
+gap> x := S.1 * S.2;
+e_1e_2
+gap> RightOne(x);
+v_3
+gap> x * RightOne(x) = x;
+true
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>

--- a/doc/semigraph.xml
+++ b/doc/semigraph.xml
@@ -277,7 +277,7 @@ gap> IndexOfVertexOfGraphInverseSemigroup(v_3);
 <#GAPDoc Label="LeftOne">
 <ManSection>
   <Oper Name = "LeftOne" Arg = "x" Label="for a graph inverse semigroup element"/>
-  <Returns>A semigroup element.</Returns>
+  <Returns>A graph inverse semigroup element.</Returns>
   <Description>
     <C>LeftOne(<A>x</A>)</C> returns the unique idempotent
     <C>e</C> such that <C>e * <A>x</A> = <A>x</A></C> and
@@ -299,7 +299,7 @@ true
 <#GAPDoc Label="RightOne">
 <ManSection>
   <Oper Name = "RightOne" Arg = "x" Label="for a graph inverse semigroup element"/>
-  <Returns>A semigroup element.</Returns>
+  <Returns>A graph inverse semigroup element.</Returns>
   <Description>
     <C>RightOne(<A>x</A>)</C> returns the unique idempotent
     <C>e</C> such that <C><A>x</A> * e = <A>x</A></C> and

--- a/doc/semigraph.xml
+++ b/doc/semigraph.xml
@@ -276,10 +276,9 @@ gap> IndexOfVertexOfGraphInverseSemigroup(v_3);
 
 <#GAPDoc Label="LeftOne">
 <ManSection>
-  <Oper Name = "LeftOne" Arg = "x" Label="for an element with an inverse"/>
+  <Oper Name = "LeftOne" Arg = "x" Label="for a graph inverse semigroup element"/>
   <Returns>A semigroup element.</Returns>
   <Description>
-    if <A>x</A> has an inverse element <C>x ^ -1</C>, then
     <C>LeftOne(<A>x</A>)</C> returns the unique idempotent
     <C>e</C> such that <C>e * <A>x</A> = <A>x</A></C> and
     <C>e</C> and <A>x</A> are related by Green's R-relation.
@@ -299,10 +298,9 @@ true
 
 <#GAPDoc Label="RightOne">
 <ManSection>
-  <Oper Name = "RightOne" Arg = "x" Label="for an element with an inverse"/>
+  <Oper Name = "RightOne" Arg = "x" Label="for a graph inverse semigroup element"/>
   <Returns>A semigroup element.</Returns>
   <Description>
-    if <A>x</A> has an inverse element <C>x ^ -1</C>, then
     <C>RightOne(<A>x</A>)</C> returns the unique idempotent
     <C>e</C> such that <C><A>x</A> * e = <A>x</A></C> and
     <C>e</C> and <A>x</A> are related by Green's L-relation.

--- a/doc/z-chap07.xml
+++ b/doc/z-chap07.xml
@@ -248,6 +248,8 @@
     <#Include Label = "IsGraphInverseSubsemigroup">
     <#Include Label = "VerticesOfGraphInverseSemigroup">
     <#Include Label = "IndexOfVertexOfGraphInverseSemigroup">
+    <#Include Label = "LeftOne">
+    <#Include Label = "RightOne">
 
   </Section>
 
@@ -375,15 +377,5 @@ x1x2x2^-1x1^-1x1x2]]></Example>
       </List>
 
     </Subsection>
-  </Section>
-  
-  <Section Label="Inverse semigroups">
-    <Heading>
-      Inverse semigroups
-    </Heading>
-
-    <#Include Label = "LeftOne">
-    <#Include Label = "RightOne">
-
   </Section>
 </Chapter>

--- a/doc/z-chap07.xml
+++ b/doc/z-chap07.xml
@@ -376,5 +376,14 @@ x1x2x2^-1x1^-1x1x2]]></Example>
 
     </Subsection>
   </Section>
+  
+  <Section Label="Inverse semigroups">
+    <Heading>
+      Inverse semigroups
+    </Heading>
 
+    <#Include Label = "LeftOne">
+    <#Include Label = "RightOne">
+
+  </Section>
 </Chapter>

--- a/gap/semigroups/semigraph.gi
+++ b/gap/semigroups/semigraph.gi
@@ -304,25 +304,11 @@ InstallMethod(IsWholeFamily,
 S -> Size(ElementsFamily(FamilyObj(S))!.semigroup) = Size(S));
 
 InstallMethod(LeftOne,
-"for an element with an inverse",
-[IsAssociativeElement],
-function(x)
-  local xinv;
-  xinv := x ^ -1;
-  if xinv = fail then
-    ErrorNoReturn("the argument must have an inverse!");
-  fi;
-  return x * xinv;
-end);
+"for a graph inverse semigroup element",
+[IsGraphInverseSemigroupElement],
+x -> x * x ^ -1);
 
 InstallMethod(RightOne,
-"for an element with an inverse",
-[IsAssociativeElement],
-function(x)
-  local xinv;
-  xinv := x ^ -1;
-  if xinv = fail then
-    ErrorNoReturn("the argument must have an inverse!");
-  fi;
-  return xinv * x;
-end);
+"for a graph inverse semigroup element",
+[IsGraphInverseSemigroupElement],
+x -> x ^ -1 * x);

--- a/gap/semigroups/semigraph.gi
+++ b/gap/semigroups/semigraph.gi
@@ -302,3 +302,27 @@ InstallMethod(IsWholeFamily,
 "for a subsemigroup of a graph inverse semigroup",
 [IsGraphInverseSubsemigroup],
 S -> Size(ElementsFamily(FamilyObj(S))!.semigroup) = Size(S));
+
+InstallMethod(LeftOne,
+"for an element with an inverse",
+[IsAssociativeElement],
+function(x)
+  local xinv;
+  xinv := x ^ -1;
+  if xinv = fail then
+    ErrorNoReturn("the argument must have an inverse!");
+  fi;
+  return x * xinv;
+end);
+
+InstallMethod(RightOne,
+"for an element with an inverse",
+[IsAssociativeElement],
+function(x)
+  local xinv;
+  xinv := x ^ -1;
+  if xinv = fail then
+    ErrorNoReturn("the argument must have an inverse!");
+  fi;
+  return xinv * x;
+end);

--- a/tst/standard/semigroups/semigraph.tst
+++ b/tst/standard/semigroups/semigraph.tst
@@ -147,6 +147,10 @@ gap> G.1 < G.1;
 false
 gap> G.1 = H.1;
 false
+gap> G.1 * RightOne(G.1) = G.1;
+true
+gap> LeftOne(G.1) * G.1 = G.1;
+true
 
 #
 gap> SEMIGROUPS.StopTest();


### PR DESCRIPTION
These functions exist for transformations and partial perms, this adds the same functionality for graph inverse semigroups
