### PR TITLE
Add PreImagesSet method for semigroup homs by images

### DIFF
--- a/gap/attributes/homomorph.gi
+++ b/gap/attributes/homomorph.gi
@@ -425,6 +425,20 @@ function(hom, x)
   return preim;
 end);
 
+# GAP >= 4.17 has a library method for PreImagesSet that returns the preimage
+# of the intersection with the image; this method keeps erroring for elements
+# without preimages, consistent with the PreImagesElm method above.
+InstallMethod(PreImagesSet,
+"for a semigroup homom. by images and a list of elements in the range",
+[IsSemigroupHomomorphismByImages, IsList],
+function(hom, elms)
+  if not IsSubset(Range(hom), elms) then
+    ErrorNoReturn("the 2nd argument is not a subset of the range of the ",
+                  "1st argument (semigroup homom. by images)");
+  fi;
+  return Union(List(elms, x -> PreImagesElm(hom, x)));
+end);
+
 InstallMethod(KernelOfSemigroupHomomorphism, "for a semigroup homomorphism",
 [IsSemigroupHomomorphismByImagesOrFunction],
 function(hom)

--- a/tst/standard/attributes/homomorph.tst
+++ b/tst/standard/attributes/homomorph.tst
@@ -126,8 +126,8 @@ gap> PreImagesElm(hom, 2);
 Error, the 2nd argument is not an element of the range of the 1st argument (se\
 migroup homom. by images)
 gap> PreImagesSet(hom, [2]);
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `PreImagesSet' on 2 arguments
+Error, the 2nd argument is not a subset of the range of the 1st argument (semi\
+group homom. by images)
 gap> IsSurjective(hom);
 true
 gap> IsInjective(hom);


### PR DESCRIPTION
GAP 4.17 changes PreImagesSet: a generic method now checks that the argument is a subset of the range and returns the preimage of its intersection with the image. With that method, PreImagesSet no longer signals an error for elements without preimages, which the tests expect, and the error for elements outside the range changes.

Install a method for semigroup homomorphisms by images that performs the range check with the package's own error message and otherwise delegates to PreImagesElm, so behaviour is the same with all supported GAP versions.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

See also https://github.com/gap-system/PackageDistro/issues/1550